### PR TITLE
Improve logging significantly – color is back!

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -15,6 +15,18 @@
 - **0** => Debug disabled
 - 1 => Enables debug on startup
 
+##### SUPERVISOR_LOGLEVEL
+
+Here you can adjust the [log-level for Supervisor](http://supervisord.org/logging.html#activity-log-levels). Possible values are
+
+- critical => Only show critical messages
+- error => Only show erroneous output
+- warn => Show warnings
+- **info** => Normal informational output
+- debug => Also show debug messages
+
+The log-level will show everything in its class and above.
+
 ##### ENABLE_CLAMAV
 
 - **0** => Clamav is disabled

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -21,8 +21,8 @@ Here you can adjust the [log-level for Supervisor](http://supervisord.org/loggin
 
 - critical => Only show critical messages
 - error => Only show erroneous output
-- warn => Show warnings
-- **info** => Normal informational output
+- **warn** => Show warnings
+- info => Normal informational output
 - debug => Also show debug messages
 
 The log-level will show everything in its class and above.

--- a/target/scripts/helper-functions.sh
+++ b/target/scripts/helper-functions.sh
@@ -97,7 +97,7 @@ for key, value in acme.items():
 
     echo "${KEY}" | base64 -d >/etc/letsencrypt/live/"${HOSTNAME}"/key.pem || exit 1
     echo "${CERT}" | base64 -d >/etc/letsencrypt/live/"${HOSTNAME}"/fullchain.pem || exit 1
-    echo "Cert found in /etc/letsencrypt/acme.json for ${1}"
+    _notify 'inf' "Cert found in /etc/letsencrypt/acme.json for ${1}"
 
     return 0
   else

--- a/target/scripts/helper-functions.sh
+++ b/target/scripts/helper-functions.sh
@@ -110,22 +110,17 @@ export -f _extract_certs_from_acme
 
 function _notify
 {
-  local FINAL_MSG=''
-  local MSG="${2:-}"
-  local TYPE="${1:-}"
+  { [[ -z ${1:-} ]] || [[ -z ${2:-} ]] ; } && return
 
-  case "${TYPE}" in
-    'none'    ) FINAL_MSG=' ' ;;
-    'tasklog' ) FINAL_MSG="[ \e[0;92mTASKLOG\e[0m ]  ${MSG}" ;; # light green
-    'warn'    ) FINAL_MSG="[ \e[0;93mWARNING\e[0m ]  ${MSG}" ;; # light yellow
-    'err'     ) FINAL_MSG="[  \e[0;31mERROR\e[0m  ]  ${MSG}" ;; # light red
-    'fatal'   ) FINAL_MSG="[  \e[0;91mFATAL\e[0m  ]  ${MSG}" ;; # red
-    'inf'     ) [[ ${DMS_DEBUG} -eq 1 ]] && FINAL_MSG="[[ \e[0;34mINFO\e[0m ]]   ${MSG}" ;; # light blue
-    'task'    ) [[ ${DMS_DEBUG} -eq 1 ]] && FINAL_MSG="[[ \e[0;37mTASK\e[0m ]]   ${MSG}" ;; # light grey
-    *         ) ;;
+  case ${1} in
+    tasklog  ) echo "-e${3:-}" "[ \e[0;92mTASKLOG\e[0m ]  ${2}" ;; # light green
+    warn     ) echo "-e${3:-}" "[ \e[0;93mWARNING\e[0m ]  ${2}" ;; # light yellow
+    err      ) echo "-e${3:-}" "[  \e[0;31mERROR\e[0m  ]  ${2}" ;; # light red
+    fatal    ) echo "-e${3:-}" "[  \e[0;91mFATAL\e[0m  ]  ${2}" ;; # red
+    inf      ) [[ ${DMS_DEBUG} -eq 1 ]] && echo "-e${3:-}" "[[  \e[0;34mINF\e[0m  ]]  ${2}" ;; # light blue
+    task     ) [[ ${DMS_DEBUG} -eq 1 ]] && echo "-e${3:-}" "[[ \e[0;37mTASKS\e[0m ]]  ${2}" ;; # light grey
+    *        ) ;;
   esac
-
-  [[ -n ${FINAL_MSG} ]] && echo "-e${3:-}" "${FINAL_MSG}"
 }
 export -f _notify
 

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -41,7 +41,7 @@ SPAMASSASSIN_SPAM_TO_INBOX="${SPAMASSASSIN_SPAM_TO_INBOX:=0}"
 SPOOF_PROTECTION="${SPOOF_PROTECTION:=0}"
 SRS_SENDER_CLASSES="${SRS_SENDER_CLASSES:=envelope_sender}"
 SSL_TYPE="${SSL_TYPE:=''}"
-SUPERVISOR_LOGLEVEL="${SUPERVISOR_LOGLEVEL:=info}"
+SUPERVISOR_LOGLEVEL="${SUPERVISOR_LOGLEVEL:=warn}"
 TLS_LEVEL="${TLS_LEVEL:=modern}"
 VIRUSMAILS_DELETE_DELAY="${VIRUSMAILS_DELETE_DELAY:=7}"
 
@@ -363,9 +363,10 @@ function _setup_supervisor
         /etc/supervisor/supervisord.conf
       ;;
     * )
-      _notify 'warn' "SUPERVISOR_LOGLEVEL value unknown. Defaulting to 'info'"
+      _notify 'warn' \
+        "SUPERVISOR_LOGLEVEL value '${SUPERVISOR_LOGLEVEL}' unknown. Defaulting to 'warn'"
       sed -i -E \
-        "s+loglevel.*+loglevel = info+g" \
+        "s+loglevel.*+loglevel = warn+g" \
         /etc/supervisor/supervisord.conf
       ;;
   esac
@@ -389,9 +390,9 @@ function _setup_default_vars
   # ! needs to be a string comparison
   if [[ ${REPORT_RECIPIENT} == "0" ]]
   then
-    PFLOGSUMM_TRIGGER="${PFLOGSUMM_TRIGGER:="none"}"
+    PFLOGSUMM_TRIGGER="${PFLOGSUMM_TRIGGER:=none}"
   else
-    PFLOGSUMM_TRIGGER="${PFLOGSUMM_TRIGGER:="logrotate"}"
+    PFLOGSUMM_TRIGGER="${PFLOGSUMM_TRIGGER:=logrotate}"
   fi
 
   # expand address to simplify the rest of the script
@@ -441,6 +442,7 @@ function _setup_default_vars
     echo "SPOOF_PROTECTION=${SPOOF_PROTECTION}"
     echo "SRS_SENDER_CLASSES=${SRS_SENDER_CLASSES}"
     echo "SSL_TYPE=${SSL_TYPE}"
+    echo "SUPERVISOR_LOGLEVEL=${SUPERVISOR_LOGLEVEL}"
     echo "TLS_LEVEL=${TLS_LEVEL}"
     echo "VIRUSMAILS_DELETE_DELAY=${VIRUSMAILS_DELETE_DELAY}"
     echo "DMS_DEBUG=${DMS_DEBUG}"

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -831,7 +831,7 @@ function _setup_ldap
   fi
 
   # shellcheck disable=SC2016
-  sed -i -E 's+mydestination = $myhostname, +mydestination = +' /etc/postfix/main.cf
+  sed -i 's+mydestination = \$myhostname, +mydestination = +' /etc/postfix/main.cf
 
   return 0
 }

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -1941,7 +1941,7 @@ function _fix_cleanup_spamassassin
 
 function misc
 {
-  _notify 'tasklog' 'Startin misc'
+  _notify 'inf' 'Startin misc'
 
   for FUNC in "${FUNCS_MISC[@]}"
   do
@@ -2192,14 +2192,11 @@ function _start_changedetector
 
 if [[ ${DMS_DEBUG:-0} -eq 1 ]]
 then
-  _notify 'none'
-  _notify 'tasklog' 'ENVIRONMENT'
-  _notify 'none'
-
+  _notify 'inf' 'ENVIRONMENT'
   printenv
 fi
 
-_notify 'tasklog' 'Welcome to docker-mailserver!'
+_notify 'inf' 'Welcome to docker-mailserver!'
 
 register_functions
 check

--- a/target/supervisor/conf.d/supervisor-app.conf
+++ b/target/supervisor/conf.d/supervisor-app.conf
@@ -4,10 +4,6 @@
 # Programs can be controlled like this: 'supervisorctl start fail2ban' 'supervisorctl stop fail2ban'
 # supervisor writes program statuses in /var/log/supervisor
 
-[supervisord]
-nodaemon=true
-strip_ansi=true
-
 [program:mailserver]
 startsecs=0
 autostart=true

--- a/target/supervisor/supervisord.conf
+++ b/target/supervisor/supervisord.conf
@@ -1,28 +1,31 @@
-; supervisor config file
-
 [unix_http_server]
-file=/dev/shm/supervisor.sock    ; (the path to the socket file)
-chmod=0700                       ; sockef file mode (default 0700)
+file = /dev/shm/supervisor.sock
+chmod = 0700
+chown = nobody:nogroup
+username = docker-mailserver
+password = docker-mailserver-password
 
 [supervisord]
-logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
-pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
-childlogdir=/var/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
+user = root
+loglevel = warn
+nodaemon = true
+strip_ansi = false
+logfile = /var/log/supervisor/supervisord.log      ; default $CWD/supervisord.log
+pidfile = /var/run/supervisord.pid                 ; default supervisord.pid
+childlogdir = /var/log/supervisor                  ; default $TEMP ('AUTO' child log dir)
 
-; the below section must remain in the config file for RPC
-; (supervisorctl/web interface) to work, additional interfaces may be
-; added by defining them in separate rpcinterface: sections
+[supervisorctl]
+serverurl = unix:///dev/shm/supervisor.sock        ; use a 'unix://' path for a unix socket
+username = docker-mailserver
+password = docker-mailserver-password
+
+; must remain in config file for RPC (supervisorctl/web interface) to work, additional
+; interfaces may be added by defining them in separate rpcinterface: sections
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
-[supervisorctl]
-serverurl=unix:///dev/shm/supervisor.sock ; use a unix:// URL  for a unix socket
-
-; The [include] section can just contain the "files" setting.  This
-; setting can list multiple files (separated by whitespace or
-; newlines).  It can also contain wildcards.  The filenames are
-; interpreted as relative to this file.  Included files *cannot*
-; include files themselves.
-
+; The [include] section can just contain the "files" setting.  This setting can list multiple
+; files (separated by whitespace or newlines).  It can also contain wildcards.  The filenames
+; are interpreted as relative to this file.  Included files *cannot* include files themselves.
 [include]
 files = /etc/supervisor/conf.d/*.conf

--- a/test/mail_ssl_letsencrypt.bats
+++ b/test/mail_ssl_letsencrypt.bats
@@ -119,7 +119,6 @@ function teardown_file() {
   cp "$(private_config_path mail_lets_acme_json)/letsencrypt/acme-changed.json" "$(private_config_path mail_lets_acme_json)/acme.json"
   sleep 11
   run docker exec mail_lets_acme_json /bin/bash -c "supervisorctl tail changedetector"
-  assert_output --partial "Cert found in /etc/letsencrypt/acme.json for *.example.com"
   assert_output --partial "postfix: stopped"
   assert_output --partial "postfix: started"
   assert_output --partial "Change detected"


### PR DESCRIPTION
This one is important to me. What happened:

1. I added an environment variable which enables users to set the log-level
2. I re-enabled **color** :D See yourself:

![2021-01-21-094536_701x136_scrot](https://user-images.githubusercontent.com/44545919/105327655-71c49a80-5bcf-11eb-9957-4b65a9e069c8.png)

3. Enhanced some output that did not use `_notify` but just `echo`
4. Improved supervisor configuration
5. Got rid of (confusing) `CRIT` messages during startup

**Here is why you should like and approve it**:

---

First of all, the log right now is **all over the place**. See:

``` INI
2021-01-21 00:01:16,377 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
2021-01-21 00:01:16,377 INFO Included extra file "/etc/supervisor/conf.d/saslauth.conf" during parsing
2021-01-21 00:01:16,377 INFO Included extra file "/etc/supervisor/conf.d/supervisor-app.conf" during parsing
2021-01-21 00:01:16,394 INFO RPC interface 'supervisor' initialized
2021-01-21 00:01:16,394 CRIT Server 'unix_http_server' running without any HTTP authentication checking
2021-01-21 00:01:16,394 INFO supervisord started with pid 8
2021-01-21 00:01:17,398 INFO spawned: 'mailserver' with pid 11
 
2021-01-21 00:01:17,444 INFO success: mailserver entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
[ TASKLOG ]  Welcome to docker-mailserver!
 
[ TASKLOG ]  Initializing setup
[ TASKLOG ]  Checking configuration
[ TASKLOG ]  Configuring mail server
Cert found in /etc/letsencrypt/acme.json for mail.Domain.com

[ TASKLOG ]  Startin misc
[ TASKLOG ]  Starting mail server
2021-01-21 00:01:21,967 INFO spawned: 'cron' with pid 264
2021-01-21 00:01:21,968 INFO success: cron entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
cron: started

```

Let's break this down. At the moment, there is no color in our logs. With this PR, this is not the case anymore. More importantly, there are two `CRIT` messages, which **absolutely should not be there**:

``` INI
2021-01-21 00:01:16,377 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.

2021-01-21 00:01:16,394 CRIT Server 'unix_http_server' running without any HTTP authentication checking
```

This was due to a sloppy supervisor configuration. This is now fixed. The configuration file has been cleaned up and improved.

Someone introduced a plain `echo` here:

``` INI
Cert found in /etc/letsencrypt/acme.json for mail.itbsd.com
```

This is now a `_notify`. (Note here that I had to adjust the unit tests to not check against our own logs. We never do that and we can't because of a limitation of ANSI-escape parsing. That is absolutely fine though.)

You can see that I changed the supervisor log-level to `warn`. Before you light this PR up, let me explain:) Currently, you will see this _next_ to our log:

``` INI
2021-01-21 00:01:16,377 INFO Included extra file "/etc/supervisor/conf.d/saslauth.conf" during parsing
2021-01-21 00:01:16,377 INFO Included extra file "/etc/supervisor/conf.d/supervisor-app.conf" during parsing
2021-01-21 00:01:16,394 INFO RPC interface 'supervisor' initialized
2021-01-21 00:01:16,394 INFO supervisord started with pid 8
2021-01-21 00:01:17,398 INFO spawned: 'mailserver' with pid 11
 
2021-01-21 00:01:17,444 INFO success: mailserver entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
```

This will now not be printed anymore. Is this a problem? I argue it's not: 

This will always work, because it is baked into the Dockerfile:

``` INI
2021-01-21 00:01:16,377 INFO Included extra file "/etc/supervisor/conf.d/saslauth.conf" during parsing
2021-01-21 00:01:16,377 INFO Included extra file "/etc/supervisor/conf.d/supervisor-app.conf" during parsing
```

If it's not, a warning is issued and you will see it. Then for

``` INI
2021-01-21 00:01:16,394 INFO RPC interface 'supervisor' initialized
```

it's the same line of reasoning. If you#re interested in the PIDs:

``` INI
2021-01-21 00:01:16,394 INFO supervisord started with pid 8
2021-01-21 00:01:17,398 INFO spawned: 'mailserver' with pid 11
```

run `docker exec mail ps`. The last message:

``` INI
2021-01-21 00:01:17,444 INFO success: mailserver entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
```

has the same line of reasoning as the first two arguments. Now, when `start-mailserver.sh` is running, the default log-level will be warn **if you want** (and by default). But now you have the choice. You could set it back to `info`.

---

I'd like to see this merged as fast as possible :D