### PR TITLE
fix: dkim help message test

### DIFF
--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1130,7 +1130,7 @@ EOF
 @test "setup.sh :: setup.sh config dkim help correctly displayed" {
   run ./setup.sh -c mail config dkim help
   assert_success
-  assert_line --index 3 "    open-dkim - configure DomainKeys Identified Mail (DKIM)"
+  assert_line --index 3 --partial "    open-dkim - configure DomainKeys Identified Mail (DKIM)"
 }
 
 # debug


### PR DESCRIPTION
# Description

Hotfix of this issue that appeared after some refactoring of setup.sh and the open-dkim script: https://github.com/docker-mailserver/docker-mailserver/pull/1812#discussion_r578668242
Also provided via PR as changes to tests are not run in CI if pushed directly on master.

```
# -- line differs --
# index    : 3
# expected :     open-dkim - configure DomainKeys Identified Mail (DKIM)
# actual   :     open-dkim - configure DomainKeys Identified Mail (DKIM)
# --
# 
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or ENVIRONMENT.md or the Wiki)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
