### PR TITLE
Make it compatible with docker compose 2.x

### DIFF
--- a/mailserver.env
+++ b/mailserver.env
@@ -341,7 +341,7 @@ POSTGREY_DELAY=300
 # delete entries older than N days since the last time that they have been seen
 POSTGREY_MAX_AGE=35
 # response when a mail is greylisted
-POSTGREY_TEXT=Delayed by Postgrey
+POSTGREY_TEXT="Delayed by Postgrey"
 # whitelist host after N successful deliveries (N=0 to disable whitelisting)
 POSTGREY_AUTO_WHITELIST_CLIENTS=5
 

--- a/mailserver.env
+++ b/mailserver.env
@@ -341,7 +341,7 @@ POSTGREY_DELAY=300
 # delete entries older than N days since the last time that they have been seen
 POSTGREY_MAX_AGE=35
 # response when a mail is greylisted
-POSTGREY_TEXT="Delayed by Postgrey"
+"POSTGREY_TEXT=Delayed by Postgrey"
 # whitelist host after N successful deliveries (N=0 to disable whitelisting)
 POSTGREY_AUTO_WHITELIST_CLIENTS=5
 


### PR DESCRIPTION
# Description

docker compose 2.x complains with this error: "key cannot contain a space" or 
```
unexpected character "(" in variable name near "whitelist host after N successful deliveries (N=0 to disable whitelisting)\nPOSTGREY_AUTO_WHITELIST_CLIENTS=5\n\n#
```
when `POSTGREY_TEXT` value is something with spaces.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
