### PR TITLE
Support extra user_attributes in accounts configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ clean:
 generate-accounts:
 	@ docker run --rm -e MAIL_USER=user1@localhost.localdomain -e MAIL_PASS=mypassword -t $(NAME) /bin/sh -c 'echo "$$MAIL_USER|$$(doveadm pw -s SHA512-CRYPT -u $$MAIL_USER -p $$MAIL_PASS)"' > test/config/postfix-accounts.cf
 	@ docker run --rm -e MAIL_USER=user2@otherdomain.tld -e MAIL_PASS=mypassword -t $(NAME) /bin/sh -c 'echo "$$MAIL_USER|$$(doveadm pw -s SHA512-CRYPT -u $$MAIL_USER -p $$MAIL_PASS)"' >> test/config/postfix-accounts.cf
+	@ docker run --rm -e MAIL_USER=user3@localhost.localdomain -e MAIL_PASS=mypassword -t $(NAME) /bin/sh -c 'echo "$$MAIL_USER|$$(doveadm pw -s SHA512-CRYPT -u $$MAIL_USER -p $$MAIL_PASS)|userdb_mail=mbox:~/mail:INBOX=~/inbox"' >> test/config/postfix-accounts.cf
 	@ echo "# this is a test comment, please don't delete me :'(" >> test/config/postfix-accounts.cf
 	@ echo "           # this is also a test comment, :O" >> test/config/postfix-accounts.cf
 

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -136,12 +136,11 @@ do
 
         # creating users ; 'pass' is encrypted
         # comments and empty lines are ignored
-        while IFS=$'|' read -r LOGIN PASS
+        while IFS=$'|' read -r LOGIN PASS USER_ATTRIBUTES
         do
           USER=$(echo "${LOGIN}" | cut -d @ -f1)
           DOMAIN=$(echo "${LOGIN}" | cut -d @ -f2)
 
-          user_attributes=""
           # test if user has a defined quota
           if [[ -f /tmp/docker-mailserver/dovecot-quotas.cf ]]
           then
@@ -149,7 +148,7 @@ do
             IFS=':' ; read -r -a USER_QUOTA < <(grep "${USER}@${DOMAIN}:" -i /tmp/docker-mailserver/dovecot-quotas.cf)
             unset IFS
 
-            [[ ${#USER_QUOTA[@]} -eq 2 ]] && user_attributes="${user_attributes}userdb_quota_rule=*:bytes=${USER_QUOTA[1]}"
+            [[ ${#USER_QUOTA[@]} -eq 2 ]] && USER_ATTRIBUTES="${USER_ATTRIBUTES} userdb_quota_rule=*:bytes=${USER_QUOTA[1]}"
           fi
 
           echo "${LOGIN} ${DOMAIN}/${USER}/" >>/etc/postfix/vmailbox
@@ -158,7 +157,7 @@ do
           # user:password:uid:gid:(gecos):home:(shell):extra_fields
           # example :
           # ${LOGIN}:${PASS}:5000:5000::/var/mail/${DOMAIN}/${USER}::userdb_mail=maildir:/var/mail/${DOMAIN}/${USER}
-          echo "${LOGIN}:${PASS}:5000:5000::/var/mail/${DOMAIN}/${USER}::${user_attributes}" >>/etc/dovecot/userdb
+          echo "${LOGIN}:${PASS}:5000:5000::/var/mail/${DOMAIN}/${USER}::${USER_ATTRIBUTES}" >>/etc/dovecot/userdb
           mkdir -p "/var/mail/${DOMAIN}/${USER}"
 
           if [[ -e /tmp/docker-mailserver/${LOGIN}.dovecot.sieve ]]

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -711,13 +711,12 @@ function _setup_dovecot_local_user
 
     # creating users ; 'pass' is encrypted
     # comments and empty lines are ignored
-    while IFS=$'|' read -r LOGIN PASS
+    while IFS=$'|' read -r LOGIN PASS USER_ATTRIBUTES
     do
       # Setting variables for better readability
       USER=$(echo "${LOGIN}" | cut -d @ -f1)
       DOMAIN=$(echo "${LOGIN}" | cut -d @ -f2)
 
-      USER_ATTRIBUTES=""
       # test if user has a defined quota
       if [[ -f /tmp/docker-mailserver/dovecot-quotas.cf ]]
       then
@@ -725,7 +724,7 @@ function _setup_dovecot_local_user
         IFS=':' ; read -r -a USER_QUOTA < <(grep "${USER}@${DOMAIN}:" -i /tmp/docker-mailserver/dovecot-quotas.cf)
         unset IFS
 
-        [[ ${#USER_QUOTA[@]} -eq 2 ]] && USER_ATTRIBUTES="${USER_ATTRIBUTES}userdb_quota_rule=*:bytes=${USER_QUOTA[1]}"
+        [[ ${#USER_QUOTA[@]} -eq 2 ]] && USER_ATTRIBUTES="${USER_ATTRIBUTES} userdb_quota_rule=*:bytes=${USER_QUOTA[1]}"
       fi
 
       # Let's go!

--- a/test/test-files/email-templates/existing-user3.txt
+++ b/test/test-files/email-templates/existing-user3.txt
@@ -1,0 +1,12 @@
+HELO mail.external.tld
+MAIL FROM: user@external.tld
+RCPT TO: user3@localhost.localdomain
+DATA
+From: Docker Mail Server <dockermailserver@external.tld>
+To: Existing Local User <user1@localhost.localdomain>
+Date: Sat, 22 May 2010 07:43:33 -0400
+Subject: Test Message existing-user1.txt
+This is a test mail.
+
+.
+QUIT

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -60,6 +60,7 @@ setup_file() {
 	docker exec mail /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-alias-recipient-delimiter.txt"
 	docker exec mail /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user1.txt"
 	docker exec mail /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user2.txt"
+	docker exec mail /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user3.txt"
 	docker exec mail /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-added.txt"
 	docker exec mail /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user-and-cc-local-alias.txt"
 	docker exec mail /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-regexp-alias-external.txt"
@@ -248,6 +249,7 @@ teardown_file() {
  1 <user1@localhost.localdomain>, orig_to=<root>
  1 <user1~test@localhost.localdomain>
  2 <user2@otherdomain.tld>
+ 1 <user3@localhost.localdomain>
 EOF
 }
 
@@ -338,7 +340,8 @@ EOF
   assert_success
   assert_line --index 0 "user1@localhost.localdomain"
   assert_line --index 1 "user2@otherdomain.tld"
-  assert_line --index 2 "added@localhost.localdomain"
+  assert_line --index 2 "user3@localhost.localdomain"
+  assert_line --index 3 "added@localhost.localdomain"
 }
 
 @test "checking accounts: user mail folder for user1" {
@@ -348,6 +351,11 @@ EOF
 
 @test "checking accounts: user mail folder for user2" {
   run docker exec mail /bin/bash -c "ls -d /var/mail/otherdomain.tld/user2"
+  assert_success
+}
+
+@test "checking accounts: user mail folder for user3" {
+  run docker exec mail /bin/bash -c "ls -d /var/mail/localhost.localdomain/user3/mail"
   assert_success
 }
 


### PR DESCRIPTION
This allows you to add for example

    |userdb_mail=mbox:~/mail:INBOX=~/inbox

 to the end of an account to have a different mailbox configuration.