### PR TITLE
Change tag convention and allow multiple registries

### DIFF
--- a/.github/workflows/default_on_push.yml
+++ b/.github/workflows/default_on_push.yml
@@ -59,8 +59,8 @@ jobs:
         uses: crazy-max/ghaction-docker-meta@v1
         with:
           images: |
-            docker.io/mailserver/docker-mailserver
-            ghcr.io/docker-mailserver/docker-mailserver
+            ${{ secrets.DOCKER_REPOSITORY }}
+            ${{ secrets.GHCR_REPOSITORY }}
           tag-edge: true
           tag-semver: |
             {{major}}

--- a/.github/workflows/default_on_push.yml
+++ b/.github/workflows/default_on_push.yml
@@ -2,7 +2,11 @@ name: "Build, Test & Deploy"
 
 on:
   push:
-    branches: [ "master", "stable" ]
+    branches:
+      - master
+      - stable
+    tags:
+      - '*.*.*'
 
 jobs:
   build-and-test-image:
@@ -52,14 +56,16 @@ jobs:
           submodules: recursive
       - name: Prepare tags
         id: prep
-        run: |
-          DOCKER_IMAGE=${{ secrets.DOCKER_REPOSITORY }}
-          VERSION=latest
-          [[ $GITHUB_REF == refs/tags/* ]] && VERSION=${GITHUB_REF#refs/tags/v}
-          [[ $GITHUB_REF == 'refs/heads/stable' ]] && VERSION=stable
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]] && TAGS="$TAGS,${DOCKER_IMAGE}:latest"
-          echo ::set-output name=tags::${TAGS}
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: |
+            docker.io/mailserver/docker-mailserver
+            ghcr.io/docker-mailserver/docker-mailserver
+          tag-edge: true
+          tag-semver: |
+            {{major}}
+            {{major}}.{{minor}}
+            {{major}}.{{minor}}.{{patch}}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -77,6 +83,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_PASSWORD }}
       - name: Build image locally
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/default_on_push.yml
+++ b/.github/workflows/default_on_push.yml
@@ -87,7 +87,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ secrets.GHCR_USERNAME }}
           password: ${{ secrets.GHCR_PASSWORD }}
       - name: Build image locally
         uses: docker/build-push-action@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ The development workflow is the following:
 7. [Commit][commit] and [sign your commit][gpg], push and create a pull-request to merge into `master`
    1. Pull requests are automatically tested against the CI and will be reviewed when tests pass
    2. When your changes are validated, your branch is merged
-   3. CI builds the new `:latest` image
+   3. CI builds the new `:edge` image immediately and your changes will be includes in the next version release.
 
 ## Coding Style
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ A fullstack but simple mail server (SMTP, IMAP, LDAP, Antispam, Antivirus, etc.)
 
 ## Usage
 
+### Available image sources / tags
+
+The [CI/CD workflows](https://github.com/docker-mailserver/docker-mailserver/actions) automatically build, test and push new images to container registries. Currently, the following registries are supported:
+- [DockerHub](https://hub.docker.com/repository/docker/mailserver/docker-mailserver)
+- [GitHub Container Registry](https://github.com/orgs/docker-mailserver/packages?repo_name=docker-mailserver)
+
+All workflows are using the **tagging convention** listed below. It is subsequently applied to all images pushed to supported container registries:
+
+| Event        | Ref                   | Commit SHA | Image Tags                    |
+|--------------|-----------------------|------------|-------------------------------|
+| `push`       | `refs/heads/master`   | `cf20257`  | `edge`                        |
+| `push`       | `refs/heads/stable`   | `cf20257`  | `stable`                      |
+| `push tag`   | `refs/tags/1.2.3`     | `ad132f5`  | `1.2.3`, `1.2`, `1`, `latest` |
+| `push tag`   | `refs/tags/v1.2.3`    | `ad132f5`  | `1.2.3`, `1.2`, `1`, `latest` |
+
 ### Get the tools
 
 Download the `docker-compose.yml`, `compose.env`, `mailserver.env` and the `setup.sh` files:


### PR DESCRIPTION
Closes #1759, replaces #1762 and introduces the new tagging convention of the docker images.

As discussed by the project maintainer team this PR brings in the new tagging convention:
| Event           | Ref                                       | Commit SHA | Docker Tags                         |
|--------------|-------------------------------|----------------|-------------------------------|
| `push`          | `refs/heads/master`             | `cf20257`       | `edge`                    |
| `push`          | `refs/heads/stable`              | `cf20257`        | `stable`                                |
| `push tag`    | `refs/tags/1.2.3`                 | `ad132f5`       | `1.2.3`, `1.2`, `1`, `latest`        |
| `push tag`    | `refs/tags/v1.2.3`                 | `ad132f5`       | `1.2.3`, `1.2`, `1`, `latest`        |

Furthermore it is now possible to push to multiple registries **only by adding them to the `image` section** (only isn't completely true as one needs to add a login step to the additional registry but **no** changes to the logic is needed) of the preparation job:
```
images: |
  docker.io/mailserver/docker-mailserver
  ghcr.io/docker-mailserver/docker-mailserver
```
These values can of course again be transformed into github secrets.

An additional secret/PAT (`${{ secrets.GHCR_PASSWORD }}`) for the login to ghcr is needed with the permissions:
- `read:packages`
- `write:packages`
- `delete:packages`

Make sure to deselect the `repo` scope when creating the PAT (according to [the security guideline for github actions](https://docs.github.com/en/packages/guides/pushing-and-pulling-docker-images). @aendeavor that might be your task).

Furthermore (thanks @radicand) we need `${{ secrets.GHCR_USERNAME }}` set appropriate (see [comment](https://github.com/docker-mailserver/docker-mailserver/pull/1763#discussion_r563211955)).

To be able to push to the github container registry @aendeavor (someone else hast access too?) will need to enable the [improved container support](https://docs.github.com/en/packages/guides/enabling-improved-container-support) on the organization level.

Additionally during my test i discovered that the current triggers didn't run the worklflow (at least when using the new action) when tags were pushed so i added the appropriate trigger matching only semver tags:
```
tags:
    - '*.*.*'
``` 

~~One question to @radicand:~~
~~Are the following lines needed:~~
<details>
<summary>Code</summary>

```
build-args: |
  VCS_REF=${{ github.sha }}
  VCS_VER=${{ github.ref }}
```
</details>

~~On the first sight I did not get the point of these vars but I might have overlooked something~~

__________

Checklist/Requirements
- [x] Add `${{ secrets.GHCR_USERNAME }}`
- [x] Add `${{ secrets.GHCR_PASSWORD }}`
- [x] Enable improved container support for organization

Optional:
- [x] Add  `${{ secrets.GHCR_REPOSITORY }}`
- [x] Add  `${{ secrets.DOCKER_REPOSITORY }}` // edit by @aendeavor,changed `DOCKERHUB_...` to `DOCKER_...`
