### PR TITLE
Create Archives folder and subscribe by default

### DIFF
--- a/target/dovecot/15-mailboxes.conf
+++ b/target/dovecot/15-mailboxes.conf
@@ -28,7 +28,7 @@ namespace inbox {
     auto = subscribe
     special_use = \Trash
   }
-  mailbox Archives {
+  mailbox Archive {
     auto = subscribe
     special_use = \Archive
   }

--- a/target/dovecot/15-mailboxes.conf
+++ b/target/dovecot/15-mailboxes.conf
@@ -28,6 +28,10 @@ namespace inbox {
     auto = subscribe
     special_use = \Trash
   }
+  mailbox Archives {
+    auto = subscribe
+    special_use = \Archive
+  }
 
   # For \Sent mailboxes there are two widely used names. We'll mark both of
   # them as \Sent. User typically deletes one of them if duplicates are created.


### PR DESCRIPTION
# Description
Clients should be able to share this "Archives" folder by default.
Usually email clients want to have an "Archives" folder.
By creating one following RFC-6154, all clients should be able to use it.

Tested on Linux Thunderbird, Outlook for Android and Spark for Android.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #2026

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
