### PR TITLE
Solve Fetchmail imap idle issue

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -335,6 +335,13 @@ Note: activate this only if you are confident in your bayes database for identif
 
 - **300** => `fetchmail` The number of seconds for the interval
 
+##### FETCHMAIL_PARALLEL
+
+  **0** => `fetchmail` runs with a single config file ```/etc/fetchmailrc```
+  **1** => ```/etc/fetchmailrc``` is split per poll entry. For every poll entry a seperate fetchmail instance is started  to allow having multiple imap idle configurations defined.
+
+Note: The defaults of your fetchmailrc file need to be at the top of the file. Otherwise it won't be added correctly to all separate `fetchmail` instances.
+
 #### LDAP
 
 ##### ENABLE_LDAP

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -131,7 +131,7 @@ Set the mailbox size limit for all users. If set to zero, the size will be unlim
 
 - **1** => Dovecot quota is enabled
 - 0 => Dovecot quota is disabled
-  
+
 See [mailbox quota](https://github.com/tomav/docker-mailserver/wiki/Configure-Accounts#mailbox-quota).
 
 ##### POSTFIX\_MESSAGE\_SIZE\_LIMIT
@@ -337,8 +337,8 @@ Note: activate this only if you are confident in your bayes database for identif
 
 ##### FETCHMAIL_PARALLEL
 
-  **0** => `fetchmail` runs with a single config file ```/etc/fetchmailrc```
-  **1** => ```/etc/fetchmailrc``` is split per poll entry. For every poll entry a seperate fetchmail instance is started  to allow having multiple imap idle configurations defined.
+  **0** => `fetchmail` runs with a single config file `/etc/fetchmailrc`
+  **1** => `/etc/fetchmailrc` is split per poll entry. For every poll entry a seperate fetchmail instance is started  to allow having multiple imap idle configurations defined.
 
 Note: The defaults of your fetchmailrc file need to be at the top of the file. Otherwise it won't be added correctly to all separate `fetchmail` instances.
 

--- a/target/bin/fetchmailrc_split
+++ b/target/bin/fetchmailrc_split
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /bin/bash
 # Description: This script will split the content of /etc/fetchmailrc into
 #              smaller fetchmailrc files per server [poll] entries. Each
 #              separate fetchmailrc file is stored in /etc/fetchmailrc.d
@@ -13,43 +13,43 @@ FETCHMAILRCD="/etc/fetchmailrc.d"
 DEFAULT_FILE="${FETCHMAILRCD}/defaults"
 
 # Pre checks, check if needed files and folders exists
-if [ ! -r "${FETCHMAILRC}" ]
+if [[ ! -r "${FETCHMAILRC}" ]]
 then
-	echo "Error: File ${FETCHMAILRC} not found"
-	exit 1
+  echo "Error: File ${FETCHMAILRC} not found"
+  exit 1
 fi
 
-if [ ! -d "${FETCHMAILRCD}" ]
+if [[ ! -d "${FETCHMAILRCD}" ]]
 then
-	if ! mkdir "${FETCHMAILRCD}";
-	then
-		echo "Error: Unable to create folder ${FETCHMAILRCD}"
-		exit 1
-	fi
+  if ! mkdir "${FETCHMAILRCD}";
+  then
+    echo "Error: Unable to create folder ${FETCHMAILRCD}"
+    exit 1
+  fi
 fi
 
 COUNTER=0
 SERVER=0
-while read -r line
+while read -r LINE
 do
-	if [[ "${line}" =~ poll ]]
-	then
-		# If we read "poll" then we reached a new server definition
-		# We need to create a new file with fetchmail defaults from
-		# /etc/fetcmailrc
-		COUNTER=$((COUNTER+1))
-		SERVER=1
-		cat "${DEFAULT_FILE}" > "${FETCHMAILRCD}/fetchmail-${COUNTER}.rc"
-		echo "${line}" >> "${FETCHMAILRCD}/fetchmail-${COUNTER}.rc"
-	elif [ "${SERVER}" -eq 0 ]
-	then
-		# We have not yet found "poll". Let's assume we are still reading
-		# the default settings from /etc/fetchmailrc file
-		echo "${line}" >> "${DEFAULT_FILE}"
-	else
-		# Just the server settings that need to be added to the specific rc.d file
-		echo "${line}" >> "${FETCHMAILRCD}/fetchmail-${COUNTER}.rc"
-	fi
+  if [[ "${LINE}" =~ poll ]]
+  then
+    # If we read "poll" then we reached a new server definition
+    # We need to create a new file with fetchmail defaults from
+    # /etc/fetcmailrc
+    COUNTER=$((COUNTER+1))
+    SERVER=1
+    cat "${DEFAULT_FILE}" > "${FETCHMAILRCD}/fetchmail-${COUNTER}.rc"
+    echo "${LINE}" >> "${FETCHMAILRCD}/fetchmail-${COUNTER}.rc"
+  elif [[ "${SERVER}" -eq 0 ]]
+  then
+    # We have not yet found "poll". Let's assume we are still reading
+    # the default settings from /etc/fetchmailrc file
+    echo "${LINE}" >> "${DEFAULT_FILE}"
+  else
+    # Just the server settings that need to be added to the specific rc.d file
+    echo "${LINE}" >> "${FETCHMAILRCD}/fetchmail-${COUNTER}.rc"
+  fi
 done < "${FETCHMAILRC}"
 
 # Cleaning

--- a/target/bin/fetchmailrc_split
+++ b/target/bin/fetchmailrc_split
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Description: This script will split the content of /etc/fetchmailrc into
+#              smaller fetchmailrc files per server [poll] entries. Each
+#              separate fetchmailrc file is stored in /etc/fetchmailrc.d
+#
+#              The mail purpose for this is to work around what is known
+#              as the Fetchmail IMAP idle issue.
+#
+
+# Global variables
+FETCHMAILRC="/etc/fetchmailrc"
+FETCHMAILRCD="/etc/fetchmailrc.d"
+DEFAULT_FILE="${FETCHMAILRCD}/defaults"
+
+# Pre checks, check if needed files and folders exists
+if [ ! -r "${FETCHMAILRC}" ]
+then
+	echo "Error: File ${FETCHMAILRC} not found"
+	exit 1
+fi
+
+if [ ! -d "${FETCHMAILRCD}" ]
+then
+	if ! mkdir "${FETCHMAILRCD}";
+	then
+		echo "Error: Unable to create folder ${FETCHMAILRCD}"
+		exit 1
+	fi
+fi
+
+COUNTER=0
+SERVER=0
+while read -r line
+do
+	if [[ "${line}" =~ poll ]]
+	then
+		# If we read "poll" then we reached a new server definition
+		# We need to create a new file with fetchmail defaults from
+		# /etc/fetcmailrc
+		COUNTER=$((COUNTER+1))
+		SERVER=1
+		cat "${DEFAULT_FILE}" > "${FETCHMAILRCD}/fetchmail-${COUNTER}.rc"
+		echo "${line}" >> "${FETCHMAILRCD}/fetchmail-${COUNTER}.rc"
+	elif [ "${SERVER}" -eq 0 ]
+	then
+		# We have not yet found "poll". Let's assume we are still reading
+		# the default settings from /etc/fetchmailrc file
+		echo "${line}" >> "${DEFAULT_FILE}"
+	else
+		# Just the server settings that need to be added to the specific rc.d file
+		echo "${line}" >> "${FETCHMAILRCD}/fetchmail-${COUNTER}.rc"
+	fi
+done < "${FETCHMAILRC}"
+
+# Cleaning
+rm "${DEFAULT_FILE}"

--- a/target/bin/fetchmailrc_split
+++ b/target/bin/fetchmailrc_split
@@ -1,4 +1,5 @@
 #! /bin/bash
+
 # Description: This script will split the content of /etc/fetchmailrc into
 #              smaller fetchmailrc files per server [poll] entries. Each
 #              separate fetchmailrc file is stored in /etc/fetchmailrc.d
@@ -7,21 +8,19 @@
 #              as the Fetchmail IMAP idle issue.
 #
 
-# Global variables
 FETCHMAILRC="/etc/fetchmailrc"
 FETCHMAILRCD="/etc/fetchmailrc.d"
 DEFAULT_FILE="${FETCHMAILRCD}/defaults"
 
-# Pre checks, check if needed files and folders exists
 if [[ ! -r "${FETCHMAILRC}" ]]
 then
   echo "Error: File ${FETCHMAILRC} not found"
   exit 1
 fi
 
-if [[ ! -d "${FETCHMAILRCD}" ]]
+if [[ ! -d ${FETCHMAILRCD} ]]
 then
-  if ! mkdir "${FETCHMAILRCD}";
+  if ! mkdir "${FETCHMAILRCD}"
   then
     echo "Error: Unable to create folder ${FETCHMAILRCD}"
     exit 1
@@ -32,7 +31,7 @@ COUNTER=0
 SERVER=0
 while read -r LINE
 do
-  if [[ "${LINE}" =~ poll ]]
+  if [[ ${LINE} =~ poll ]]
   then
     # If we read "poll" then we reached a new server definition
     # We need to create a new file with fetchmail defaults from
@@ -41,7 +40,7 @@ do
     SERVER=1
     cat "${DEFAULT_FILE}" > "${FETCHMAILRCD}/fetchmail-${COUNTER}.rc"
     echo "${LINE}" >> "${FETCHMAILRCD}/fetchmail-${COUNTER}.rc"
-  elif [[ "${SERVER}" -eq 0 ]]
+  elif [[ ${SERVER} -eq 0 ]]
   then
     # We have not yet found "poll". Let's assume we are still reading
     # the default settings from /etc/fetchmailrc file
@@ -52,5 +51,4 @@ do
   fi
 done < "${FETCHMAILRC}"
 
-# Cleaning
 rm "${DEFAULT_FILE}"

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -2078,7 +2078,7 @@ function _start_daemons_fetchmail
     /usr/local/bin/fetchmailrc_split
 
     COUNTER=0
-    for rc in /etc/fetchmailrc.d/fetchmail-*.rc
+    for RC in /etc/fetchmailrc.d/fetchmail-*.rc
     do
       COUNTER=$((COUNTER+1))
       cat <<EOF > "/etc/supervisor/conf.d/fetchmail-${COUNTER}.conf"
@@ -2089,8 +2089,10 @@ autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 user=fetchmail
-command=/usr/bin/fetchmail -f ${rc} -v --nodetach --daemon %(ENV_FETCHMAIL_POLL)s -i /var/lib/fetchmail/.fetchmail-UIDL-cache --pidfile /var/run/fetchmail/%(program_name)s.pid
+command=/usr/bin/fetchmail -f ${RC} -v --nodetach --daemon %(ENV_FETCHMAIL_POLL)s -i /var/lib/fetchmail/.fetchmail-UIDL-cache --pidfile /var/run/fetchmail/%(program_name)s.pid
 EOF
+      chmod 700 "${RC}"
+      chown fetchmail:root "${RC}"
     done
 
     supervisorctl reread
@@ -2099,9 +2101,9 @@ EOF
     COUNTER=0
     for rc in /etc/fetchmailrc.d/fetchmail-*.rc
     do
+      COUNTER=$((COUNTER+1))
       _notify 'task' "Starting fetchmail instance ${COUNTER}" 'n'
       supervisorctl start "fetchmail-${COUNTER}"
-      COUNTER=$((COUNTER+1))
     done
 
   else

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -18,6 +18,7 @@ ENABLE_SASLAUTHD="${ENABLE_SASLAUTHD:=0}"
 ENABLE_SPAMASSASSIN="${ENABLE_SPAMASSASSIN:=0}"
 ENABLE_SRS="${ENABLE_SRS:=0}"
 FETCHMAIL_POLL="${FETCHMAIL_POLL:=300}"
+FETCHMAIL_PARALLEL="${FETCHMAIL_PARALLEL:=0}"
 LDAP_START_TLS="${LDAP_START_TLS:=no}"
 LOGROTATE_INTERVAL="${LOGROTATE_INTERVAL:=${REPORT_INTERVAL:-daily}}"
 LOGWATCH_INTERVAL="${LOGWATCH_INTERVAL:=none}"
@@ -2068,9 +2069,45 @@ function _start_daemons_dovecot
 
 function _start_daemons_fetchmail
 {
-  _notify 'task' 'Starting fetchmail' 'n'
+  _notify 'task' 'Preparing fetchmail config'
   /usr/local/bin/setup-fetchmail
-  supervisorctl start fetchmail
+  if [[ ${FETCHMAIL_PARALLEL} -eq 1 ]]
+  then
+    mkdir /etc/fetchmailrc.d/
+    /usr/local/bin/fetchmailrc_split
+
+    i=0
+    for rc in /etc/fetchmailrc.d/fetchmail-*.rc
+    do
+
+      cat <<EOF > "/etc/supervisor/conf.d/fetchmail-${i}.conf"
+[program:fetchmail-${i}]
+startsecs=0
+autostart=false
+autorestart=true
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+user=fetchmail
+command=/usr/bin/fetchmail -f ${rc} -v --nodetach --daemon %(ENV_FETCHMAIL_POLL)s -i /var/lib/fetchmail/.fetchmail-UIDL-cache --pidfile /var/run/fetchmail/%(program_name)s.pid
+EOF
+      i=$((i+1))
+    done
+
+    supervisorctl reread
+    supervisorctl update
+
+    i=0
+    for rc in /etc/fetchmailrc.d/fetchmail-*.rc
+    do
+      _notify 'task' "Starting fetchmail instance ${i}" 'n'
+      supervisorctl start "fetchmail-${i}"
+      i=$((i+1))
+    done
+
+  else
+    _notify 'task' 'Starting fetchmail' 'n'
+    supervisorctl start fetchmail
+  fi
 }
 
 function _start_daemons_clamav

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -2099,7 +2099,7 @@ EOF
     supervisorctl update
 
     COUNTER=0
-    for RC in /etc/fetchmailrc.d/fetchmail-*.rc
+    for _ in /etc/fetchmailrc.d/fetchmail-*.rc
     do
       COUNTER=$((COUNTER+1))
       _notify 'task' "Starting fetchmail instance ${COUNTER}" 'n'

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -2099,7 +2099,7 @@ EOF
     supervisorctl update
 
     COUNTER=0
-    for rc in /etc/fetchmailrc.d/fetchmail-*.rc
+    for RC in /etc/fetchmailrc.d/fetchmail-*.rc
     do
       COUNTER=$((COUNTER+1))
       _notify 'task' "Starting fetchmail instance ${COUNTER}" 'n'

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -397,6 +397,7 @@ function _setup_default_vars
     echo "ENABLE_SPAMASSASSIN=${ENABLE_SPAMASSASSIN}"
     echo "ENABLE_SRS=${ENABLE_SRS}"
     echo "FETCHMAIL_POLL=${FETCHMAIL_POLL}"
+    echo "FETCHMAIL_PARALLEL=${FETCHMAIL_PARALLEL}"
     echo "LDAP_START_TLS=${LDAP_START_TLS}"
     echo "LOGROTATE_INTERVAL=${LOGROTATE_INTERVAL}"
     echo "LOGWATCH_INTERVAL=${LOGWATCH_INTERVAL}"
@@ -2076,12 +2077,12 @@ function _start_daemons_fetchmail
     mkdir /etc/fetchmailrc.d/
     /usr/local/bin/fetchmailrc_split
 
-    i=0
+    COUNTER=0
     for rc in /etc/fetchmailrc.d/fetchmail-*.rc
     do
 
-      cat <<EOF > "/etc/supervisor/conf.d/fetchmail-${i}.conf"
-[program:fetchmail-${i}]
+      cat <<EOF > "/etc/supervisor/conf.d/fetchmail-${COUNTER}.conf"
+[program:fetchmail-${COUNTER}]
 startsecs=0
 autostart=false
 autorestart=true
@@ -2090,18 +2091,18 @@ stderr_logfile=/var/log/supervisor/%(program_name)s.log
 user=fetchmail
 command=/usr/bin/fetchmail -f ${rc} -v --nodetach --daemon %(ENV_FETCHMAIL_POLL)s -i /var/lib/fetchmail/.fetchmail-UIDL-cache --pidfile /var/run/fetchmail/%(program_name)s.pid
 EOF
-      i=$((i+1))
+      COUNTER=$((COUNTER+1))
     done
 
     supervisorctl reread
     supervisorctl update
 
-    i=0
+    COUNTER=0
     for rc in /etc/fetchmailrc.d/fetchmail-*.rc
     do
-      _notify 'task' "Starting fetchmail instance ${i}" 'n'
-      supervisorctl start "fetchmail-${i}"
-      i=$((i+1))
+      _notify 'task' "Starting fetchmail instance ${COUNTER}" 'n'
+      supervisorctl start "fetchmail-${COUNTER}"
+      COUNTER=$((COUNTER+1))
     done
 
   else

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -2080,7 +2080,7 @@ function _start_daemons_fetchmail
     COUNTER=0
     for rc in /etc/fetchmailrc.d/fetchmail-*.rc
     do
-
+      COUNTER=$((COUNTER+1))
       cat <<EOF > "/etc/supervisor/conf.d/fetchmail-${COUNTER}.conf"
 [program:fetchmail-${COUNTER}]
 startsecs=0
@@ -2091,7 +2091,6 @@ stderr_logfile=/var/log/supervisor/%(program_name)s.log
 user=fetchmail
 command=/usr/bin/fetchmail -f ${rc} -v --nodetach --daemon %(ENV_FETCHMAIL_POLL)s -i /var/lib/fetchmail/.fetchmail-UIDL-cache --pidfile /var/run/fetchmail/%(program_name)s.pid
 EOF
-      COUNTER=$((COUNTER+1))
     done
 
     supervisorctl reread

--- a/test/config/fetchmail.cf
+++ b/test/config/fetchmail.cf
@@ -3,3 +3,9 @@ poll pop3.example.com. with proto POP3
 	password 'secret'
 	is 'user2@domain.tld'
 	here options keep ssl
+	
+poll pop3.example2.com. with proto POP3
+	user 'username' there with
+	password 'secret'
+	is 'user3@domain.tld'
+	here options keep ssl

--- a/test/config/fetchmail.cf
+++ b/test/config/fetchmail.cf
@@ -4,7 +4,7 @@ poll pop3.example.com. with proto POP3
 	is 'user2@domain.tld'
 	here options keep ssl
 	
-poll pop3.example2.com. with proto POP3
+poll pop3-2.example.com. with proto POP3
 	user 'username' there with
 	password 'secret'
 	is 'user3@domain.tld'

--- a/test/mail_fetchmail_parallel.bats
+++ b/test/mail_fetchmail_parallel.bats
@@ -19,7 +19,7 @@ function setup_file() {
 		--cap-add=NET_ADMIN \
 		-e DMS_DEBUG=0 \
 		-h mail.my-domain.com -t "${NAME}"
-    wait_for_finished_setup_in_container mail_fetchmail
+    wait_for_finished_setup_in_container mail_fetchmail_parallel
 }
 
 function teardown_file() {
@@ -35,12 +35,12 @@ function teardown_file() {
 #
 
 @test "checking process: fetchmail 1 (fetchmail server enabled)" {
-  run docker exec mail_fetchmail /bin/bash -c "ps aux --forest | grep -v grep | grep '/usr/bin/fetchmail -f /etc/fetchmailrc.d/fetchmail-1.rc'"
+  run docker exec mail_fetchmail_parallel /bin/bash -c "ps aux --forest | grep -v grep | grep '/usr/bin/fetchmail -f /etc/fetchmailrc.d/fetchmail-1.rc'"
   assert_success
 }
 
 @test "checking process: fetchmail 2 (fetchmail server enabled)" {
-  run docker exec mail_fetchmail /bin/bash -c "ps aux --forest | grep -v grep | grep '/usr/bin/fetchmail -f /etc/fetchmailrc.d/fetchmail-2.rc'"
+  run docker exec mail_fetchmail_parallel /bin/bash -c "ps aux --forest | grep -v grep | grep '/usr/bin/fetchmail -f /etc/fetchmailrc.d/fetchmail-2.rc'"
   assert_success
 }
 
@@ -49,32 +49,32 @@ function teardown_file() {
 #
 
 @test "checking fetchmail: gerneral options in fetchmail-1.rc are loaded" {
-  run docker exec mail_fetchmail grep 'set syslog' /etc/fetchmailrc.d/fetchmail-1.rc
+  run docker exec mail_fetchmail_parallel grep 'set syslog' /etc/fetchmailrc.d/fetchmail-1.rc
   assert_success
 }
 
 @test "checking fetchmail: gerneral options in fetchmail-2.rc are loaded" {
-  run docker exec mail_fetchmail grep 'set syslog' /etc/fetchmailrc.d/fetchmail-2.rc
+  run docker exec mail_fetchmail_parallel grep 'set syslog' /etc/fetchmailrc.d/fetchmail-2.rc
   assert_success
 }
 
 @test "checking fetchmail: fetchmail-1.rc is loaded with pop3.example.com" {
-  run docker exec mail_fetchmail grep 'pop3.example.com' /etc/fetchmailrc.d/fetchmail-1.rc
+  run docker exec mail_fetchmail_parallel grep 'pop3.example.com' /etc/fetchmailrc.d/fetchmail-1.rc
   assert_success
 }
 
 @test "checking fetchmail: fetchmail-1.rc is loaded without pop3.example2.com" {
-  run docker exec mail_fetchmail grep 'pop3.example2.com' /etc/fetchmailrc.d/fetchmail-1.rc
+  run docker exec mail_fetchmail_parallel grep 'pop3.example2.com' /etc/fetchmailrc.d/fetchmail-1.rc
   assert_failure
 }
 
 @test "checking fetchmail: fetchmail-2.rc is loaded without pop3.example.com" {
-  run docker exec mail_fetchmail grep 'pop3.example.com' /etc/fetchmailrc.d/fetchmail-2.rc
+  run docker exec mail_fetchmail_parallel grep 'pop3.example.com' /etc/fetchmailrc.d/fetchmail-2.rc
   assert_failure
 }
 
 @test "checking fetchmail: fetchmail-2.rc is loaded with pop3.example2.com" {
-  run docker exec mail_fetchmail grep 'pop3.example2.com' /etc/fetchmailrc.d/fetchmail-2.rc
+  run docker exec mail_fetchmail_parallel grep 'pop3.example2.com' /etc/fetchmailrc.d/fetchmail-2.rc
   assert_success
 }
 
@@ -83,7 +83,7 @@ function teardown_file() {
 #
 
 @test "checking restart of process: fetchmail" {
-  run docker exec mail_fetchmail /bin/bash -c "killall fetchmail && sleep 10 && ps aux --forest | grep -v grep | grep '/usr/bin/fetchmail'"
+  run docker exec mail_fetchmail_parallel /bin/bash -c "killall fetchmail && sleep 10 && ps aux --forest | grep -v grep | grep '/usr/bin/fetchmail'"
   assert_success
 }
 

--- a/test/mail_fetchmail_parallel.bats
+++ b/test/mail_fetchmail_parallel.bats
@@ -39,7 +39,7 @@ function teardown_file() {
   assert_success
 }
 
-@test "checking process: fetchmail 1 (fetchmail server enabled)" {
+@test "checking process: fetchmail 2 (fetchmail server enabled)" {
   run docker exec mail_fetchmail /bin/bash -c "ps aux --forest | grep -v grep | grep '/usr/bin/fetchmail -f /etc/fetchmailrc.d/fetchmail-2.rc'"
   assert_success
 }
@@ -58,22 +58,22 @@ function teardown_file() {
   assert_success
 }
 
-@test "checking fetchmail: fetchmail-1.rc is loaded" {
+@test "checking fetchmail: fetchmail-1.rc is loaded with pop3.example.com" {
   run docker exec mail_fetchmail grep 'pop3.example.com' /etc/fetchmailrc.d/fetchmail-1.rc
   assert_success
 }
 
-@test "checking fetchmail: fetchmail-1.rc is loaded" {
+@test "checking fetchmail: fetchmail-1.rc is loaded without pop3.example2.com" {
   run docker exec mail_fetchmail grep 'pop3.example2.com' /etc/fetchmailrc.d/fetchmail-1.rc
   assert_failure
 }
 
-@test "checking fetchmail: fetchmail-2.rc is loaded" {
+@test "checking fetchmail: fetchmail-2.rc is loaded without pop3.example.com" {
   run docker exec mail_fetchmail grep 'pop3.example.com' /etc/fetchmailrc.d/fetchmail-2.rc
   assert_failure
 }
 
-@test "checking fetchmail: fetchmail-2.rc is loaded" {
+@test "checking fetchmail: fetchmail-2.rc is loaded with pop3.example2.com" {
   run docker exec mail_fetchmail grep 'pop3.example2.com' /etc/fetchmailrc.d/fetchmail-2.rc
   assert_success
 }

--- a/test/mail_fetchmail_parallel.bats
+++ b/test/mail_fetchmail_parallel.bats
@@ -1,0 +1,92 @@
+load 'test_helper/common'
+
+function setup() {
+    run_setup_file_if_necessary
+}
+
+function teardown() {
+    run_teardown_file_if_necessary
+}
+
+function setup_file() {
+    local PRIVATE_CONFIG
+    PRIVATE_CONFIG="$(duplicate_config_for_container .)"
+    docker run -d --name mail_fetchmail_parallel \
+		-v "${PRIVATE_CONFIG}":/tmp/docker-mailserver \
+		-v "$(pwd)/test/test-files":/tmp/docker-mailserver-test:ro \
+		-e ENABLE_FETCHMAIL=1 \
+		-e FETCHMAIL_PARALLEL=1 \
+		--cap-add=NET_ADMIN \
+		-e DMS_DEBUG=0 \
+		-h mail.my-domain.com -t "${NAME}"
+    wait_for_finished_setup_in_container mail_fetchmail
+}
+
+function teardown_file() {
+    docker rm -f mail_fetchmail_parallel
+}
+
+@test "first" {
+  skip 'this test must come first to reliably identify when to run setup_file'
+}
+
+#
+# processes
+#
+
+@test "checking process: fetchmail 1 (fetchmail server enabled)" {
+  run docker exec mail_fetchmail /bin/bash -c "ps aux --forest | grep -v grep | grep '/usr/bin/fetchmail -f /etc/fetchmailrc.d/fetchmail-1.rc'"
+  assert_success
+}
+
+@test "checking process: fetchmail 1 (fetchmail server enabled)" {
+  run docker exec mail_fetchmail /bin/bash -c "ps aux --forest | grep -v grep | grep '/usr/bin/fetchmail -f /etc/fetchmailrc.d/fetchmail-2.rc'"
+  assert_success
+}
+
+#
+# fetchmail
+#
+
+@test "checking fetchmail: gerneral options in fetchmail-1.rc are loaded" {
+  run docker exec mail_fetchmail grep 'set syslog' /etc/fetchmailrc.d/fetchmail-1.rc
+  assert_success
+}
+
+@test "checking fetchmail: gerneral options in fetchmail-2.rc are loaded" {
+  run docker exec mail_fetchmail grep 'set syslog' /etc/fetchmailrc.d/fetchmail-2.rc
+  assert_success
+}
+
+@test "checking fetchmail: fetchmail-1.rc is loaded" {
+  run docker exec mail_fetchmail grep 'pop3.example.com' /etc/fetchmailrc.d/fetchmail-1.rc
+  assert_success
+}
+
+@test "checking fetchmail: fetchmail-1.rc is loaded" {
+  run docker exec mail_fetchmail grep 'pop3.example2.com' /etc/fetchmailrc.d/fetchmail-1.rc
+  assert_failure
+}
+
+@test "checking fetchmail: fetchmail-2.rc is loaded" {
+  run docker exec mail_fetchmail grep 'pop3.example.com' /etc/fetchmailrc.d/fetchmail-2.rc
+  assert_failure
+}
+
+@test "checking fetchmail: fetchmail-2.rc is loaded" {
+  run docker exec mail_fetchmail grep 'pop3.example2.com' /etc/fetchmailrc.d/fetchmail-2.rc
+  assert_success
+}
+
+#
+# supervisor
+#
+
+@test "checking restart of process: fetchmail" {
+  run docker exec mail_fetchmail /bin/bash -c "killall fetchmail && sleep 10 && ps aux --forest | grep -v grep | grep '/usr/bin/fetchmail'"
+  assert_success
+}
+
+@test "last" {
+  skip 'this test is only there to reliably mark the end for the teardown_file'
+}

--- a/test/mail_fetchmail_parallel.bats
+++ b/test/mail_fetchmail_parallel.bats
@@ -63,8 +63,8 @@ function teardown_file() {
   assert_success
 }
 
-@test "checking fetchmail: fetchmail-1.rc is loaded without pop3.example2.com" {
-  run docker exec mail_fetchmail_parallel grep 'pop3.example2.com' /etc/fetchmailrc.d/fetchmail-1.rc
+@test "checking fetchmail: fetchmail-1.rc is loaded without pop3-2.example.com" {
+  run docker exec mail_fetchmail_parallel grep 'pop3-2.example.com' /etc/fetchmailrc.d/fetchmail-1.rc
   assert_failure
 }
 
@@ -73,8 +73,8 @@ function teardown_file() {
   assert_failure
 }
 
-@test "checking fetchmail: fetchmail-2.rc is loaded with pop3.example2.com" {
-  run docker exec mail_fetchmail_parallel grep 'pop3.example2.com' /etc/fetchmailrc.d/fetchmail-2.rc
+@test "checking fetchmail: fetchmail-2.rc is loaded with pop3-2.example.com" {
+  run docker exec mail_fetchmail_parallel grep 'pop3-2.example.com' /etc/fetchmailrc.d/fetchmail-2.rc
   assert_success
 }
 

--- a/test/mail_fetchmail_parallel.bats
+++ b/test/mail_fetchmail_parallel.bats
@@ -82,8 +82,13 @@ function teardown_file() {
 # supervisor
 #
 
-@test "checking restart of process: fetchmail" {
-  run docker exec mail_fetchmail_parallel /bin/bash -c "killall fetchmail && sleep 10 && ps aux --forest | grep -v grep | grep '/usr/bin/fetchmail'"
+@test "checking restart of process: fetchmail-1" {
+  run docker exec mail_fetchmail_parallel /bin/bash -c "pkill fetchmail && sleep 10 && ps aux --forest | grep -v grep | grep '/usr/bin/fetchmail -f /etc/fetchmailrc.d/fetchmail-1.rc'"
+  assert_success
+}
+
+@test "checking restart of process: fetchmail-2" {
+  run docker exec mail_fetchmail_parallel /bin/bash -c "pkill fetchmail && sleep 10 && ps aux --forest | grep -v grep | grep '/usr/bin/fetchmail -f /etc/fetchmailrc.d/fetchmail-2.rc'"
   assert_success
 }
 


### PR DESCRIPTION
Continuation of   PR #1730

The known issue with fetchmail imap idle is already solved a few times.
You can also see the example on how to solve it + detailed problem description here: https://marek.dopiera.pl/2018/10/03/fetchmail-imap-idle-systemd-generators/

I suggest to adapt the solution a little bit to split the fetchmail conf in multiple entries per server and add those as new supervisor entries at startup.