### PR TITLE
Add Kmail as sieve client

### DIFF
--- a/docs/content/config/advanced/mail-sieve.md
+++ b/docs/content/config/advanced/mail-sieve.md
@@ -82,5 +82,5 @@ All user defined sieve scripts that are managed by ManageSieve are stored in the
 
 The extension is known to work with the following ManageSieve clients:
 
-- **Sieve Editor**  a portable standalone application based on the former Thunderbird plugin (https://github.com/thsmi/sieve).
+- **[Sieve Editor](https://github.com/thsmi/sieve)**  a portable standalone application based on the former Thunderbird plugin.
 - **[Kmail](https://kontact.kde.org/components/kmail.html)**  the mail client of [KDE](https://kde.org/)'s Kontact Suite.

--- a/docs/content/config/advanced/mail-sieve.md
+++ b/docs/content/config/advanced/mail-sieve.md
@@ -83,3 +83,4 @@ All user defined sieve scripts that are managed by ManageSieve are stored in the
 The extension is known to work with the following ManageSieve clients:
 
 - **Sieve Editor**  a portable standalone application based on the former Thunderbird plugin (https://github.com/thsmi/sieve).
+- **Kmail**  the mail client of [KDE](https://kde.org/)'s Kontact Suit (https://kontact.kde.org/components/kmail.html).

--- a/docs/content/config/advanced/mail-sieve.md
+++ b/docs/content/config/advanced/mail-sieve.md
@@ -83,4 +83,4 @@ All user defined sieve scripts that are managed by ManageSieve are stored in the
 The extension is known to work with the following ManageSieve clients:
 
 - **Sieve Editor**  a portable standalone application based on the former Thunderbird plugin (https://github.com/thsmi/sieve).
-- **Kmail**  the mail client of [KDE](https://kde.org/)'s Kontact Suit (https://kontact.kde.org/components/kmail.html).
+- **[Kmail](https://kontact.kde.org/components/kmail.html)**  the mail client of [KDE](https://kde.org/)'s Kontact Suite.


### PR DESCRIPTION
# Description

The sieve client of [Kmail](https://kontact.kde.org/components/kmail.html) works great with docker-mailserver, I propose to add it as sieve client to the documentation.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)
- [x] This change requires a documentation update

## Checklist:

No code, just a documentation update.
