### PR TITLE
Add supervisord stop grace period

### DIFF
--- a/target/supervisor/conf.d/supervisor-app.conf
+++ b/target/supervisor/conf.d/supervisor-app.conf
@@ -6,6 +6,7 @@
 
 [program:mailserver]
 startsecs=0
+stopwaitsecs=55
 autostart=true
 autorestart=false
 stdout_logfile=/dev/stdout
@@ -16,6 +17,7 @@ command=/usr/local/bin/start-mailserver.sh
 
 [program:cron]
 startsecs=0
+stopwaitsecs=55
 autostart=false
 autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
@@ -24,6 +26,7 @@ command=/usr/sbin/cron -f
 
 [program:rsyslog]
 startsecs=0
+stopwaitsecs=55
 autostart=false
 autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
@@ -32,6 +35,7 @@ command=/usr/sbin/rsyslogd -n
 
 [program:fail2ban]
 startsecs=0
+stopwaitsecs=55
 autostart=false
 autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
@@ -40,6 +44,7 @@ command=/usr/local/bin/fail2ban-wrapper.sh
 
 [program:opendkim]
 startsecs=0
+stopwaitsecs=55
 autostart=false
 autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
@@ -48,6 +53,7 @@ command=/usr/sbin/opendkim -f
 
 [program:opendmarc]
 startsecs=0
+stopwaitsecs=55
 autostart=false
 autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
@@ -56,6 +62,7 @@ command=/usr/sbin/opendmarc -f -p "inet:8893@localhost" -P /var/run/opendmarc/op
 
 [program:dovecot]
 startsecs=0
+stopwaitsecs=55
 autostart=false
 autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
@@ -64,6 +71,7 @@ command=/usr/sbin/dovecot -F -c /etc/dovecot/dovecot.conf
 
 [program:clamav]
 startsecs=0
+stopwaitsecs=55
 autostart=false
 autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
@@ -72,6 +80,7 @@ command=/usr/sbin/clamd -c /etc/clamav/clamd.conf
 
 [program:postgrey]
 startsecs=0
+stopwaitsecs=55
 autostart=false
 autorestart=true
 stdout_logfile=/var/log/mail/mail.log
@@ -80,6 +89,7 @@ command=/usr/sbin/postgrey --inet=127.0.0.1:10023 --syslog-facility=mail --delay
 
 [program:amavis]
 startsecs=0
+stopwaitsecs=55
 autostart=false
 autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
@@ -88,6 +98,7 @@ command=/usr/sbin/amavisd-new foreground
 
 [program:fetchmail]
 startsecs=0
+stopwaitsecs=55
 autostart=false
 autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
@@ -97,6 +108,7 @@ command=/usr/bin/fetchmail -f /etc/fetchmailrc -v --nodetach --daemon %(ENV_FETC
 
 [program:postfix]
 startsecs=0
+stopwaitsecs=55
 autostart=false
 autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
@@ -105,6 +117,7 @@ command=/usr/local/bin/postfix-wrapper.sh
 
 [program:changedetector]
 startsecs=0
+stopwaitsecs=55
 autostart=false
 autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
@@ -113,6 +126,7 @@ command=/usr/local/bin/check-for-changes.sh
 
 [program:postsrsd]
 startsecs=0
+stopwaitsecs=55
 autostart=false
 autorestart=unexpected
 stdout_logfile=/var/log/supervisor/%(program_name)s.log


### PR DESCRIPTION
# Description

Follow up for #1896. Increasing docker-compose stop grace period to 1 minute was pretty pointless, because supervisord also sends a SIGKILL after 10 seconds. This adds a stop grace period to supervisord also.

<!-- Please link the issue which will be fixed (if any) here: -->
Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or ENVIRONMENT.md or the documentation)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
