### PR TITLE
Replace $_ in error trap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ A construct to trace error in your scripts looks like this. Remember: Remove `se
 
 ``` BASH
 set -xeuEo pipefail
-trap '__log_err ${FUNCNAME[0]:-"?"} ${_:-"?"} ${LINENO:-"?"} ${?:-"?"}' ERR
+trap '__log_err ${FUNCNAME[0]:-"?"} ${BASH_COMMAND:-"?"} ${LINENO:-"?"} ${?:-"?"}' ERR
 
 SCRIPT='name_of_this_script.sh'
 

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,7 @@
 SCRIPT='setup.sh'
 
 set -euEo pipefail
-trap '__log_err ${FUNCNAME[0]:-"?"} ${_:-"?"} ${LINENO:-"?"} ${?:-"?"}' ERR
+trap '__log_err ${FUNCNAME[0]:-"?"} ${BASH_COMMAND:-"?"} ${LINENO:-"?"} ${?:-"?"}' ERR
 trap '_unset_vars || :' EXIT
 
 function __log_err

--- a/test/linting/lint.sh
+++ b/test/linting/lint.sh
@@ -24,7 +24,7 @@ _get_current_directory
 # ? ––––––––––––––––––––––––––––––––––––––––––––– ERRORS
 
 set -eEuo pipefail
-trap '__log_err ${FUNCNAME[0]:-"?"} ${_:-"?"} ${LINENO:-"?"} ${?:-"?"}' ERR
+trap '__log_err ${FUNCNAME[0]:-"?"} ${BASH_COMMAND:-"?"} ${LINENO:-"?"} ${?:-"?"}' ERR
 
 function __log_err
 {


### PR DESCRIPTION
`$_` returns the last argument to the previous command.

Example: `false foo`

` $_` returns "foo"
`$BASH_COMMAND` returns the failing command and argument(s) "false foo"