### PR TITLE
Fix deletion of supervisord.pid

### DIFF
--- a/target/scripts/startup/fixes-stack.sh
+++ b/target/scripts/startup/fixes-stack.sh
@@ -9,7 +9,7 @@ function fix
   done
 
   _notify 'inf' 'Removing leftover PID files from a stop/start'
-  rm -rf /var/run/*.pid /var/run/*/*.pid
+  find /var/run/ -not -name 'supervisord.pid' -name '*.pid' -delete
   touch /dev/shm/supervisor.sock
 }
 


### PR DESCRIPTION
# Description

On container start, `/var/run/supervisord.pid` is deleted by https://github.com/docker-mailserver/docker-mailserver/blob/80a0425adeee01f873b506bd9aa63eee2394ad95/target/scripts/startup/fixes-stack.sh#L12

This shouldn't be the case.

<!-- Link the issue which will be fixed (if any) here: -->

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
