### PR TITLE
Replace wrong docker tag pattern

### DIFF
--- a/.github/workflows/default_on_push.yml
+++ b/.github/workflows/default_on_push.yml
@@ -65,7 +65,7 @@ jobs:
           tag-semver: |
             {{major}}
             {{major}}.{{minor}}
-            {{major}}.{{minor}}.{{patch}}
+            {{version}}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx


### PR DESCRIPTION
With the previous pattern, a tag such as `1.0.0-beta1` would be wrongly released as `1.0.0`.

Related to #1759.