### PR TITLE
chore: Housekeeping on the 'open-dkim' script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ NAME   ?= mailserver-testing:ci
 VCS_REF = $(shell git rev-parse --short HEAD)
 VCS_VER = $(shell git describe --tags --contains --always)
 
-export CDIR = $(shell pwd)
-
 # -----------------------------------------------
 # --- Generic Build Targets ---------------------
 # -----------------------------------------------

--- a/target/bin/open-dkim
+++ b/target/bin/open-dkim
@@ -150,9 +150,9 @@ do
     opendkim-genkey \
       --bits="${KEYSIZE}" \
       --subdomains \
-      --DOMAIN="${DKIM_DOMAIN}" \
+      --domain="${DKIM_DOMAIN}" \
       --selector="${SELECTOR}" \
-      -D "/tmp/docker-mailserver/opendkim/keys/${DKIM_DOMAIN}"
+      --directory="/tmp/docker-mailserver/opendkim/keys/${DKIM_DOMAIN}"
   fi
 
   # write to KeyTable if necessary

--- a/target/bin/open-dkim
+++ b/target/bin/open-dkim
@@ -139,24 +139,24 @@ then
   exit 0
 fi
 
-while read -r DOMAINNAME
+while read -r DKIM_DOMAIN
 do
-  mkdir -p "/tmp/docker-mailserver/opendkim/keys/${DOMAINNAME}"
+  mkdir -p "/tmp/docker-mailserver/opendkim/keys/${DKIM_DOMAIN}"
 
-  if [[ ! -f "/tmp/docker-mailserver/opendkim/keys/${DOMAINNAME}/${SELECTOR}.private" ]]
+  if [[ ! -f "/tmp/docker-mailserver/opendkim/keys/${DKIM_DOMAIN}/${SELECTOR}.private" ]]
   then
-    echo "Creating DKIM private key /tmp/docker-mailserver/opendkim/keys/${DOMAINNAME}/${SELECTOR}.private"
+    echo "Creating DKIM private key /tmp/docker-mailserver/opendkim/keys/${DKIM_DOMAIN}/${SELECTOR}.private"
 
     opendkim-genkey \
       --bits="${KEYSIZE}" \
       --subdomains \
-      --DOMAIN="${DOMAINNAME}" \
+      --DOMAIN="${DKIM_DOMAIN}" \
       --selector="${SELECTOR}" \
-      -D "/tmp/docker-mailserver/opendkim/keys/${DOMAINNAME}"
+      -D "/tmp/docker-mailserver/opendkim/keys/${DKIM_DOMAIN}"
   fi
 
   # write to KeyTable if necessary
-  KEYTABLEENTRY="${SELECTOR}._domainkey.${DOMAINNAME} ${DOMAINNAME}:${SELECTOR}:/etc/opendkim/keys/${DOMAINNAME}/${SELECTOR}.private"
+  KEYTABLEENTRY="${SELECTOR}._domainkey.${DKIM_DOMAIN} ${DKIM_DOMAIN}:${SELECTOR}:/etc/opendkim/keys/${DKIM_DOMAIN}/${SELECTOR}.private"
   if [[ ! -f "/tmp/docker-mailserver/opendkim/KeyTable" ]]
   then
     echo "Creating DKIM KeyTable"
@@ -169,11 +169,11 @@ do
   fi
 
   # write to SigningTable if necessary
-  SIGNINGTABLEENTRY="*@${DOMAINNAME} ${SELECTOR}._domainkey.${DOMAINNAME}"
+  SIGNINGTABLEENTRY="*@${DKIM_DOMAIN} ${SELECTOR}._domainkey.${DKIM_DOMAIN}"
   if [[ ! -f /tmp/docker-mailserver/opendkim/SigningTable ]]
   then
     echo "Creating DKIM SigningTable"
-    echo "*@${DOMAINNAME} ${SELECTOR}._domainkey.${DOMAINNAME}" >/tmp/docker-mailserver/opendkim/SigningTable
+    echo "*@${DKIM_DOMAIN} ${SELECTOR}._domainkey.${DKIM_DOMAIN}" >/tmp/docker-mailserver/opendkim/SigningTable
   else
     if ! grep -q "${SIGNINGTABLEENTRY}" /tmp/docker-mailserver/opendkim/SigningTable
     then

--- a/test/open_dkim.bats
+++ b/test/open_dkim.bats
@@ -21,7 +21,7 @@ function setup_file
     --name "${CONTAINER_NAME}" \
 		--cap-add=SYS_PTRACE \
 		-v "${PRIVATE_CONFIG}":/tmp/docker-mailserver \
-		-v "${CDIR}/test/test-files":/tmp/docker-mailserver-test:ro \
+		-v "${PWD}/test/test-files":/tmp/docker-mailserver-test:ro \
 		-e DEFAULT_RELAY_HOST=default.relay.host.invalid:25 \
 		-e PERMIT_DOCKER=host \
 		-e DMS_DEBUG=0 \


### PR DESCRIPTION
# Description

This is extracted from https://github.com/docker-mailserver/docker-mailserver/pull/2245 as it does not need to be part of that PR.

- The internal var `DOMAINNAME` is used elsewhere in the project as a global, as this is a local var it should not use a name that could be mistaken as associated to the more widespread one.
- `opendkim-genkey` options made consistent:
  - `--domain` is all lowercase, it shouldn't be uppercase.
  - `--directory` should be used instead of the more ambiguous short option `-D`.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
