### PR TITLE
Remove fix-missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # –––––––––––––––––––––––––––––––––––––––––––––––
 
 RUN \
-  apt-get -qq --fix-missing update && \
+  apt-get -qq update && \
   apt-get -y install apt-utils &>/dev/null && \
   apt-get -y dist-upgrade >/dev/null && \
   apt-get -y install postfix >/dev/null && \


### PR DESCRIPTION
# Description

Remove unnecessary/dangerous `--fix-missing` option in build process.

From the `apt-get` man page:

`Ignore missing packages; if packages cannot be retrieved or fail the integrity check after retrieval (corrupted package files), hold back those packages and handle the result.`

I cannot imagine a case, where we would want that behavior.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or ENVIRONMENT.md or the Wiki)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
