### PR TITLE
reworked mail_crypt guide to make things way more simple and prepare …

### DIFF
--- a/docs/content/config/security/mail_crypt.md
+++ b/docs/content/config/security/mail_crypt.md
@@ -59,7 +59,7 @@ Official Dovecot documentation: https://doc.dovecot.org/configuration_manual/mai
 
 6. Start the container, monitor the logs for any errors, send yourself a message, and then confirm the file on disk is encrypted:
     ```
-    [root@ip-XXXXXXXXXX ~]# cat /mnt/efs-us-west-2/maildata/awesomesite.com/me/cur/1623989305.M6v�z�@�� m}��,��9����B*�247.us-west-2.compute.inE��\Ck*�@7795,W=7947:2,
+    [root@ip-XXXXXXXXXX ~]# cat -A /mnt/efs-us-west-2/maildata/awesomesite.com/me/cur/1623989305.M6v�z�@�� m}��,��9����B*�247.us-west-2.compute.inE��\Ck*�@7795,W=7947:2,
     T�9�8t�6�� t���e�W��S   `�H��C�ڤ �yeY��XZ��^�d�/��+�A
     ```
 

--- a/docs/content/config/security/mail_crypt.md
+++ b/docs/content/config/security/mail_crypt.md
@@ -45,7 +45,7 @@ Official Dovecot documentation: https://doc.dovecot.org/configuration_manual/mai
         . . .
     ```
 
-5. While you're editing the docker-compose.yml, add the configuration file:
+5. While you're editing the `docker-compose.yml`, add the configuration file:
     ```yaml
     services:
       mailserver:

--- a/docs/content/config/security/mail_crypt.md
+++ b/docs/content/config/security/mail_crypt.md
@@ -10,22 +10,31 @@ title: 'Security | mail_crypt (email/storage encryption)'
 
     There can be a single encryption key for the whole system or each user can have a key of their own. The used cryptographical methods are widely used standards and keys are stored in portable formats, when possible.
 
+
+
 Official Dovecot documentation: https://doc.dovecot.org/configuration_manual/mail_crypt_plugin/
 
 ---
 
-## Basic Setup
+## Single Encryption Key / Global Method
 
-1. Before you can enable mail_crypt, you'll need to copy out several dovecot/conf.d files to the host (from a running container) and then take the container down:
-    ```bash
-    mkdir -p config/dovecot
-    docker cp mailserver:/etc/dovecot/conf.d/20-lmtp.conf config/dovecot/
-    docker cp mailserver:/etc/dovecot/conf.d/20-imap.conf config/dovecot/
-    docker cp mailserver:/etc/dovecot/conf.d/20-pop3.conf config/dovecot/
-    docker-compose down
+1. Create `10-custom.conf` and populate it with in the following:
+
     ```
-2. You then need to [generate your global EC key](https://doc.dovecot.org/configuration_manual/mail_crypt_plugin/#ec-key).
-3. The EC key needs to be available in the container. I prefer to mount a /certs directory into the container: 
+    # Enables mail_crypt for all services (imap, pop3, etc)
+    mail_plugins = $mail_plugins mail_crypt
+    plugin {
+      mail_crypt_global_private_key = </certs/ecprivkey.pem
+      mail_crypt_global_public_key = </certs/ecpubkey.pem
+      mail_crypt_save_version = 2
+    }
+    ```
+
+2. Shut down your mailserver (`docker-compose down`/etc)
+
+3. You then need to [generate your global EC key](https://doc.dovecot.org/configuration_manual/mail_crypt_plugin/#ec-key). We named them `/certs/ecprivkey.pem` and `/certs/ecpubkey.pem` in Step #1.
+
+4. The EC key needs to be available in the container. I prefer to mount a /certs directory into the container: 
     ```yaml
     services:
       mailserver:
@@ -35,43 +44,24 @@ Official Dovecot documentation: https://doc.dovecot.org/configuration_manual/mai
           - ./certs/:/certs
         . . .
     ```
-4. While you're editing the docker-compose.yml, add the configuration files you copied out:
+
+5. While you're editing the docker-compose.yml, add the configuration file:
     ```yaml
     services:
       mailserver:
         image: docker.io/mailserver/docker-mailserver:latest
         volumes:
         . . .
-          - ./config/dovecot/20-lmtp.conf:/etc/dovecot/conf.d/20-lmtp.conf
-          - ./config/dovecot/20-imap.conf:/etc/dovecot/conf.d/20-imap.conf
-          - ./config/dovecot/20-pop3.conf:/etc/dovecot/conf.d/20-pop3.conf
+          - ./config/dovecot/10-custom.conf:/etc/dovecot/conf.d/10-custom.conf
           - ./certs/:/certs
         . . .
     ```
-5. The `mail_crypt` plugin, unless you're using a non-standard configuration of docker-mailserver, should be enabled on both `lmtp` and `imap`. You'll want to edit three different files:
-    - `./config/dovecot/20-lmtp.conf`
-      ```
-      protocol lmtp {
-        mail_plugins = $mail_plugins sieve mail_crypt
-        plugin {
-          mail_crypt_global_private_key = </certs/ecprivkey.pem
-          mail_crypt_global_public_key = </certs/ecpubkey.pem
-          mail_crypt_save_version = 2
-        }
-      }
-      ```
-    - `./config/dovecot/20-imap.conf`
-      ```
-      protocol imap {
-        mail_plugins = $mail_plugins imap_quota mail_crypt
-        plugin {
-          mail_crypt_global_private_key = </certs/ecprivkey.pem
-          mail_crypt_global_public_key = </certs/ecpubkey.pem
-          mail_crypt_save_version = 2
-        }
-      }
-      ```
-    - If you use pop3, make the same changes in `20-pop3.conf`
-6. Start the container and monitor the logs for any errors
+
+6. Start the container, monitor the logs for any errors, send yourself a message, and then confirm the file on disk is encrypted:
+    ```
+    [root@ip-XXXXXXXXXX ~]# cat /mnt/efs-us-west-2/maildata/awesomesite.com/me/cur/1623989305.M6v�z�@�� m}��,��9����B*�247.us-west-2.compute.inE��\Ck*�@7795,W=7947:2,
+    T�9�8t�6�� t���e�W��S   `�H��C�ڤ �yeY��XZ��^�d�/��+�A
+    ```
 
 This should be the minimum required for encryption of the mail while in storage.
+

--- a/docs/content/config/security/mail_crypt.md
+++ b/docs/content/config/security/mail_crypt.md
@@ -30,7 +30,7 @@ Official Dovecot documentation: https://doc.dovecot.org/configuration_manual/mai
     }
     ```
 
-2. Shut down your mailserver (`docker-compose down`/etc)
+2. Shutdown your mailserver (`docker-compose down`)
 
 3. You then need to [generate your global EC key](https://doc.dovecot.org/configuration_manual/mail_crypt_plugin/#ec-key). We named them `/certs/ecprivkey.pem` and `/certs/ecpubkey.pem` in Step #1.
 

--- a/docs/content/config/security/mail_crypt.md
+++ b/docs/content/config/security/mail_crypt.md
@@ -18,7 +18,7 @@ Official Dovecot documentation: https://doc.dovecot.org/configuration_manual/mai
 
 ## Single Encryption Key / Global Method
 
-1. Create `10-custom.conf` and populate it with in the following:
+1. Create `10-custom.conf` and populate it with the following:
 
     ```
     # Enables mail_crypt for all services (imap, pop3, etc)
@@ -64,4 +64,3 @@ Official Dovecot documentation: https://doc.dovecot.org/configuration_manual/mai
     ```
 
 This should be the minimum required for encryption of the mail while in storage.
-

--- a/docs/content/config/security/mail_crypt.md
+++ b/docs/content/config/security/mail_crypt.md
@@ -32,7 +32,7 @@ Official Dovecot documentation: https://doc.dovecot.org/configuration_manual/mai
 
 2. Shutdown your mailserver (`docker-compose down`)
 
-3. You then need to [generate your global EC key](https://doc.dovecot.org/configuration_manual/mail_crypt_plugin/#ec-key). We named them `/certs/ecprivkey.pem` and `/certs/ecpubkey.pem` in Step #1.
+3. You then need to [generate your global EC key](https://doc.dovecot.org/configuration_manual/mail_crypt_plugin/#ec-key). We named them `/certs/ecprivkey.pem` and `/certs/ecpubkey.pem` in step #1.
 
 4. The EC key needs to be available in the container. I prefer to mount a /certs directory into the container: 
     ```yaml


### PR DESCRIPTION
…for user folder encryption

# Description

Preparing for per folder/user encryption guide per https://github.com/docker-mailserver/docker-mailserver/issues/1904 discussion by cleaning up and simplifying the mail_crypt guide. Also, not enabling mail_crypt globally doesn't allow `doveadm mailbox cryptokey` to work: http://dovecot.2317879.n4.nabble.com/doveadm-mailbox-cryptokey-not-found-td58533.html

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
