### PR TITLE
Feat/enable custom dkim selector

### DIFF
--- a/target/bin/open-dkim
+++ b/target/bin/open-dkim
@@ -147,20 +147,20 @@ while read -r DOMAINNAME
 do
   mkdir -p "/tmp/docker-mailserver/opendkim/keys/${DOMAINNAME}"
 
-  if [[ ! -f "/tmp/docker-mailserver/opendkim/keys/${DOMAINNAME}/mail.private" ]]
+  if [[ ! -f "/tmp/docker-mailserver/opendkim/keys/${DOMAINNAME}/${SELECTOR}.private" ]]
   then
-    echo "Creating DKIM private key /tmp/docker-mailserver/opendkim/keys/${DOMAINNAME}/mail.private"
+    echo "Creating DKIM private key /tmp/docker-mailserver/opendkim/keys/${DOMAINNAME}/${SELECTOR}.private"
 
     opendkim-genkey \
       --bits="${KEYSIZE}" \
       --subdomains \
       --DOMAIN="${DOMAINNAME}" \
-      --selector=mail \
+      --selector="${SELECTOR}" \
       -D "/tmp/docker-mailserver/opendkim/keys/${DOMAINNAME}"
   fi
 
   # write to KeyTable if necessary
-  KEYTABLEENTRY="mail._domainkey.${DOMAINNAME} ${DOMAINNAME}:mail:/etc/opendkim/keys/${DOMAINNAME}/mail.private"
+  KEYTABLEENTRY="${SELECTOR}._domainkey.${DOMAINNAME} ${DOMAINNAME}:${SELECTOR}:/etc/opendkim/keys/${DOMAINNAME}/${SELECTOR}.private"
   if [[ ! -f "/tmp/docker-mailserver/opendkim/KeyTable" ]]
   then
     echo "Creating DKIM KeyTable"
@@ -173,11 +173,11 @@ do
   fi
 
   # write to SigningTable if necessary
-  SIGNINGTABLEENTRY="*@${DOMAINNAME} mail._domainkey.${DOMAINNAME}"
+  SIGNINGTABLEENTRY="*@${DOMAINNAME} ${SELECTOR}._domainkey.${DOMAINNAME}"
   if [[ ! -f /tmp/docker-mailserver/opendkim/SigningTable ]]
   then
     echo "Creating DKIM SigningTable"
-    echo "*@${DOMAINNAME} mail._domainkey.${DOMAINNAME}" >/tmp/docker-mailserver/opendkim/SigningTable
+    echo "*@${DOMAINNAME} ${SELECTOR}._domainkey.${DOMAINNAME}" >/tmp/docker-mailserver/opendkim/SigningTable
   else
     if ! grep -q "${SIGNINGTABLEENTRY}" /tmp/docker-mailserver/opendkim/SigningTable
     then

--- a/target/bin/open-dkim
+++ b/target/bin/open-dkim
@@ -25,7 +25,7 @@ function __usage
     \e[94mConfiguration adjustments\e[39m
         keysize    Set the size of the keys to be generated. Possible are 1024, 2024 and 4096 (default).
         selector   Set a manual selector (default is 'mail') for the key. (\e[96mATTENTION\e[39m: NOT IMPLEMENTED YET!)
-        domains    Provide the domains for which keys are to be generated.
+        domain     Provide the domain(s) for which keys are to be generated.
 
 \e[38;5;214mEXAMPLES\e[39m
     \e[37m./setup.sh config dkim size 2048\e[39m

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -1106,9 +1106,9 @@ function _setup_dkim
 {
   _notify 'task' 'Setting up DKIM'
 
-  mkdir -p /etc/opendkim && touch /etc/opendkim/SigningTable
+  mkdir -p /etc/opendkim
 
-  # Check if keys are already available
+  # Check if any keys are available
   if [[ -e "/tmp/docker-mailserver/opendkim/KeyTable" ]]
   then
     cp -a /tmp/docker-mailserver/opendkim/* /etc/opendkim/
@@ -1117,12 +1117,9 @@ function _setup_dkim
     _notify 'inf' "Changing permissions on /etc/opendkim"
 
     chown -R opendkim:opendkim /etc/opendkim/
-    chmod -R 0700 /etc/opendkim/keys/ # make sure permissions are right
+    chmod -R 0700 /etc/opendkim/keys/ 
   else
-    _notify 'warn' "No DKIM key provided. Check the documentation to find how to get your keys."
-
-    local KEYTABLE_FILE="/etc/opendkim/KeyTable"
-    [[ ! -f ${KEYTABLE_FILE} ]] && touch "${KEYTABLE_FILE}"
+    _notify 'warn' "No DKIM key provided. Check the documentation on how to get your keys."
   fi
 
   # setup nameservers paramater from /etc/resolv.conf if not defined

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -1117,7 +1117,7 @@ function _setup_dkim
     _notify 'inf' "Changing permissions on /etc/opendkim"
 
     chown -R opendkim:opendkim /etc/opendkim/
-    chmod -R 0700 /etc/opendkim/keys/ 
+    chmod -R 0700 /etc/opendkim/keys/
   else
     _notify 'warn' "No DKIM key provided. Check the documentation on how to get your keys."
   fi

--- a/test/open_dkim.bats
+++ b/test/open_dkim.bats
@@ -387,7 +387,7 @@ function teardown_file
   # Generate first key
   run docker run --rm \
     -v "${PRIVATE_CONFIG}/with-selector/":/tmp/docker-mailserver/ \
-    "${IMAGE_NAME:?}" /bin/sh -c 'generate-dkim-config 2048 domain1.tld mailer| wc -l'
+    "${IMAGE_NAME:?}" /bin/sh -c 'open-dkim keysize 2048 domain 'domain1.tld' selector mailer| wc -l'
   assert_success
   assert_output 4
 

--- a/test/open_dkim.bats
+++ b/test/open_dkim.bats
@@ -379,7 +379,7 @@ function teardown_file
   assert_output 4
 }
 
-@test "checking opendkim: generator creates keys, tables and TrustedHosts using manual provided selector name" {
+@test "${TEST_FILE}generator creates keys, tables and TrustedHosts using manual provided selector name" {
   local PRIVATE_CONFIG
   PRIVATE_CONFIG="$(duplicate_config_for_container . "${BATS_TEST_NAME}")"
   rm -rf "${PRIVATE_CONFIG}/with-selector" && mkdir -p "${PRIVATE_CONFIG}/with-selector"

--- a/test/open_dkim.bats
+++ b/test/open_dkim.bats
@@ -401,7 +401,7 @@ function teardown_file
   # Check key names with selector for domain1.tld
   run docker run --rm \
     -v "${PRIVATE_CONFIG}/with-selector/opendkim":/etc/opendkim \
-    "${IMAGE_NAME:?}" /bin/sh -c 'ls -1 /etc/opendkim/keys/domain1.tld | grep -E 'mailer.private|mailer.txt' | wc -l'
+    "${IMAGE_NAME:?}" /bin/sh -c "ls -1 /etc/opendkim/keys/domain1.tld | grep -E 'mailer.private|mailer.txt' | wc -l"
   assert_success
   assert_output 2
 

--- a/test/open_dkim.bats
+++ b/test/open_dkim.bats
@@ -387,7 +387,7 @@ function teardown_file
   # Generate first key
   run docker run --rm \
     -v "${PRIVATE_CONFIG}/with-selector/":/tmp/docker-mailserver/ \
-    "${IMAGE_NAME:?}" /bin/sh -c 'open-dkim keysize 2048 domain 'domain1.tld' selector mailer| wc -l'
+    "${IMAGE_NAME:?}" /bin/sh -c "open-dkim keysize 2048 domain 'domain1.tld' selector mailer| wc -l"
   assert_success
   assert_output 4
 

--- a/test/open_dkim.bats
+++ b/test/open_dkim.bats
@@ -45,25 +45,6 @@ function teardown_file
 # ––– Actual Tests ––––––––––––––––––––––––––––––
 # –––––––––––––––––––––––––––––––––––––––––––––––
 
-@test "${TEST_FILE}/etc/opendkim/KeyTable dummy file generated without keys provided" {
-  docker run --rm -d \
-    --name mail_smtponly_without_config \
-		-e SMTP_ONLY=1 \
-		-e ENABLE_LDAP=1 \
-		-e PERMIT_DOCKER=network \
-		-e OVERRIDE_HOSTNAME=mail.mydomain.com \
-		-t "${IMAGE_NAME}"
-
-  function teardown
-  {
-    docker rm -f mail_smtponly_without_config
-  }
-
-  run repeat_in_container_until_success_or_timeout 15 \
-    mail_smtponly_without_config /bin/bash -c "cat /etc/opendkim/KeyTable"
-  assert_success
-}
-
 @test "${TEST_FILE}/etc/opendkim/KeyTable should contain 2 entries" {
   run docker exec "${CONTAINER_NAME}" /bin/bash -c "cat /etc/opendkim/KeyTable | wc -l"
   assert_success

--- a/test/open_dkim.bats
+++ b/test/open_dkim.bats
@@ -416,15 +416,15 @@ function teardown_file
   run docker run --rm \
     -v "${PRIVATE_CONFIG}/with-selector/opendkim":/etc/opendkim \
     "${IMAGE_NAME:?}" /bin/sh -c \
-    "egrep 'domain1.tld|domain2.tld|domain3.tld|domain4.tld' /etc/opendkim/KeyTable | wc -l"
+    "grep 'domain1.tld' /etc/opendkim/KeyTable | wc -l"
   assert_success
-  assert_output 4
+  assert_output 1
   
   # Check valid entries actually present in SigningTable
   run docker run --rm \
     -v "${PRIVATE_CONFIG}/with-selector/opendkim":/etc/opendkim \
     "${IMAGE_NAME:?}" /bin/sh -c \
-    "egrep 'domain1.tld|domain2.tld|domain3.tld|domain4.tld' /etc/opendkim/SigningTable | wc -l"
+    "grep 'domain1.tld' /etc/opendkim/SigningTable | wc -l"
   assert_success
-  assert_output 4
+  assert_output 1
 }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->
Enable generate-dkim-config to accept selector as third parameter.

```bash
./setup.sh config dkim <key-size> <domain.tld>[,<domain2.tld>] <selector>
```

which will apply to `private key generation`, `key names`, `KeyTable`, `SigningTable`

<!-- Please link the issue which will be fixed (if any) here: -->
Fixes #1304

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or ENVIRONMENT.md or the Wiki)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
