### PR TITLE
adds switch for macos systems to use greadlink instead

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -36,11 +36,11 @@ ly and use ./setup.sh help and read the VERSION section.\n" >&2
 
 function _use_readlink
 {
-  if uname -a | grep Darwin == "" &>/dev/null
+  if uname -a | grep -q Darwin
   then
-    READLINK="$(readlink -f "${0}")"
-  else
     READLINK="$(greadlink -f "${0}")"
+  else
+    READLINK="$(readlink -f "${0}")"
   fi
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -34,13 +34,24 @@ the version / tag of docker-mailserver. Please read the
 ly and use ./setup.sh help and read the VERSION section.\n" >&2
 }
 
+<<<<<<< HEAD
 function _use_readlink
+=======
+function _unset_vars
+{
+  unset CDIR CRI INFO IMAGE_NAME CONTAINER_NAME DEFAULT_CONFIG_PATH
+  unset USE_CONTAINER WISHED_CONFIG_PATH CONFIG_PATH VOLUME USE_TTY
+  unset SCRIPT USING_SELINUX
+}
+
+function _get_script_path
+>>>>>>> 513202f (more meaningful names)
 {
   if uname -a | grep -q Darwin
   then
-    READLINK="$(greadlink -f "${0}")"
+    SCRIPT_PATH="$(greadlink -f "${0}")"
   else
-    READLINK="$(readlink -f "${0}")"
+    SCRIPT_PATH="$(readlink -f "${0}")"
   fi
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -34,11 +34,21 @@ the version / tag of docker-mailserver. Please read the
 ly and use ./setup.sh help and read the VERSION section.\n" >&2
 }
 
+function _use_readlink
+{
+  if uname -a | grep Darwin == "" &>/dev/null
+  then
+    READLINK="$(readlink -f "${0}")"
+  else
+    READLINK="$(greadlink -f "${0}")"
+  fi
+}
+
 function _get_absolute_script_directory
 {
-  if dirname "$(readlink -f "${0}")" &>/dev/null
+  if dirname ${READLINK} &>/dev/null
   then
-    DIR="$(dirname "$(readlink -f "${0}")")"
+    DIR="$(dirname ${READLINK})"
   elif realpath -e -L "${0}" &>/dev/null
   then
     DIR="$(realpath -e -L "${0}")"
@@ -47,6 +57,7 @@ function _get_absolute_script_directory
 }
 
 DIR="$(pwd)"
+_use_readlink
 _get_absolute_script_directory
 
 CRI=

--- a/setup.sh
+++ b/setup.sh
@@ -34,18 +34,7 @@ the version / tag of docker-mailserver. Please read the
 ly and use ./setup.sh help and read the VERSION section.\n" >&2
 }
 
-<<<<<<< HEAD
-function _use_readlink
-=======
-function _unset_vars
-{
-  unset CDIR CRI INFO IMAGE_NAME CONTAINER_NAME DEFAULT_CONFIG_PATH
-  unset USE_CONTAINER WISHED_CONFIG_PATH CONFIG_PATH VOLUME USE_TTY
-  unset SCRIPT USING_SELINUX
-}
-
 function _get_script_path
->>>>>>> 513202f (more meaningful names)
 {
   if uname -a | grep -q Darwin
   then
@@ -57,9 +46,9 @@ function _get_script_path
 
 function _get_absolute_script_directory
 {
-  if dirname ${READLINK} &>/dev/null
+  if dirname "${SCRIPT_PATH}" &>/dev/null
   then
-    DIR="$(dirname ${READLINK})"
+    DIR=$(dirname "${SCRIPT_PATH}")
   elif realpath -e -L "${0}" &>/dev/null
   then
     DIR="$(realpath -e -L "${0}")"
@@ -68,7 +57,7 @@ function _get_absolute_script_directory
 }
 
 DIR="$(pwd)"
-_use_readlink
+_get_script_path
 _get_absolute_script_directory
 
 CRI=


### PR DESCRIPTION
Issue on macos is readlink does not support -f greadlink instead does

# Description

readlink on macos does not support -f 

<!-- Please link the issue which will be fixed (if any) here: -->
Fixes # (issue)
https://github.com/docker-mailserver/docker-mailserver/issues/1884

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
