### PR TITLE
Fix REPORT_RECIPIENT=1 behavior

### DIFF
--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -392,10 +392,9 @@ function _setup_default_vars
   fi
 
   # expand address to simplify the rest of the script
-  if [[ ${REPORT_RECIPIENT} == "0" ]] || [[ ${REPORT_RECIPIENT} == "0" ]]
+  if [[ ${REPORT_RECIPIENT} == "0" ]] || [[ ${REPORT_RECIPIENT} == "1" ]]
   then
     REPORT_RECIPIENT="${POSTMASTER_ADDRESS}"
-    REPORT_RECIPIENT="${REPORT_RECIPIENT}"
   fi
 
   PFLOGSUMM_RECIPIENT="${PFLOGSUMM_RECIPIENT:=${REPORT_RECIPIENT}}"


### PR DESCRIPTION
# Description

While REPORT_RECIPIENT=1, reports were sent to 1@ instead of postmaster@.
It happened because condition has never matched.

Must be some [migration](/docker-mailserver/docker-mailserver/blame/c1a6bd9d3de61429bad067ce72285af7599621c3/target/scripts/start-mailserver.sh#L395) leftovers.

Fixes #1829

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or ENVIRONMENT.md or the Wiki)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
