### PR TITLE
Adjusted documentation for service name and Traefik certificate issuance

### DIFF
--- a/docs/content/config/security/ssl.md
+++ b/docs/content/config/security/ssl.md
@@ -26,7 +26,7 @@ To enable Let's Encrypt on your mail server, you have to:
 
     ```yaml
     services:
-      mail:
+      mailserver:
         hostname: mail
         domainname: myserver.tld
         fqdn: mail.myserver.tld
@@ -193,7 +193,7 @@ The second part of the setup is the actual mail container. So, in another folder
     ```yaml
     version: '2'
     services:
-      mail:
+      mailserver:
         image: mailserver/docker-mailserver:latest
         hostname: ${HOSTNAME}
         domainname: ${DOMAINNAME}
@@ -379,14 +379,14 @@ Traefik's V2 storage format is natively supported if the `acme.json` store is mo
 2. `$HOSTNAME`
 3. `$DOMAINNAME`
 
-This allows for support of wild card certificates: `SSL_DOMAIN=*.example.com`. Here is an example setup for [`docker-compose`](https://docs.docker.com/compose/):
+This allows for support of wild card certificates: `SSL_DOMAIN=example.com`. Here is an example setup for [`docker-compose`](https://docs.docker.com/compose/):
 
 ???+ example "Example Code"
 
     ```yaml
     version: '3.8'
     services:
-      mail:
+      mailserver:
         image: mailserver/docker-mailserver:stable
         hostname: mail
         domainname: example.com
@@ -394,7 +394,7 @@ This allows for support of wild card certificates: `SSL_DOMAIN=*.example.com`. H
         - /etc/ssl/acme-v2.json:/etc/letsencrypt/acme.json:ro
         environment:
           SSL_TYPE: letsencrypt
-          # SSL_DOMAIN: "*.example.com" 
+          # SSL_DOMAIN: example.com" 
       traefik:
         image: traefik:v2.2
         restart: always

--- a/docs/content/config/security/ssl.md
+++ b/docs/content/config/security/ssl.md
@@ -199,19 +199,19 @@ The second part of the setup is the actual mail container. So, in another folder
         domainname: ${DOMAINNAME}
         container_name: ${CONTAINER_NAME}
         ports:
-        - "25:25"
-        - "143:143"
-        - "465:465"
-        - "587:587"
-        - "993:993"
+          - "25:25"
+          - "143:143"
+          - "465:465"
+          - "587:587"
+          - "993:993"
         volumes:
-        - ./mail:/var/mail
-        - ./mail-state:/var/mail-state
-        - ./config/:/tmp/docker-mailserver/
-        - /mnt/data/nginx/certs/:/etc/letsencrypt/live/:ro
+          - ./mail:/var/mail
+          - ./mail-state:/var/mail-state
+          - ./config/:/tmp/docker-mailserver/
+          - /mnt/data/nginx/certs/:/etc/letsencrypt/live/:ro
         cap_add:
-        - NET_ADMIN
-        - SYS_PTRACE
+          - NET_ADMIN
+          - SYS_PTRACE
         restart: always
 
       cert-companion:

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -793,12 +793,12 @@ function _setup_ssl
   # Primary certificate to serve for TLS
   function _set_certificate
   {
-    local POSTFIX_KEY_WITH_FULLCHAIN=$1
-    local DOVECOT_KEY=$1
-    local DOVECOT_CERT=$1
+    local POSTFIX_KEY_WITH_FULLCHAIN=${1}
+    local DOVECOT_KEY=${1}
+    local DOVECOT_CERT=${1}
 
     # If 2nd param is provided, we've been provided separate key and cert instead of a fullkeychain
-    if [[ -n $2 ]]
+    if [[ -n ${2} ]]
     then
       local PRIVATE_KEY=$1
       local CERT_CHAIN=$2
@@ -885,7 +885,7 @@ function _setup_ssl
       ;;
 
     * )
-      _notify 'err' 'TLS_LEVEL not found [ in _setup_ssl ]'
+      _notify 'err' "TLS_LEVEL not found [ in ${FUNCNAME[0]} ]"
       ;;
 
   esac


### PR DESCRIPTION
# Description

- changed container name from `mail` to `mailserver` to streamline docs
- some braces around variables in Bash scripts were added
- changed Traefik's certificate section
  - removed docs for Traefik v1 - we want everyone to use Traefik v2 from `9.2.0`
  - **the wildcard certificate issue** in #1915 was addressed
  - proper indentation was added




I have drafted a prerelease for `v9.2.0`. Have a look :)

### TODO

1. Make sure the adjustments to `SSL_DOMAIN` are correct (by solving #1915)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or ENVIRONMENT.md or the documentation)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
