### PR TITLE
chore(docs): Update Kubernetes CRI-O Capability Description

### DIFF
--- a/docs/content/config/advanced/kubernetes.md
+++ b/docs/content/config/advanced/kubernetes.md
@@ -269,9 +269,7 @@ There is nothing much in deploying mailserver to Kubernetes itself. The things a
     Make sure that [Pod][k8s-workload-pod] is [assigned][k8s-assign-pod-node] to specific [Node][k8s-nodes] in case you're using volume for data directly with `hostPath`. Otherwise Pod can be rescheduled on a different Node and previous data won't be found. Except the case when you're using some shared filesystem on your Nodes.
     
 !!! note
-    If you experience issues with the processes crashing with an error of `operation not permitted`, such as the following:
-    `postfix/pickup[987]: fatal: chroot(/var/spool/postfix): Operation not permitted`
-    Then you should add the `SYS_CHROOT` capability. This is true (at least) for the cri-o container runtime.
+    If you experience issues with processes crashing showing an error like `operation not permitted` or `postfix/pickup[987]: fatal: chroot(/var/spool/postfix): Operation not permitted`, then you should add the `SYS_CHROOT` capability. Runtimes like CRI-O do not ship with this capability by default.
    
 
 ## Exposing to the Outside World

--- a/docs/content/config/advanced/kubernetes.md
+++ b/docs/content/config/advanced/kubernetes.md
@@ -173,6 +173,11 @@ There is nothing much in deploying mailserver to Kubernetes itself. The things a
           - name: docker-mailserver
             image: mailserver/docker-mailserver:latest
             imagePullPolicy: Always
+            securityContext:
+              capabilities:
+                # If fail2ban is not enabled, you can remove NET_ADMIN
+                # If you are running on cri-o, you will need SYS_CHROOT, as it is no longer a default capability.
+                add: ["NET_ADMIN", "SYS_PTRACE", "SYS_CHROOT" ]
             volumeMounts:
               - name: config
                 subPath: postfix-accounts.cf
@@ -262,6 +267,12 @@ There is nothing much in deploying mailserver to Kubernetes itself. The things a
 
 !!! note
     Make sure that [Pod][k8s-workload-pod] is [assigned][k8s-assign-pod-node] to specific [Node][k8s-nodes] in case you're using volume for data directly with `hostPath`. Otherwise Pod can be rescheduled on a different Node and previous data won't be found. Except the case when you're using some shared filesystem on your Nodes.
+    
+!!! note
+    If you experience issues with the processes crashing with an error of `operation not permitted`, such as the following:
+    `postfix/pickup[987]: fatal: chroot(/var/spool/postfix): Operation not permitted`
+    Then you should add the `SYS_CHROOT` capability. This is true (at least) for the cri-o container runtime.
+   
 
 ## Exposing to the Outside World
 

--- a/docs/content/config/advanced/kubernetes.md
+++ b/docs/content/config/advanced/kubernetes.md
@@ -175,8 +175,9 @@ There is nothing much in deploying mailserver to Kubernetes itself. The things a
             imagePullPolicy: Always
             securityContext:
               capabilities:
-                # If fail2ban is not enabled, you can remove NET_ADMIN
-                # If you are running on cri-o, you will need SYS_CHROOT, as it is no longer a default capability.
+                # If Fail2Ban is not enabled, you can remove NET_ADMIN.
+                # If you are running on CRI-O, you will need the SYS_CHROOT capability,
+                # as it is no longer a default capability.
                 add: ["NET_ADMIN", "SYS_PTRACE", "SYS_CHROOT" ]
             volumeMounts:
               - name: config


### PR DESCRIPTION




# Description
Heya!

I'm really sorry if the formatting is messed up for this. I spent about an hour trying to diagnose why a deployment into my Kubernetes cluster wasn't working. Had a bunch of 'operation not permitted' errors when attempting to start services.

Turns out CRI-O does not allow for chrooting inside a container anymore. It was changed in cri-o/cri-o@63b9f4ec986da267a18f73d4b1ef13282d103e00

I figured I'd update the documentation for anyone that might be having the same issue!

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [] If necessary I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
