### PR TITLE
docs(fix): Update external registry links

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -156,5 +156,5 @@ nav:
     - 'Coding Style': contributing/coding-style.md
     - 'Tests': contributing/tests.md
     - 'Documentation': contributing/documentation.md
-  - 'DockerHub': https://hub.docker.com/repository/docker/mailserver/docker-mailserver
-  - 'GHCR': https://github.com/orgs/docker-mailserver/packages/container/package/docker-mailserver
+  - 'DockerHub': https://hub.docker.com/r/mailserver/docker-mailserver/
+  - 'GHCR': https://github.com/docker-mailserver/docker-mailserver/pkgs/container/docker-mailserver


### PR DESCRIPTION
# Description

- DockerHub was invalid.
- GHCR serves a redirect, might as well update to that too.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
