### PR TITLE
Disable name resolution in iptables check

### DIFF
--- a/target/bin/fail2ban
+++ b/target/bin/fail2ban
@@ -3,7 +3,7 @@
 # shellcheck source=../scripts/helper-functions.sh
 . /usr/local/bin/helper-functions.sh
 
-if ! IPTABLES_OUTPUT=$(iptables -L 2>&1)
+if ! IPTABLES_OUTPUT=$(iptables -L -n 2>&1)
 then
   echo "IPTables is not functioning correctly. The output of \`iptables -L\` was:
 


### PR DESCRIPTION
# Description

I had the problem, that running the `fail2ban` script took ages to complete, because there were hostnames, that could not be resolved. There is no need for name resolution. This PR disables that.

<!-- Link the issue which will be fixed (if any) here: -->


## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
