### PR TITLE
Apply image template

### DIFF
--- a/.copier-answers.image-template.yml
+++ b/.copier-answers.image-template.yml
@@ -1,0 +1,17 @@
+# Changes here will be overwritten by Copier; do NOT edit manually
+_commit: v0.1.0
+_src_path: https://github.com/Tecnativa/image-template.git
+dockerhub_image: ''
+image_platforms:
+- linux/amd64
+- linux/arm/v7
+- linux/arm64
+main_branches:
+- stable
+- master
+project_name: docker-mailserver
+project_owner: docker-mailserver
+push_to_ghcr: true
+pytest: false
+python_versions:
+- '3.9'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,124 @@
+
+name: test
+
+"on":
+  pull_request:
+  push:
+    branches:
+      - stable
+      - master
+  schedule:
+    - cron: "0 0 * * 5"
+  workflow_dispatch:
+
+env:
+  LANG: "en_US.utf-8"
+  LC_ALL: "en_US.utf-8"
+
+jobs:
+    build-push:
+      runs-on: ubuntu-20.04
+      services:
+        registry:
+          image: registry:2
+          ports:
+            - 5000:5000
+      env:
+        DOCKER_IMAGE_NAME: ${{ github.repository }}
+        PUSH: ${{ toJSON(github.event_name != 'pull_request') }}
+      steps:
+        # Set up Docker Environment
+        - uses: actions/checkout@v2
+          if: github.event_name != 'schedule'
+          with:
+            submodules: recursive
+        # HACK: scheduled actions run on the default branch and GH Actions doesn't allow a conditional "ref" assignment
+        - uses: actions/checkout@v2
+          if: github.event_name == 'schedule'
+          with:
+            submodules: recursive
+            ref: stable
+        - uses: actions/cache@v2
+          with:
+            path: |
+              /tmp/.buildx-cache
+            key:
+              buildx|${{ secrets.CACHE_DATE }}|${{ runner.os }}|${{
+              hashFiles('Dockerfile') }}
+        - name: Set up QEMU
+          uses: docker/setup-qemu-action@v1
+        - name: Set up Docker Buildx
+          id: buildx
+          uses: docker/setup-buildx-action@v1
+          with:
+            driver-opts: network=host
+            install: true
+        # Build and push
+        - name: Docker meta for local images
+          id: docker_meta_local
+          uses: crazy-max/ghaction-docker-meta@v1
+          with:
+            images: localhost:5000/${{ env.DOCKER_IMAGE_NAME }}
+            tag-edge: true
+            tag-semver: |
+              {{version}}
+              {{major}}
+              {{major}}.{{minor}}
+        - name: Build and push to local (test) registry
+          uses: docker/build-push-action@v2
+          with:
+            context: .
+            file: ./Dockerfile
+            platforms: |
+              linux/amd64
+              linux/arm/v7
+              linux/arm64
+            load: false
+            push: true
+            cache-from: type=local,src=/tmp/.buildx-cache
+            cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+            labels: ${{ steps.docker_meta_local.outputs.labels }}
+            tags: ${{ steps.docker_meta_local.outputs.tags }}
+        - name: Run test suite
+          # All tags from docker_meta will refer to the same image, so we can use the first one
+          run: >
+            NAME=localhost:5000/${{ env.DOCKER_IMAGE_NAME }}:${{ steps.docker_meta_local.outputs.tags[0] }}
+            bash -c 'make generate-accounts tests'
+          env:
+            CI: true
+        # Next jobs only happen outside of pull requests and on main branches
+        - name: Login to GitHub Container Registry
+          if: ${{ fromJSON(env.PUSH) }}
+          uses: docker/login-action@v1
+          with:
+            registry: ghcr.io
+            username: ${{ secrets.BOT_LOGIN }}
+            password: ${{ secrets.BOT_TOKEN }}
+        - name: Docker meta for public images
+          if: ${{ fromJSON(env.PUSH) }}
+          id: docker_meta_public
+          uses: crazy-max/ghaction-docker-meta@v1
+          with:
+            images: |
+              ghcr.io/${{ env.DOCKER_IMAGE_NAME }}
+            tag-edge: true
+            tag-semver: |
+              {{version}}
+              {{major}}
+              {{major}}.{{minor}}
+        - name: Build and push to public registry(s)
+          if: ${{ fromJSON(env.PUSH) }}
+          uses: docker/build-push-action@v2
+          with:
+            context: .
+            file: ./Dockerfile
+            platforms: |
+              linux/amd64
+              linux/arm/v7
+              linux/arm64
+            load: false
+            push: true
+            cache-from: type=local,src=/tmp/.buildx-cache
+            cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+            labels: ${{ steps.docker_meta_public.outputs.labels }}
+            tags: ${{ steps.docker_meta_public.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Last image-template](https://img.shields.io/badge/last%20template%20update-v0.1.0-informational)](https://github.com/Tecnativa/image-template/tree/v0.1.0)
+[![GitHub Container Registry](https://img.shields.io/badge/GitHub%20Container%20Registry-latest-%2324292e)](https://github.com/orgs/docker-mailserver/packages/container/package/docker-mailserver)
+
 # Docker Mailserver
 
 [![ci::status]][ci::github] [![docker::pulls]][docker::hub]


### PR DESCRIPTION
Closes https://github.com/docker-mailserver/docker-mailserver/issues/1759

This applies https://github.com/Tecnativa/image-template to this repo. It sets up the CI workflow to build, test and push the images to the Github Container Registry.

**A few changes and comments about how this affects your current flow:**
1. I've tried to merge the whole functionality implemented by the `default_on_push`, `scheduled_builds` and `test_merge_requests` files into the new `ci` file that will apply to **PRs**, push to **master and stable branches**, **scheduled** and **manual** actions. The workflows were basically similar, and I tried to merge the different cases on the same workflow through some conditionals. However, the new workflow won't affect your current ones, as **only the funcionality of pushing to GHCR** is enabled. If, in the future, you would like to remove the other actions and merge everything into this new flow, a simple update from the template is enough (I explain more bellow)
2. The tagging mechanism is slightly different, as mentioned in https://github.com/docker-mailserver/docker-mailserver/issues/1759#issuecomment-765307941. This allows us to generate the docker tags with the https://github.com/crazy-max/ghaction-docker-meta/ action and transverse some logic from the git versioning to docker. It basically tags `:latest` as the latest *released* version in git if a git tag is being pushed, `:edge` as the version that is in *the repo's default* branch, and then each individual git released version with `:{{version}}`, `:{{major}}` and `:{{major}}.{{minor}}` according to the context of the current build. This basically means that:
2.1. In a PR, it will generate a tag of the type `pr-X`
2.2. Once the PR arrives at the default branch, it will push a new `:edge` image and, if a git tag is being applied, it will also push new `:latest` and `:vX-X-X` images, again, according to the templates mentioned above.
3. The images are always built in all the available architectures (linux/amd64, linux/arm/v7 and linux/arm64) even for testing. IMHO, this covers a broader spectrum when you are testing (for example, in a PR), helping to identify potential issues. If we are on a master branch or on a scheduled action (where the goal is to push), the cache is used and the build is very quick, so it won't take much longer.
4. As the images are always built with the same tagging system, it no longer makes sense to tag a `:ci` image and, instead, use the specific image tag generated by the docker meta action (See https://github.com/crazy-max/ghaction-docker-meta/#basic)

As this just adds the new push to GHCR feature in a separate workflow, you can try this configurations there without affecting your DockerHub images and push flow. At the same time, you can try the `image-template` mentioned above which makes it easier to maintain these configurations.

**Some notes about the template:**
https://github.com/Tecnativa/image-template is a [copier](https://github.com/copier-org/copier) template. For updating, check the README on the template.
If you want to change some variables in the template itself, you can do that by simply running a normal update (`copier update`) and changing your answers to some questions.
So, for example, if you end up concentrating all the GH Actions on the `ci.yml` file generated by this template, you'd simply change your answer to the `dockerhub_image` question during the update.
If you have more questions about it, feel free to ask. :smiley: 

@Tecnativa
TT27819

ping @Yajo @aendeavor @wernerfred 