### PR TITLE
introduce variable to control Amavis' loglevel

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -34,6 +34,15 @@ Amavis content filter (used for ClamAV & SpamAssassin)
 - 0 => Amavis is disabled
 - **1** => Amavis is enabled
 
+##### AMAVIS_LOGLEVEL
+
+[This page](https://lists.amavis.org/pipermail/amavis-users/2011-March/000158.html) provides information on Amavis' logging statistics.
+
+- -1 => log errors
+- **0** => log warnings
+- 1 => log info
+- 3 => log debug
+
 ##### ENABLE_CLAMAV
 
 - **0** => Clamav is disabled

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -2,9 +2,8 @@
 
 ## Variables
 
-1. If an option doesn't work as documented here, check if you are running the latest image!
-2. Values in **bold** are the default values.
-3. Since `docker-mailserver v7.1.0`, comparisons for environment variables are executed differently. If you previously used `VARIABLE=''` as the `empty` value, **update** to now use `VARIABLE=`.
+1. Values in **bold** are the default values.
+2. If an option doesn't work as documented here, check if you are running the latest image. The current `master` branch corresponds to the image `mailserver/docker-mailserver:edge`.
 
 ### Assignments
 
@@ -13,17 +12,17 @@
 ##### DMS_DEBUG
 
 - **0** => Debug disabled
-- 1 => Enables debug on startup
+- 1     => Enables debug on startup
 
 ##### SUPERVISOR_LOGLEVEL
 
 Here you can adjust the [log-level for Supervisor](http://supervisord.org/logging.html#activity-log-levels). Possible values are
 
 - critical => Only show critical messages
-- error => Only show erroneous output
+- error    => Only show erroneous output
 - **warn** => Show warnings
-- info => Normal informational output
-- debug => Also show debug messages
+- info     => Normal informational output
+- debug    => Also show debug messages
 
 The log-level will show everything in its class and above.
 
@@ -31,17 +30,17 @@ The log-level will show everything in its class and above.
 
 Amavis content filter (used for ClamAV & SpamAssassin)
 
-- 0 => Amavis is disabled
+- 0     => Amavis is disabled
 - **1** => Amavis is enabled
 
 ##### AMAVIS_LOGLEVEL
 
 [This page](https://lists.amavis.org/pipermail/amavis-users/2011-March/000158.html) provides information on Amavis' logging statistics.
 
-- -1 => log errors
-- **0** => log warnings
-- 1 => log info
-- 3 => log debug
+- -1/-2/-3 => Only show errors
+- **0**    => Show warnings
+- 1/2      => Show default informational output
+- 3/4/5    => log debug information (very verbose)
 
 ##### ENABLE_CLAMAV
 

--- a/docs/content/config/advanced/override-defaults/user-patches.md
+++ b/docs/content/config/advanced/override-defaults/user-patches.md
@@ -22,8 +22,6 @@ The contents could look like this
 ``` sh
 #! /bin/bash
 
-sed -i -E 's|(log_level).*|\1 = -1;|g' /etc/amavis/conf.d/49-docker-mailserver
-
 cat >/etc/amavis/conf.d/50-user << "END"
 use strict;
 

--- a/mailserver.env
+++ b/mailserver.env
@@ -69,6 +69,12 @@ ENABLE_CLAMAV=0
 # 1 => Enabled
 ENABLE_AMAVIS=1
 
+# -1/-2/-3 => Only show errors
+# **0**    => Show warnings
+# 1/2      => Show default informational output
+# 3/4/5    => log debug information (very verbose)
+AMAVIS_LOGLEVEL=0
+
 # If you enable Fail2Ban, don't forget to add the following lines to your `docker-compose.yml`:
 #    cap_add:
 #      - NET_ADMIN

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -16,6 +16,7 @@ declare -a FUNCS_SETUP FUNCS_FIX FUNCS_CHECK FUNCS_MISC DAEMONS_START
 # ? >> Setup of default and global values / variables
 # ––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
 
+VARS[AMAVIS_LOGLEVEL]="${AMAVIS_LOGLEVEL:=0}"
 VARS[DEFAULT_RELAY_HOST]="${DEFAULT_RELAY_HOST:=}"
 VARS[DMS_DEBUG]="${DMS_DEBUG:=0}"
 VARS[DOVECOT_MAILBOX_FORMAT]="${DOVECOT_MAILBOX_FORMAT:=maildir}"

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -1501,6 +1501,10 @@ function _setup_security_stack
     then
       cp /tmp/docker-mailserver/amavis.cf /etc/amavis/conf.d/50-user
     fi
+
+    sed -i -E \
+      "s|(log_level).*|\1 = ${AMAVIS_LOGLEVEL};|g" \
+      /etc/amavis/conf.d/49-docker-mailserver
   fi
 }
 

--- a/test/mail_disabled_clamav_spamassassin.bats
+++ b/test/mail_disabled_clamav_spamassassin.bats
@@ -12,12 +12,13 @@ setup_file() {
     local PRIVATE_CONFIG
     PRIVATE_CONFIG="$(duplicate_config_for_container .)"
     docker run --rm -d --name mail_disabled_clamav_spamassassin \
-		-v "${PRIVATE_CONFIG}":/tmp/docker-mailserver \
-		-v "$(pwd)/test/test-files":/tmp/docker-mailserver-test:ro \
-		-e ENABLE_CLAMAV=0 \
-		-e ENABLE_SPAMASSASSIN=0 \
-		-e DMS_DEBUG=0 \
-		-h mail.my-domain.com -t "${NAME}"
+		  -v "${PRIVATE_CONFIG}":/tmp/docker-mailserver \
+		  -v "$(pwd)/test/test-files":/tmp/docker-mailserver-test:ro \
+		  -e ENABLE_CLAMAV=0 \
+		  -e ENABLE_SPAMASSASSIN=0 \
+		  -e DMS_DEBUG=0 \
+		  -e AMAVIS_LOGLEVEL=2 \
+		  -h mail.my-domain.com -t "${NAME}"
     # TODO: find a better way to know when we have waited long enough
     #       for clamav to should have come up, if it were enabled
     wait_for_smtp_port_in_container mail_disabled_clamav_spamassassin

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -25,6 +25,7 @@ setup_file() {
 		-e SA_TAG=-5.0 \
 		-e SA_TAG2=2.0 \
 		-e SA_KILL=3.0 \
+		-e AMAVIS_LOGLEVEL=2 \
 		-e SA_SPAM_SUBJECT="SPAM: " \
 		-e VIRUSMAILS_DELETE_DELAY=7 \
 		-e ENABLE_SRS=1 \


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->
Introduced `AMAVIS_LOGLEVEL` variable to control the log level. This way, one can control the verbositoy of Amavis. This can be of special importance when users post logs (for the first time) as they always post the (huge) Amavis log too. See #1944.

This is a "breaking" change, as the default of `0` (= warning) is new. We can merge this before releasing `10.0.0`. I can test this feature in my setup for a week if necessary,

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or ENVIRONMENT.md or the documentation)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
