### PR TITLE
Use time zone from host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - maildata:/var/mail
       - mailstate:/var/mail-state
       - maillogs:/var/log/mail
+      - /etc/localtime:/etc/localtime:ro
       - ./config/:/tmp/docker-mailserver/${SELINUX_LABEL}
     restart: always
     cap_add: [ "NET_ADMIN", "SYS_PTRACE" ]


### PR DESCRIPTION
# Description

It's probably intended behaviour, that the container uses the same timezone as the host. If nothing is configured, UTC is used.
Without a proper configured timezone, e.g. log files will have time offset.

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->

<!-- Please link the issue which will be fixed (if any) here: -->
Inspired by #1849

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or ENVIRONMENT.md or the Wiki)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
