### PR TITLE
Exlude files from triggering workflows

### DIFF
--- a/.github/workflows/default_on_push.yml
+++ b/.github/workflows/default_on_push.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
       - stable
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.github/**'
     tags:
       - '*.*.*'
 

--- a/.github/workflows/default_on_push.yml
+++ b/.github/workflows/default_on_push.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - master
       - stable
-    paths-ignore:
-      - '**.md'
-      - 'LICENSE'
-      - '.github/**'
+    paths: 
+      - 'target/**'
+      - '.dockerignore'
+      - '.gitmodules'
+      - 'Dockerfile'
+      - 'setup.sh'
     tags:
       - '*.*.*'
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,8 +3,16 @@ name: "Lint"
 on:
   pull_request:
     branches: [ "*" ]
+    paths-ignore: 
+      - '**.md'
+      - 'LICENSE'
+      - '.github/**'
   push:
     branches: [ "master", "stable" ]
+    paths-ignore: 
+      - '**.md'
+      - 'LICENSE'
+      - '.github/**'
 
 jobs:
   lint:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,16 +3,8 @@ name: "Lint"
 on:
   pull_request:
     branches: [ "*" ]
-    paths-ignore: 
-      - '**.md'
-      - 'LICENSE'
-      - '.github/**'
   push:
     branches: [ "master", "stable" ]
-    paths-ignore: 
-      - '**.md'
-      - 'LICENSE'
-      - '.github/**'
 
 jobs:
   lint:

--- a/.github/workflows/test_merge_requests.yml
+++ b/.github/workflows/test_merge_requests.yml
@@ -2,10 +2,13 @@ name: "Test Merge Requests"
 
 on: 
   pull_request:
-    paths-ignore: 
-      - '**.md'
-      - 'LICENSE'
-      - '.github/**'
+    paths: 
+      - 'target/**'
+      - 'test/**'
+      - '.dockerignore'
+      - '.gitmodules'
+      - 'Dockerfile'
+      - 'setup.sh'
 
 jobs:
   build-and-test:

--- a/.github/workflows/test_merge_requests.yml
+++ b/.github/workflows/test_merge_requests.yml
@@ -1,6 +1,11 @@
 name: "Test Merge Requests"
 
-on: pull_request
+on: 
+  pull_request:
+    paths-ignore: 
+      - '**.md'
+      - 'LICENSE'
+      - '.github/**'
 
 jobs:
   build-and-test:


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->

<!-- Please link the issue which will be fixed (if any) here: -->
In this PR I added the functionality to our CI/CD pipelines to exclude some files to trigger the workflow.
Basically i added the following lines:
```
paths-ignore: 
  - '**.md'
  - 'LICENSE'
  - '.github/**'
```
Imho this change can save up (waiting)time of unnecessary workflow runs as a change or hotfix on the excluded files will **never** impact the image. Furthermore I think it is possible to exclude even more files as they won't affect the image as well but I want your opinion on the topic itself and then the files that can be excluded too to not miss anything important.

The files that could be also excluded:
- `docker-compose.yml`
- `compose.env`
- `mailserver.env`
- `setup.sh`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or ENVIRONMENT.md or the Wiki)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
