### PR TITLE
ci: Allow other workflows to trigger linting

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,6 +6,12 @@ on:
   push:
     branches:
       - master
+  # These workflows when done will trigger this workflow too:
+  workflow_run:
+    workflows: ['Update contributors']
+    types:
+      - completed
+
 jobs:
   lint:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This should resolve the issue of the lint workflow not being triggered by PRs opened via another workflow (`contributors.yml`).

This workflow will be triggered after the dependent workflow completes (regardless of status).

Resolves: https://github.com/docker-mailserver/docker-mailserver/pull/2218

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
