### PR TITLE
Use bind mounts in sample config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,9 @@ services:
       - "587:587"  # ESMTP (explicit TLS => STARTTLS)
       - "993:993"  # IMAP4 (implicit TLS)
     volumes:
-      - maildata:/var/mail
-      - mailstate:/var/mail-state
-      - maillogs:/var/log/mail
+      - ./data/maildata:/var/mail
+      - ./data/mailstate:/var/mail-state
+      - ./data/maillogs:/var/log/mail
       - /etc/localtime:/etc/localtime:ro
       - ./config/:/tmp/docker-mailserver/
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,4 @@ services:
     restart: always
     stop_grace_period: 1m
     cap_add: [ "NET_ADMIN", "SYS_PTRACE" ]
-
-volumes:
-  maildata:
-  mailstate:
-  maillogs:
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,4 +25,3 @@ services:
     restart: always
     stop_grace_period: 1m
     cap_add: [ "NET_ADMIN", "SYS_PTRACE" ]
-    

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -54,16 +54,22 @@ Please do not use `CRLF`.
 
 ### What about backups?
 
+#### Bind mounts (default)
+
+```bash
+tar czf backup-$(date +%F).tar.gz config data
+```
+
+#### Volumes
+
 Assuming that you use `docker-compose` and data volumes, you can backup the configuration, emails and logs like this:
 
 ```sh
 # create backup
-docker run --rm -ti \
-  -v maildata:/var/mail \
-  -v mailstate:/var/mail-state \
-  -v maillogs:/var/logs/mail \
+docker run --rm -it \
   -v "$PWD/config":/tmp/docker-mailserver \
   -v /backup/mail:/backup \
+  --volumes-from mailserver \
   alpine:latest \
   tar czf "/backup/mail-$(date +%F).tar.gz" /var/mail /var/mail-state /var/logs/mail /tmp/docker-mailserver
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -65,7 +65,7 @@ tar --gzip -cf "backup-$(date +%F).tar.gz" config data
 Then to restore `./config` and `./data` folders from your backup file:
 
 ```bash
-tar -xf backup-date.tar.gz
+tar --gzip -xf backup-date.tar.gz
 ```
 
 #### Volumes

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -56,8 +56,16 @@ Please do not use `CRLF`.
 
 #### Bind mounts (default)
 
+From the location of your `docker-compose.yml`, create a compressed archive of your `./config` and `./data` folders:
+
 ```bash
-tar czf backup-$(date +%F).tar.gz config data
+tar --gzip -cf "backup-$(date +%F).tar.gz" config data
+```
+
+Then to restore `./config` and `./data` folders from your backup file:
+
+```bash
+tar -xf backup-date.tar.gz
 ```
 
 #### Volumes


### PR DESCRIPTION
# Description

If we switch to bind mounts in the sample config, that will simplify backup/restore of DMS.

See also: #1906

This would also make the not 100% correct working script at https://docker-mailserver.github.io/docker-mailserver/edge/faq/#what-about-backups obsolete.

Backup/restore would then just be simple host commands `cp / mv`..

What do you think?

<!-- Link the issue which will be fixed (if any) here: -->


## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
