### PR TITLE
Fail2Ban block behaviour

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -63,6 +63,12 @@ cap_add:
 
 Otherwise, `iptables` won't be able to ban IPs.
 
+##### FAIL2BAN_BLOCKTYPE
+
+- **drop**   => drop packet (send NO reply)
+- reject => reject packet (send ICMP unreachable)
+FAIL2BAN_BLOCKTYPE=drop
+
 ##### SMTP_ONLY
 
 - **empty** => all daemons start

--- a/config/fail2ban-jail.cf
+++ b/config/fail2ban-jail.cf
@@ -9,3 +9,8 @@
 
 # "maxretry" is the number of failures before a host get banned.
 #maxretry = 5
+
+# Default ban action
+# iptables-multiport:	block IP only on affected port
+# iptables-allports:	block IP on all ports
+#banaction = iptables-allports

--- a/mailserver.env
+++ b/mailserver.env
@@ -75,6 +75,11 @@ ENABLE_AMAVIS=1
 # Otherwise, `iptables` won't be able to ban IPs.
 ENABLE_FAIL2BAN=0
 
+# Fail2Ban blocktype
+# drop   => drop packet (send NO reply)
+# reject => reject packet (send ICMP unreachable)
+FAIL2BAN_BLOCKTYPE=drop
+
 # 1 => Enables Managesieve on port 4190
 # empty => disables Managesieve
 ENABLE_MANAGESIEVE=

--- a/target/fail2ban/jail.local
+++ b/target/fail2ban/jail.local
@@ -15,6 +15,11 @@ maxretry = 3
 # can be defined using space (and/or comma) separator.
 ignoreip = 127.0.0.1/8
 
+# Default ban action
+# iptables-multiport:	block IP only on affected port
+# iptables-allports:	block IP on all ports
+banaction = iptables-allports
+
 [dovecot]
 enabled = true
 

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -32,6 +32,7 @@ VARS[ENABLE_QUOTAS]="${ENABLE_QUOTAS:=1}"
 VARS[ENABLE_SASLAUTHD]="${ENABLE_SASLAUTHD:=0}"
 VARS[ENABLE_SPAMASSASSIN]="${ENABLE_SPAMASSASSIN:=0}"
 VARS[ENABLE_SRS]="${ENABLE_SRS:=0}"
+VARS[FAIL2BAN_BLOCKTYPE]="${FAIL2BAN_BLOCKTYPE:=drop}"
 VARS[FETCHMAIL_POLL]="${FETCHMAIL_POLL:=300}"
 VARS[FETCHMAIL_PARALLEL]="${FETCHMAIL_PARALLEL:=0}"
 VARS[LDAP_START_TLS]="${LDAP_START_TLS:=no}"
@@ -103,6 +104,7 @@ function register_functions
   [[ ${ENABLE_POSTGREY} -eq 1 ]] && _register_setup_function '_setup_postgrey'
   [[ ${ENABLE_SASLAUTHD} -eq 1 ]] && _register_setup_function '_setup_saslauthd'
   [[ ${POSTFIX_INET_PROTOCOLS} != 'all' ]] && _register_setup_function '_setup_inet_protocols'
+  [[ ${ENABLE_FAIL2BAN} -eq 1 ]] && _register_setup_function '_setup_fail2ban'
 
   _register_setup_function '_setup_dkim'
   _register_setup_function '_setup_ssl'

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -1613,3 +1613,12 @@ function _setup_environment
     echo "VIRUSMAILS_DELETE_DELAY=${VIRUSMAILS_DELETE_DELAY}" >>/etc/environment
   fi
 }
+
+function _setup_fail2ban
+{
+  _notify 'task' 'Setting up fail2ban'
+  if [[ ${FAIL2BAN_BLOCKTYPE} != "reject" ]]
+  then
+    echo -e "[Init]\nblocktype = DROP" > /etc/fail2ban/action.d/iptables-common.local
+  fi
+}

--- a/test/config/fail2ban-jail.cf
+++ b/test/config/fail2ban-jail.cf
@@ -9,3 +9,8 @@ findtime  = 321
 
 # "maxretry" is the number of failures before a host get banned.
 maxretry = 2
+
+# Default ban action
+# iptables-multiport:   block IP only on affected port
+# iptables-allports:    block IP on all ports
+banaction = iptables-multiport

--- a/test/mail_fail2ban.bats
+++ b/test/mail_fail2ban.bats
@@ -75,6 +75,15 @@ function teardown_file() {
 
     run docker exec mail_fail2ban /bin/sh -c "fail2ban-client get ${FILTER} maxretry"
     assert_output 2
+
+    run docker exec mail_fail2ban /bin/sh -c "fail2ban-client -d | grep -F \"['set', 'dovecot', 'addaction', 'iptables-multiport']\""
+    assert_output "['set', 'dovecot', 'addaction', 'iptables-multiport']"
+
+    run docker exec mail_fail2ban /bin/sh -c "fail2ban-client -d | grep -F \"['set', 'postfix', 'addaction', 'iptables-multiport']\""
+    assert_output "['set', 'postfix', 'addaction', 'iptables-multiport']"
+
+    run docker exec mail_fail2ban /bin/sh -c "fail2ban-client -d | grep -F \"['set', 'postfix-sasl', 'addaction', 'iptables-multiport']\""
+    assert_output "['set', 'postfix-sasl', 'addaction', 'iptables-multiport']"
   done
 }
 

--- a/test/mail_fail2ban.bats
+++ b/test/mail_fail2ban.bats
@@ -144,6 +144,7 @@ function teardown_file() {
   run ./setup.sh -c mail_fail2ban debug fail2ban
   assert_output --regexp "^Banned in dovecot: 192.0.66.5.*"
   run ./setup.sh -c mail_fail2ban debug fail2ban unban 192.0.66.5
+  assert_output --partial "Unbanned IP from dovecot: 192.0.66.5"
   run ./setup.sh -c mail_fail2ban debug fail2ban unban
   assert_output --partial "You need to specify an IP address. Run"
 }

--- a/test/mail_fail2ban.bats
+++ b/test/mail_fail2ban.bats
@@ -100,7 +100,7 @@ function teardown_file() {
   assert_success
 
   # Checking that FAIL_AUTH_MAILER_IP is banned by iptables
-  run docker exec mail_fail2ban /bin/sh -c "iptables -L f2b-postfix-sasl -n | grep REJECT | grep '${FAIL_AUTH_MAILER_IP}'"
+  run docker exec mail_fail2ban /bin/sh -c "iptables -L f2b-postfix-sasl -n | grep DROP | grep '${FAIL_AUTH_MAILER_IP}'"
   assert_success
 }
 

--- a/test/mail_fail2ban.bats
+++ b/test/mail_fail2ban.bats
@@ -108,14 +108,7 @@ function teardown_file() {
   run docker exec mail_fail2ban /bin/sh -c "fail2ban-client status postfix-sasl | grep '${FAIL_AUTH_MAILER_IP}'"
   assert_success
 
-  # Checking that FAIL_AUTH_MAILER_IP is banned by iptables
-  run docker exec mail_fail2ban /bin/sh -c "iptables -n -L f2b-postfix-sasl"
-  assert_output --regexp "DROP.+all.+${FAIL_AUTH_MAILER_IP}"
-}
-
-@test "checking fail2ban: blocktype set to drop" {
-  FAIL_AUTH_MAILER_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' fail-auth-mailer)
-
+  # Checking that FAIL_AUTH_MAILER_IP is banned by iptables and blocktype set to DROP
   run docker exec mail_fail2ban /bin/sh -c "iptables -n -L f2b-postfix-sasl"
   assert_output --regexp "DROP.+all.+${FAIL_AUTH_MAILER_IP}"
 }

--- a/test/mail_fail2ban.bats
+++ b/test/mail_fail2ban.bats
@@ -109,8 +109,15 @@ function teardown_file() {
   assert_success
 
   # Checking that FAIL_AUTH_MAILER_IP is banned by iptables
-  run docker exec mail_fail2ban /bin/sh -c "iptables -L f2b-postfix-sasl -n | grep DROP | grep '${FAIL_AUTH_MAILER_IP}'"
-  assert_success
+  run docker exec mail_fail2ban /bin/sh -c "iptables -n -L f2b-postfix-sasl"
+  assert_output --regexp "DROP.+all.+${FAIL_AUTH_MAILER_IP}"
+}
+
+@test "checking fail2ban: blocktype set to drop" {
+  FAIL_AUTH_MAILER_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' fail-auth-mailer)
+
+  run docker exec mail_fail2ban /bin/sh -c "iptables -n -L f2b-postfix-sasl"
+  assert_output --regexp "DROP.+all.+${FAIL_AUTH_MAILER_IP}"
 }
 
 @test "checking fail2ban: unban ip works" {


### PR DESCRIPTION
# Description

Further work from #1821.

- Introduce `FAIL2BAN_BLOCKTYPE`
      **drop**   => drop packet (send NO reply)
      reject => reject packet (send ICMP unreachable)

- Block IP for all ports now. The old behavior was to block the IP only for the affected port/service. This can be reverted via `config/fail2ban-jail.cf`

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or ENVIRONMENT.md or the documentation)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
