### PR TITLE
Update F2B wrapper to show possible errors with IPTables

### DIFF
--- a/target/bin/fail2ban
+++ b/target/bin/fail2ban
@@ -3,11 +3,11 @@
 # shellcheck source=../scripts/helper-functions.sh
 . /usr/local/bin/helper-functions.sh
 
-if ! iptables -L &>/tmp/iptables-check-command-output
+if ! IPTABLES_OUTPUT=$(iptables -L 2>&1)
 then
   echo "IPTables does not seem to work properly. The output of 'iptables -L' was:
 
-$(</tmp/iptables-check-command-output)
+${IPTABLES_OUTPUT}
 
 Possible causes for this errore are
 

--- a/target/bin/fail2ban
+++ b/target/bin/fail2ban
@@ -3,6 +3,23 @@
 # shellcheck source=../scripts/helper-functions.sh
 . /usr/local/bin/helper-functions.sh
 
+if ! iptables -L &>/tmp/iptables-check-command-output
+then
+  echo "IPTables does not seem to work properly. The output of 'iptables -L' was:
+
+$(</tmp/iptables-check-command-output)
+
+Possible causes for this errore are
+
+1. Missing capabilities
+2. Modification by user-patches.sh
+
+Aborting.
+"
+
+  exit 1
+fi
+
 function usage { echo "Usage: ${0} [<unban> <ip-address>]" ; }
 
 unset JAILS

--- a/target/bin/fail2ban
+++ b/target/bin/fail2ban
@@ -5,16 +5,17 @@
 
 if ! IPTABLES_OUTPUT=$(iptables -L 2>&1)
 then
-  echo "IPTables does not seem to work properly. The output of 'iptables -L' was:
+  echo "IPTables is not functioning correctly. The output of \`iptables -L\` was:
 
 ${IPTABLES_OUTPUT}
 
-Possible causes for this errore are
+Possible causes for this error are
 
-1. Missing capabilities
-2. Modification by user-patches.sh
+1. Missing capabilities (you need CAP_NET_RAW & CAP_NET_ADMIN, see \`capsh --print\`)
+2. Modifications caused by user-patches.sh
+3. Host is configured incorrectly
 
-Aborting.
+Aborting...
 "
 
   exit 1


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

The `fail2ban` wrapper would show `No IPs have been banned` even when IPTables did not work. This is now shown and the script aborts.

<!-- Link the issue which will be fixed (if any) here: -->
Partly helps with #2169

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
