### PR TITLE
Fix for #1808

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -340,7 +340,7 @@ function _main
       case ${2:-} in
         add      ) shift 2 ; _docker_image addmailuser "${@}" ;;
         update   ) shift 2 ; _docker_image updatemailuser "${@}" ;;
-        del      ) shift 2 ; _docker_image delmailuser "${@}" ;;
+        del      ) shift 2 ; _docker_container delmailuser "${@}" ;;
         restrict ) shift 2 ; _docker_container restrict-access "${@}" ;;
         list     ) _docker_image listmailuser ;;
         *        ) _usage ;;


### PR DESCRIPTION
# Description

It was not possible to delete the mail directory when using `setup.sh`

```
./setup.sh email del foo@example.com
[..]
Mailbox directory '/var/mail/example.com/foo' did not exist.
```

That was caused by not using the running mail container, instead a new container was started without `maildata` being mounted.

<!-- Please link the issue which will be fixed (if any) here: -->
Fixes #1808

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or ENVIRONMENT.md or the documentation)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
