### PR TITLE
Rewrite of `delmailuser` to enable proper account deletion (again)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -127,7 +127,7 @@ SUBCOMMANDS:
 
     ${0} email add <email> [<password>]
     ${0} email update <email> [<password>]
-    ${0} email del <email>
+    ${0} email del [OPTIONS] <email>
     ${0} email restrict <add|del|list> <send|receive> [<email>]
     ${0} email list
 

--- a/setup.sh
+++ b/setup.sh
@@ -132,11 +132,13 @@ SUBCOMMANDS:
     ${0} email list
 
   alias:
+
     ${0} alias add <email> <recipient>
     ${0} alias del <email> <recipient>
     ${0} alias list
 
   quota:
+
     ${0} quota set <email> [<quota>]
     ${0} quota del <email>
 
@@ -185,7 +187,7 @@ function _docker_image
     fi
 
     ${CRI} run --rm \
-      -v "${CONFIG_PATH}":/tmp/docker-mailserver"${USING_SELINUX}" \
+      -v "${CONFIG_PATH}:/tmp/docker-mailserver${USING_SELINUX}" \
       "${USE_TTY}" "${IMAGE_NAME}" "${@}"
   fi
 }

--- a/target/bin/delmailuser
+++ b/target/bin/delmailuser
@@ -27,7 +27,11 @@ function __usage
     Delete a mail user, aliases, quotas and mail data.
 
 \e[38;5;214mOPTIONS\e[39m
-    -y    Inidicate that \e[1mall mail data\e[22m is to be deleted without another prompt.
+    -y
+        Indicate that \e[1mall mail data\e[22m is to be deleted without another prompt.
+
+    -h
+        Show this help dialogue.
 
 \e[38;5;214mEXAMPLES\e[39m
     ./setup.sh email del -y test@domain.com another-test@domain.com
@@ -39,8 +43,7 @@ function __usage
         mailbox data should be deleted.
 
 \e[38;5;214mEXIT STATUS\e[39m
-    Exit status is 0 if command was successful, and 1 if there is a an error.
-
+    Exit status is 0 if command was successful, and 1 if there was an error.
 "
 }
 
@@ -50,17 +53,24 @@ then
   exit 0
 fi
 
-while getopts ":yY" OPT
+while getopts ":yYh" OPT
 do
   case ${OPT} in
     y | Y )
       MAILDEL=true
       ;;
+
+    h )
+      __usage
+      exit 0
+      ;;
+
     * )
       __usage
       echo "The option ${OPT} is unknown." >&2
       exit 1
       ;;
+
   esac
 done
 shift $((OPTIND-1))

--- a/target/bin/delmailuser
+++ b/target/bin/delmailuser
@@ -38,11 +38,15 @@ shift $((OPTIND-1))
 if ! ${MAILDEL}
 then
   read -r -p "Do you want to delete the mailbox as well (removing all mails) ? [Y/n] " MAILDEL_CHOSEN
-  [[ ${MAILDEL_CHOSEN} =~ (y|Y| ) ]] && MAILDEL=true
+  if [[ ${MAILDEL_CHOSEN} =~ (y|Y|yes|Yes) ]] || [[ -z ${MAILDEL_CHOSEN} ]]
+  then
+    MAILDEL=true
+  fi
 fi
 
 (
   flock -e 200
+  ERROR=false
 
   for USER in "${@}"
   do
@@ -54,13 +58,15 @@ fi
     MAILARR[1]="${USER#*@}"
 
     # ${USER} must not contain /s and other syntactic characters
+    UNESCAPED_USER="${USER}"
     USER=$(escape "${USER}")
 
     if [[ -f ${DATABASE} ]]
     then
       if ! sed -i "/^${USER}|/d" "${DATABASE}"
       then
-        errex "${USER} couldn't be deleted in ${DATABASE}. ${?}"
+        echo "${USER} couldn't be deleted in ${DATABASE}. ${?}" >&2
+        ERROR=true
       fi
     fi
 
@@ -72,9 +78,10 @@ fi
         -e "/ ${USER}$/d" -e "s/,${USER}//g" -e "s/${USER},//g" \
         "${ALIAS_DATABASE}"
       then
-        echo "${USER} and potential aliases deleted."
+        echo "${UNESCAPED_USER} and potential aliases deleted."
       else
-        errex "Aliases for ${USER} couldn't be deleted in ${ALIAS_DATABASE}."
+        echo "Aliases for ${UNESCAPED_USER} couldn't be deleted in ${ALIAS_DATABASE}." >&2
+        ERROR=true
       fi
     fi
 
@@ -83,7 +90,8 @@ fi
     then
       if ! sed -i -e "/^${USER}:.*$/d" "${QUOTA_DATABASE}"
       then
-        errex "Quota for ${USER} couldn't be deleted in ${QUOTA_DATABASE}."
+        echo "Quota for ${UNESCAPED_USER} couldn't be deleted in ${QUOTA_DATABASE}." >&2
+        ERROR=true
       fi
     fi
 
@@ -93,17 +101,20 @@ fi
       exit 0
     fi
 
-    if [[ -d "/var/mail/${MAILARR[1]}/${MAILARR[0]}" ]]
+    if [[ -e "/var/mail/${MAILARR[1]}/${MAILARR[0]}" ]]
     then
-      if rm -r -f "/var/mail/${MAILARR[1]}/${MAILARR[0]}"
+      if rm -R "/var/mail/${MAILARR[1]}/${MAILARR[0]}"
       then
         echo "Mailbox deleted."
       else
-        errex "Mailbox couldn't be deleted."
+        echo "Mailbox couldn't be deleted." >&2
+        ERROR=true
       fi
     else
       echo "Mailbox directory '/var/mail/${MAILARR[1]}/${MAILARR[0]}' did not exist."
     fi
   done
+
+  ${ERROR} && errex "Errors encountered."
 
 ) 200< "${DATABASE}"

--- a/target/bin/delmailuser
+++ b/target/bin/delmailuser
@@ -65,7 +65,7 @@ fi
     then
       if ! sed -i "/^${USER}|/d" "${DATABASE}"
       then
-        echo "${USER} couldn't be deleted in ${DATABASE}. ${?}" >&2
+        echo "${USER} couldn't be deleted in ${DATABASE}." >&2
         ERROR=true
       fi
     fi
@@ -91,7 +91,6 @@ fi
       if ! sed -i -e "/^${USER}:.*$/d" "${QUOTA_DATABASE}"
       then
         echo "Quota for ${UNESCAPED_USER} couldn't be deleted in ${QUOTA_DATABASE}." >&2
-        ERROR=true
       fi
     fi
 
@@ -111,10 +110,13 @@ fi
         ERROR=true
       fi
     else
-      echo "Mailbox directory '/var/mail/${MAILARR[1]}/${MAILARR[0]}' did not exist."
+      echo "Mailbox directory '/var/mail/${MAILARR[1]}/${MAILARR[0]}' did not exist." >&2
+      ERROR=true
     fi
   done
 
-  ${ERROR} && errex "Errors encountered."
+  ${ERROR} && errex 'Errors encountered.'
 
 ) 200< "${DATABASE}"
+
+exit 0

--- a/target/bin/delmailuser
+++ b/target/bin/delmailuser
@@ -13,10 +13,42 @@ ALIAS_DATABASE="/tmp/docker-mailserver/postfix-virtual.cf"
 QUOTA_DATABASE="/tmp/docker-mailserver/dovecot-quotas.cf"
 MAILDEL=false
 
-function usage
+function __usage
 {
-  echo "Usage: delmailuser [-y] <user@domain> [<user2@anotherdomain>]"
+  echo -e "\e[35mDELMAILUSER\e[31m(\e[93m8\e[31m)
+
+\e[38;5;214mNAME\e[39m
+    delmailuser - delete a user and related data
+
+\e[38;5;214mSYNOPSIS\e[39m
+    ./setup.sh email del [ OPTIONS ] { <MAIL ADDRESS> [<MAIL ADDRESS 2>\e[31m...\e[39m] \e[31m|\e[39m help }
+
+\e[38;5;214mDESCRIPTION\e[39m
+    Delete a mail user, aliases, quotas and mail data.
+
+\e[38;5;214mOPTIONS\e[39m
+    -y    Inidicate that \e[1mall mail data\e[22m is to be deleted without another prompt.
+
+\e[38;5;214mEXAMPLES\e[39m
+    ./setup.sh email del -y test@domain.com another-test@domain.com
+        Delete all mail data for the users 'test' and 'another-test'
+        and do not prompt to ask if all mail data should be deleted.
+
+    ./setup.sh email del woohoo@some-domain.org
+        Delete the mail user, quotas and aliases, but ask again whether
+        mailbox data should be deleted.
+
+\e[38;5;214mEXIT STATUS\e[39m
+    Exit status is 0 if command was successful, and 1 if there is a an error.
+
+"
 }
+
+if [[ ${1} == 'help' ]]
+then
+  __usage
+  exit 0
+fi
 
 while getopts ":yY" OPT
 do
@@ -25,7 +57,8 @@ do
       MAILDEL=true
       ;;
     * )
-      usage
+      __usage
+      echo "The option ${OPT} is unknown." >&2
       exit 1
       ;;
   esac
@@ -65,7 +98,7 @@ fi
     then
       if ! sed -i "/^${USER}|/d" "${DATABASE}"
       then
-        echo "${USER} couldn't be deleted in ${DATABASE}." >&2
+        echo "${UNESCAPED_USER} couldn't be deleted in ${DATABASE}." >&2
         ERROR=true
       fi
     fi


### PR DESCRIPTION
# Description

Mailbox contents should be deleted properly now when using `./setup.sh email del <user@domain.tld>`.

Fixes #1808

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or ENVIRONMENT.md or the Wiki)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
