### PR TITLE
Add LDAP_QUERY_FILTER_SENDERS setting for spoof protection with LDAP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,7 @@ COPY \
   target/postfix/ldap-groups.cf \
   target/postfix/ldap-aliases.cf \
   target/postfix/ldap-domains.cf \
+  target/postfix/ldap-senders.cf \
   /etc/postfix/
 
 # hadolint ignore=SC2016

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -417,6 +417,11 @@ Note: The defaults of your fetchmailrc file need to be at the top of the file. O
 - e.g. `(&(|(mail=*@%s)(mailalias=*@%s)(mailGroupMember=*@%s))(mailEnabled=TRUE))`
 - => Specify how ldap should be asked for domains
 
+##### LDAP_QUERY_FILTER_SENDERS
+
+- e.g. `(mail=%s)`
+- => Specify how ldap should be asked if a sender address is allowed for a user
+
 ##### DOVECOT_TLS
 
 - **empty** => no

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -419,9 +419,8 @@ Note: The defaults of your fetchmailrc file need to be at the top of the file. O
 
 ##### LDAP_QUERY_FILTER_SENDERS
 
-- e.g. `(mail=%s)`
+- **empty**  => use user/alias/group maps directly, equivalent to `(|($LDAP_QUERY_FILTER_USER)($LDAP_QUERY_FILTER_ALIAS)($LDAP_QUERY_FILTER_GROUP))`
 - => Override how ldap should be asked if a sender address is allowed for a user
-- Note: by default this is using the user/alias/group maps, so effectively the following filter: `(|($LDAP_QUERY_FILTER_USER)($LDAP_QUERY_FILTER_ALIAS)($LDAP_QUERY_FILTER_GROUP))`
 
 ##### DOVECOT_TLS
 

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -420,7 +420,8 @@ Note: The defaults of your fetchmailrc file need to be at the top of the file. O
 ##### LDAP_QUERY_FILTER_SENDERS
 
 - e.g. `(mail=%s)`
-- => Specify how ldap should be asked if a sender address is allowed for a user
+- => Override how ldap should be asked if a sender address is allowed for a user
+- Note: by default this is using the user/alias/group maps, so effectively the following filter: `(|($LDAP_QUERY_FILTER_USER)($LDAP_QUERY_FILTER_ALIAS)($LDAP_QUERY_FILTER_GROUP))`
 
 ##### DOVECOT_TLS
 

--- a/docs/content/config/advanced/auth-ldap.md
+++ b/docs/content/config/advanced/auth-ldap.md
@@ -20,6 +20,7 @@ Have a look at the [`ENVIRONMENT.md`][github-file-env] for information on the de
     - `LDAP_QUERY_FILTER_GROUP`
     - `LDAP_QUERY_FILTER_ALIAS`
     - `LDAP_QUERY_FILTER_DOMAIN`
+    - `LDAP_QUERY_FILTER_SENDERS`
 
 !!! example "saslauthd"
 

--- a/target/postfix/ldap-senders.cf
+++ b/target/postfix/ldap-senders.cf
@@ -1,0 +1,9 @@
+bind             = yes
+bind_dn          = cn=admin,dc=domain,dc=com
+bind_pw          = admin
+query_filter     = (mail=%s)
+result_attribute = mail, uid
+search_base      = ou=people,dc=domain,dc=com
+server_host      = mail.domain.com
+start_tls        = no
+version          = 3

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -421,6 +421,7 @@ function _setup_ldap
     /etc/postfix/ldap-groups.cf
     /etc/postfix/ldap-aliases.cf
     /etc/postfix/ldap-domains.cf
+    /etc/postfix/ldap-senders.cf
     /etc/postfix/maps/sender_login_maps.ldap
   )
 
@@ -430,6 +431,7 @@ function _setup_ldap
     [[ ${FILE} =~ ldap-group ]] && export LDAP_QUERY_FILTER="${LDAP_QUERY_FILTER_GROUP}"
     [[ ${FILE} =~ ldap-aliases ]] && export LDAP_QUERY_FILTER="${LDAP_QUERY_FILTER_ALIAS}"
     [[ ${FILE} =~ ldap-domains ]] && export LDAP_QUERY_FILTER="${LDAP_QUERY_FILTER_DOMAIN}"
+    [[ ${FILE} =~ ldap-senders ]] && export LDAP_QUERY_FILTER="${LDAP_QUERY_FILTER_SENDERS}"
     configomat.sh "LDAP_" "${FILE}"
   done
 
@@ -553,7 +555,11 @@ function _setup_spoof_protection
 
   if [[ ${ENABLE_LDAP} -eq 1 ]]
   then
-    postconf -e "smtpd_sender_login_maps = ldap:/etc/postfix/ldap-users.cf ldap:/etc/postfix/ldap-aliases.cf ldap:/etc/postfix/ldap-groups.cf"
+    if [[ -z ${LDAP_QUERY_FILTER_SENDERS} ]]; then
+      postconf -e "smtpd_sender_login_maps = ldap:/etc/postfix/ldap-users.cf ldap:/etc/postfix/ldap-aliases.cf ldap:/etc/postfix/ldap-groups.cf"
+    else
+      postconf -e "smtpd_sender_login_maps = ldap:/etc/postfix/ldap-senders.cf"
+    fi
   else
     if [[ -f /etc/postfix/regexp ]]
     then

--- a/test/test-files/auth/ldap-smtp-auth-spoofed-sender-with-filter-exception.txt
+++ b/test/test-files/auth/ldap-smtp-auth-spoofed-sender-with-filter-exception.txt
@@ -1,0 +1,15 @@
+EHLO mail
+AUTH LOGIN
+c29tZS51c2VyLmVtYWlsQGxvY2FsaG9zdC5sb2NhbGRvbWFpbgo=
+c2VjcmV0
+MAIL FROM: randomspoofedaddress@localhost.localdomain
+RCPT TO: some.user@localhost.localdomain
+DATA
+From: spoofed_address <randomspoofedaddress@localhost.localdomain>
+To: Existing Local User <some.user@localhost.localdomain>
+Date: Sat, 22 May 2010 07:43:25 -0400
+Subject: Test Message
+This is a test mail from ldap-smtp-auth-spoofed-sender-with-filter-exception.txt
+
+.
+QUIT


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->
This adds an environment variable `LDAP_QUERY_FILTER_SENDERS` that determines if a user is allowed to use a specific identity to send an email - for example, we're using something like `(|(mail=%s)(mail=noreply@example.com))`, to allow users to send an email if they either have the mail address they want to send as or if they have the mail address noreply@example.com. This applies only if SPOOF_PROTECTION=1.

~~Also, as suggested in #1340, this sets smtpd_sasl_local_domain to an empty string - it seems like without that it won't work, but I couldn't figure out the implications of that, so that might be worth discussing.~~ (that change has been reverted as the issue itself seems to have been fixed in the meantime)

If the environment variable is empty, the old sender `smtpd_sender_login_maps` behaviour will be used.

<!-- Please link the issue which will be fixed (if any) here: -->
Fixes #1340

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] ~~Bug fix (non-breaking change which fixes an issue)~~
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or ENVIRONMENT.md or the documentation)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
