### PR TITLE
Add stop grace period

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - ./config/:/tmp/docker-mailserver/${SELINUX_LABEL}
     restart: always
+    stop_grace_period: 1m
     cap_add: [ "NET_ADMIN", "SYS_PTRACE" ]
 
 volumes:


### PR DESCRIPTION
# Description

It's always best practice, to shutdown services graceful. `docker-compose down/stop` sends [SIGKILL after 10 seconds](https://docs.docker.com/compose/compose-file/compose-file-v3/#stop_grace_period). In some environments, this is not enough time for the services to stop.

`docker-compose` will now wait up to 1 minute before sending SIGKILL, which should be enough time.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or ENVIRONMENT.md or the documentation)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
