### PR TITLE
Bats 1.4.X fix: BATS_TMPDIR

### DIFF
--- a/test/security_tls_cipherlists.bats
+++ b/test/security_tls_cipherlists.bats
@@ -20,7 +20,7 @@ function setup_file() {
     export TLS_CONFIG_VOLUME
     TLS_CONFIG_VOLUME="$(pwd)/test/test-files/ssl/${DOMAIN}/:/config/ssl/:ro"
     # `${TMPDIR}` maps to `/tmp`
-    export TLS_RESULTS_DIR="${TMPDIR}/results"
+    export TLS_RESULTS_DIR="/tmp/results"
 
     # NOTE: If the network already exists, test will fail to start.
     docker network create "${NETWORK}"

--- a/test/security_tls_cipherlists.bats
+++ b/test/security_tls_cipherlists.bats
@@ -20,7 +20,7 @@ function setup_file() {
     export TLS_CONFIG_VOLUME
     TLS_CONFIG_VOLUME="$(pwd)/test/test-files/ssl/${DOMAIN}/:/config/ssl/:ro"
     # `${TMPDIR}` maps to `/tmp`
-    export TLS_RESULTS_DIR="${RUNNER_TEMP}/results"
+    export TLS_RESULTS_DIR="${PWD}/results"
 
     # NOTE: If the network already exists, test will fail to start.
     docker network create "${NETWORK}"

--- a/test/security_tls_cipherlists.bats
+++ b/test/security_tls_cipherlists.bats
@@ -150,6 +150,7 @@ function collect_cipherlist_data() {
         --volume "${TLS_CONFIG_VOLUME}" \
         --volume "${TLS_RESULTS_DIR}/${RESULTS_PATH}/:/output" \
         --workdir "/output" \
+        --security-opt seccomp=unconfined \
         drwetter/testssl.sh:3.1dev "${TESTSSL_CMD[@]}"
     assert_success
 }

--- a/test/security_tls_cipherlists.bats
+++ b/test/security_tls_cipherlists.bats
@@ -20,7 +20,7 @@ function setup_file() {
     export TLS_CONFIG_VOLUME
     TLS_CONFIG_VOLUME="$(pwd)/test/test-files/ssl/${DOMAIN}/:/config/ssl/:ro"
     # `${TMPDIR}` maps to `/tmp`
-    export TLS_RESULTS_DIR="/tmp/results"
+    export TLS_RESULTS_DIR="${RUNNER_TEMP}/results"
 
     # NOTE: If the network already exists, test will fail to start.
     docker network create "${NETWORK}"

--- a/test/security_tls_cipherlists.bats
+++ b/test/security_tls_cipherlists.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 load 'test_helper/common'
-# Globals ${BATS_TMPDIR} and ${NAME}
+# Globals ${BATS_RUN_TMPDIR} and ${NAME}
 # `${NAME}` defaults to `mailserver-testing:ci`
 
 function setup() {
@@ -19,8 +19,8 @@ function setup_file() {
     # Shared config for TLS testing (read-only)
     export TLS_CONFIG_VOLUME
     TLS_CONFIG_VOLUME="$(pwd)/test/test-files/ssl/${DOMAIN}/:/config/ssl/:ro"
-    # `${BATS_TMPDIR}` maps to `/tmp`
-    export TLS_RESULTS_DIR="${BATS_TMPDIR}/results"
+    # `${BATS_RUN_TMPDIR}` maps to `/tmp`
+    export TLS_RESULTS_DIR="${BATS_RUN_TMPDIR}/results"
 
     # NOTE: If the network already exists, test will fail to start.
     docker network create "${NETWORK}"

--- a/test/security_tls_cipherlists.bats
+++ b/test/security_tls_cipherlists.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 load 'test_helper/common'
-# Globals ${BATS_RUN_TMPDIR} and ${NAME}
+# Globals ${TMPDIR} and ${NAME}
 # `${NAME}` defaults to `mailserver-testing:ci`
 
 function setup() {
@@ -19,8 +19,8 @@ function setup_file() {
     # Shared config for TLS testing (read-only)
     export TLS_CONFIG_VOLUME
     TLS_CONFIG_VOLUME="$(pwd)/test/test-files/ssl/${DOMAIN}/:/config/ssl/:ro"
-    # `${BATS_RUN_TMPDIR}` maps to `/tmp`
-    export TLS_RESULTS_DIR="${BATS_RUN_TMPDIR}/results"
+    # `${TMPDIR}` maps to `/tmp`
+    export TLS_RESULTS_DIR="${TMPDIR}/results"
 
     # NOTE: If the network already exists, test will fail to start.
     docker network create "${NETWORK}"


### PR DESCRIPTION
# Description

While working on https://github.com/docker-mailserver/docker-mailserver/pull/2104, some of the TLS tests were locking my docker up or failing. 

(The failure below is using the verbose flags that are a pending PR in bats-core)
```
✗ begin 186 checking tls: cipher list - rsa intermediate
   (from function `assert_success' in file test/test_helper/bats-assert/src/assert.bash, line 114,
    from function `collect_cipherlist_data' in file test/security_tls_cipherlists.bats, line 154,
    from function `check_ports' in file test/security_tls_cipherlists.bats, line 86,
    in test file test/security_tls_cipherlists.bats, line 47)
     `check_ports 'rsa' 'intermediate'' failed
   $ docker run -d --name tls_test_cipherlists --volume /Users/norsegaud/docker-mailserver/test/duplicate_configs/security_tls_cipherlists.bats/:/tmp/docker-mailserver/ --volume /Users/norsegaud/docker-mailserver/test/test-files/ssl/example.test/:/config/ssl/:ro --env DMS_DEBUG=0 --env ENABLE_POP3=1 --env SSL_TYPE=manual --env SSL_CERT_PATH=/config/ssl/cert.rsa.pem --env SSL_KEY_PATH=/config/ssl/key.rsa.pem --env TLS_LEVEL=intermediate --network test-network --network-alias example.test --hostname mail.example.test --tty mailserver-testing:ci
     f7d78f74fc3eedaa1277f63d9b7a2d06f22fbae7705f75b842b56bed71fce40b
   [ TASKLOG ]  mail.example.test is up and running
   $ docker run --rm --user 501:20 --network test-network --volume /Users/norsegaud/docker-mailserver/test/test-files/ssl/example.test/:/config/ssl/:ro --volume /var/folders/vb/pjyhgj4s491_k0t025_j56y00000gn/T//results/rsa/intermediate/:/output --workdir /output drwetter/testssl.sh:3.1dev --quiet --file /config/ssl/testssl.txt --mode parallel --overwrite --preference
     standard_init_linux.go:228: exec user process caused: permission denied
   
   -- command failed --
   status : 1
   output : standard_init_linux.go:228: exec user process caused: permission denied
   --
 ```
 
 It turns out this is because of a change with BATS_TMPDIR. See https://github.com/bats-core/bats-core/pull/410#discussion_r575864351 and https://github.com/bats-core/bats-core/pull/365#issuecomment-778841245

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
