### PR TITLE
yaml base-60 float warning added

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     domainname: ${DOMAINNAME}
     container_name: ${CONTAINER_NAME}
     env_file: mailserver.env
+    # To avoid conflicts with yaml base-60 float, DO NOT remove the quotation marks.
     ports:
       - "25:25"
       - "143:143"


### PR DESCRIPTION
# Description

Removing the quotation marks in the docker-compose port section, can lead to unexpected behaviour.

More Information:

- https://github.com/compose-spec/compose-spec/blob/master/spec.md#ports
- https://yaml.org/type/float.html

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->

<!-- Please link the issue which will be fixed (if any) here: -->
Fixes #1858 and other similar

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or ENVIRONMENT.md or the Wiki)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
