### PR TITLE
Make directory with parent directories

### DIFF
--- a/target/bin/generate-ssl-certificate
+++ b/target/bin/generate-ssl-certificate
@@ -14,7 +14,7 @@ SSL_CFG_PATH="/tmp/docker-mailserver/ssl"
 
 if [[ ! -d ${SSL_CFG_PATH} ]]
 then
-  mkdir "${SSL_CFG_PATH}"
+  mkdir --parents "${SSL_CFG_PATH}"
 fi
 
 cd "${SSL_CFG_PATH}" || { echo "cd ${SSL_CFG_PATH} error" ; exit ; }


### PR DESCRIPTION
If you don't mount the ssl directory or set SSL_CFG_PATH to something else then the directory needs to be created with parents.