### PR TITLE
Use dovecot's LDAP uris option instead of hosts (fixes #1510)

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -379,7 +379,7 @@ Note: The defaults of your fetchmailrc file need to be at the top of the file. O
 ##### LDAP_SERVER_HOST
 
 - **empty** => mail.domain.com
-- => Specify the dns-name/ip-address where the ldap-server
+- => Specify the dns-name/ip-address where the ldap-server is listening, or an URI like `ldaps://mail.domain.com`
 - NOTE: If you going to use the mailserver in combination with docker-compose you can set the service name here
 
 ##### LDAP_SEARCH_BASE

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -446,10 +446,12 @@ The following variables overwrite the default values for ```/etc/dovecot/dovecot
 - **empty** => same as `LDAP_BIND_PW`
 - => Password for LDAP dn sepecifified in `DOVECOT_DN`.
 
-##### DOVECOT_HOSTS
+##### DOVECOT_URIS
 
 - **empty** => same as `LDAP_SERVER_HOST`
-- => Specify a space separated list of LDAP hosts.
+- => Specify a space separated list of LDAP uris.
+- Note: If the protocol is missing, `ldap://` will be used.
+- Note: This deprecates `DOVECOT_HOSTS` (as it didn't allow to use LDAPS), which is currently still supported for backwards compatibility.
 
 ##### DOVECOT_LDAP_VERSION
 
@@ -477,6 +479,7 @@ The following variables overwrite the default values for ```/etc/dovecot/dovecot
 ##### DOVECOT_PASS_FILTER
 
 - e.g. `(&(objectClass=PostfixBookMailAccount)(uniqueIdentifier=%n))`
+- **empty** => same as `DOVECOT_USER_FILTER`
 
 ##### DOVECOT_PASS_ATTRS
 

--- a/target/dovecot/dovecot-ldap.conf.ext
+++ b/target/dovecot/dovecot-ldap.conf.ext
@@ -2,7 +2,7 @@ base                = ou=people,dc=domain,dc=com
 default_pass_scheme = SSHA
 dn                  = cn=admin,dc=domain,dc=com
 dnpass              = admin
-hosts               = mail.domain.com
+uris                = ldap://mail.domain.com
 tls                 = no
 ldap_version        = 3
 pass_attrs          = uniqueIdentifier=user,userPassword=password

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -437,10 +437,17 @@ function _setup_ldap
 
   declare -A _dovecot_ldap_mapping
 
+  # Add protocol to LDAP_SERVER_HOST so that we can use dovecot's "uris" option:
+  # https://doc.dovecot.org/configuration_manual/authentication/ldap/
+  dovecot_ldap_server_uri="${LDAP_SERVER_HOST}"
+  if ! echo "${dovecot_ldap_server_uri}" | grep -F '://' >/dev/null; then
+    dovecot_ldap_server_uri="ldap://${dovecot_ldap_server_uri}"
+  fi
+
   _dovecot_ldap_mapping["DOVECOT_BASE"]="${DOVECOT_BASE:="${LDAP_SEARCH_BASE}"}"
   _dovecot_ldap_mapping["DOVECOT_DN"]="${DOVECOT_DN:="${LDAP_BIND_DN}"}"
   _dovecot_ldap_mapping["DOVECOT_DNPASS"]="${DOVECOT_DNPASS:="${LDAP_BIND_PW}"}"
-  _dovecot_ldap_mapping["DOVECOT_HOSTS"]="${DOVECOT_HOSTS:="${LDAP_SERVER_HOST}"}"
+  _dovecot_ldap_mapping["DOVECOT_URIS"]="${DOVECOT_URIS:="${dovecot_ldap_server_uri}"}"
 
   # Not sure whether this can be the same or not
   # _dovecot_ldap_mapping["DOVECOT_PASS_FILTER"]="${DOVECOT_PASS_FILTER:="${LDAP_QUERY_FILTER_USER}"}"

--- a/test/mail_with_ldap.bats
+++ b/test/mail_with_ldap.bats
@@ -155,7 +155,7 @@ function teardown_file() {
 }
 
 @test "checking dovecot: ldap config overwrites success" {
-  run docker exec mail_with_ldap /bin/sh -c "grep 'hosts = ldap' /etc/dovecot/dovecot-ldap.conf.ext"
+  run docker exec mail_with_ldap /bin/sh -c "grep 'uris = ldap://ldap' /etc/dovecot/dovecot-ldap.conf.ext"
   assert_success
   run docker exec mail_with_ldap /bin/sh -c "grep 'tls = no' /etc/dovecot/dovecot-ldap.conf.ext"
   assert_success


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->
According to https://doc.dovecot.org/configuration_manual/authentication/ldap/, the "uris" option has to be used when using LDAPS, while the "hosts" option seems to only work with STARTTLS. So, this PR fixes the problem that docker-mailserver can't be used with LDAPS.

The change is made in a way that allows backwards-compatibility with configurations that assume the "hosts" option to be set by LDAP_SERVER_HOST, in which case it's using "ldap://" as a default protocol if none is specified. The only change for the user is that LDAP_SERVER_HOST now supports specifying a protocol like "ldaps://...".

<!-- Please link the issue which will be fixed (if any) here: -->
Fixes #1510

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or ENVIRONMENT.md or the documentation)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes