### PR TITLE
Update README to reflect changes of `v10.2.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ You can then proceed by creating the postmaster alias and by creating DKIM keys.
 docker-compose up -d mailserver
 
 # you may add some more users
+# for SELinux, use -Z
 ./setup.sh [-Z] email add <user@domain> [<password>]
 
 # and configure aliases, DKIM and more

--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ docker-compose up -d mailserver
 ./setup.sh [-Z] email add <user@domain> [<password>]
 
 # and configure aliases, DKIM and more
-# for SELinux, use -Z
 ./setup.sh [-Z] alias add postmaster@<domain> <user@domain>
 ./setup.sh [-Z] config dkim
 ```

--- a/README.md
+++ b/README.md
@@ -108,16 +108,35 @@ If you're using `docker-mailserver` version `v10.1.x` or below, you will need to
 
 ### Get up and running
 
+#### First Things First
+
+**Use `docker-compose up / down`, not `docker-compose start / stop`**. Otherwise, the container is not properly destroyed and you may experience problems during startup because of inconsistent state.
+
+You are able to get a full overview of how the configuration works by either running:
+
+1. `./setup.sh help` which includes the options of `setup.sh`.
+2. `docker run --rm docker.io/mailserver/docker-mailserver:latest setup help` which provides you with all the information on configuration provided "inside" the container itself.
+
+#### Starting for the first time
+
+On first start, you will likely see an error stating that there are no mail accounts and the container will exit. You must now do one of two things:
+
+1. Use `setup.sh` to help you: `./setup.sh email add <user@domain> <password>`. You may need to provide the correct configuration path (to the directory mounted to `/tmp/docker-mailserver` inside the container yourself) with the `-c` option. This will spin up a new container, mount your configuration volume, and create your first account.
+2. Execute the complete command yourself: `docker run --rm -v ./docker-data/dms/config/:/tmp/docker-mailserver/ docker.io/mailserver/docker-mailserver setup email add <user@domain> <password>`. Make sure to mount the correct configuration directory.
+
+You can then proceed by creating the postmaster alias and by creating DKIM keys.
+
 ``` BASH
 docker-compose up -d mailserver
 
-# for SELinux, use -Z 
+# you may add some more users
 ./setup.sh [-Z] email add <user@domain> [<password>]
+
+# and configure aliases, DKIM and more
+# for SELinux, use -Z
 ./setup.sh [-Z] alias add postmaster@<domain> <user@domain>
 ./setup.sh [-Z] config dkim
 ```
-
-If you're seeing error messages about unchecked errors, please **verify that you're using the right version of `setup.sh`**. Refer to the [Get the tools](#get-the-tools) section and / or execute `./setup.sh help` and read the `VERSION` section.
 
 In case you're using LDAP, the setup looks a bit different as you do not add user accounts directly. Postfix doesn't know your domain(s) and you need to provide it when configuring DKIM:
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ You are able to get a full overview of how the configuration works by either run
 
 On first start, you will likely see an error stating that there are no mail accounts and the container will exit. You must now do one of two things:
 
-1. Use `setup.sh` to help you: `./setup.sh email add <user@domain> <password>`. You may need to provide the correct configuration path (to the directory mounted to `/tmp/docker-mailserver` inside the container yourself) with the `-c` option. This will spin up a new container, mount your configuration volume, and create your first account.
+1. Use `setup.sh` to help you: `./setup.sh email add <user@domain> <password>`. You may need  the `-c` option to provide the local path for persisting configuration (_a directory that mounts to `/tmp/docker-mailserver` inside the container_). This will spin up a new container, mount your configuration volume, and create your first account.
 2. Execute the complete command yourself: `docker run --rm -v ./docker-data/dms/config/:/tmp/docker-mailserver/ docker.io/mailserver/docker-mailserver setup email add <user@domain> <password>`. Make sure to mount the correct configuration directory.
 
 You can then proceed by creating the postmaster alias and by creating DKIM keys.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ You are able to get a full overview of how the configuration works by either run
 On first start, you will likely see an error stating that there are no mail accounts and the container will exit. You must now do one of two things:
 
 1. Use `setup.sh` to help you: `./setup.sh email add <user@domain> <password>`. You may need  the `-c` option to provide the local path for persisting configuration (_a directory that mounts to `/tmp/docker-mailserver` inside the container_). This will spin up a new container, mount your configuration volume, and create your first account.
-2. Execute the complete command yourself: `docker run --rm -v ./docker-data/dms/config/:/tmp/docker-mailserver/ docker.io/mailserver/docker-mailserver setup email add <user@domain> <password>`. Make sure to mount the correct configuration directory.
+2. Execute the complete command yourself: `docker run --rm -v "${PWD}/docker-data/dms/config/:/tmp/docker-mailserver/" docker.io/mailserver/docker-mailserver setup email add <user@domain> <password>`. Make sure to mount the correct configuration directory.
 
 You can then proceed by creating the postmaster alias and by creating DKIM keys.
 


### PR DESCRIPTION
# Description

Because the container will now exit on startup failure if no accounts exits, we have to update the README's section for beginners. Furthermore, I added another section containing information about not using `docker start / stop` and about the help users can get by running the `setup help` command inside the container.

This issue is related, but only an example: #2232

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
