### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - ./docker-data/dms/mail-state/:/var/mail-state/
       - ./docker-data/dms/mail-logs/:/var/log/mail/
       - ./docker-data/dms/config/:/tmp/docker-mailserver/
-      - /etc/localtime:/etc/localtime:ro/
+      - /etc/localtime:/etc/localtime:ro
     restart: always
     stop_grace_period: 1m
     cap_add:


### PR DESCRIPTION
Leaving the "/" after ":ro" throws out an error when using `docker-compose up -d`

# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #

## Type of change

<!-- Delete options that are not relevant. -->

- [ X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X ] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [X ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [X ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
