### PR TITLE
first (may-be) fixes for v9.0.0 startup problems

### DIFF
--- a/target/scripts/startup/fixes-stack.sh
+++ b/target/scripts/startup/fixes-stack.sh
@@ -25,6 +25,8 @@ function _fix_var_mail_permissions
   else
     _notify 'inf' 'Permissions in /var/mail look OK'
   fi
+
+  return 0
 }
 
 function _fix_var_amavis_permissions

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -382,7 +382,7 @@ function _setup_dovecot_local_user
     _notify 'inf' "'config/docker-mailserver/postfix-accounts.cf' is not provided. No mail account created."
   fi
 
-  if ! grep '@' /tmp/docker-mailserver/postfix-accounts.cf | grep -q '|'
+  if ! grep '@' /tmp/docker-mailserver/postfix-accounts.cf 2>/dev/null | grep -q '|'
   then
     if [[ ${ENABLE_LDAP} -eq 0 ]]
     then

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -21,7 +21,7 @@ function _setup_supervisor
         ;;
 
       * )
-        _notify 'error' \
+        _notify 'err' \
           "SUPERVISOR_LOGLEVEL value '${SUPERVISOR_LOGLEVEL}' unknown. Defaulting to 'warn'"
 
         sed -i -E \
@@ -749,7 +749,7 @@ function _setup_dkim
 {
   _notify 'task' 'Setting up DKIM'
 
-  mkdir -p /etc/opendkim
+  mkdir -p /etc/opendkim && touch /etc/opendkim/SigningTable
 
   # check if any keys are available
   if [[ -e "/tmp/docker-mailserver/opendkim/KeyTable" ]]
@@ -763,6 +763,7 @@ function _setup_dkim
     chmod -R 0700 /etc/opendkim/keys/
   else
     _notify 'warn' 'No DKIM key provided. Check the documentation on how to get your keys.'
+    [[ ! -f "/etc/opendkim/KeyTable" ]] && touch "/etc/opendkim/KeyTable"
   fi
 
   # setup nameservers paramater from /etc/resolv.conf if not defined


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->
Provides the necessary hotfixes for the startup problems mentioned in the @docker-mailserver/maintainers team and in #1834.

This may be incomplete. Suggestions are welcome.

<!-- Please link the issue which will be fixed (if any) here: -->
Fixes #1843

## What was done?

1. Partial rollback in `_setup_dkim` which may gobble setups of persons not using openDKIM
2. `_fix_var_mail_permissions` should no return normally again and should therefore not introduce failures

## What's still to investigate?

Does the `_setup_supervisor` restart supervisor if the loglevel is not `warn`? Did this work before? Why does is now seem like supervisor is restarted endlessly (looking at #1834).

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
