### PR TITLE
docs(deps): bump mkdocs-material to 7.3.0

### DIFF
--- a/.github/workflows/scripts/docs/build-docs.sh
+++ b/.github/workflows/scripts/docs/build-docs.sh
@@ -6,7 +6,7 @@ docker run \
   --rm \
   --user "$(id -u):$(id -g)" \
   -v "${PWD}:/docs" \
-  squidfunk/mkdocs-material:7.2.8 build --strict
+  squidfunk/mkdocs-material:7.3.0 build --strict
 
 # Remove unnecessary build artifacts: https://github.com/squidfunk/mkdocs-material/issues/2519
 cd site || exit


### PR DESCRIPTION
# Description

bump mkdocs-material to 7.3.0

it got released today and we now (theoretically) have the option to:
- Added support for sticky navigation tabs
- Added support for section index pages
- Added support for removing generator notice



## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
