### PR TITLE
ci(tests): Add timing measurement to output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ generate-accounts:
 	@ echo "           # this is also a test comment, :O" >> test/config/postfix-accounts.cf
 
 tests:
-	@ NAME=$(NAME) ./test/bats/bin/bats test/*.bats
+	@ NAME=$(NAME) ./test/bats/bin/bats --timing test/*.bats
 
 .PHONY: ALWAYS_RUN
 test/%.bats: ALWAYS_RUN


### PR DESCRIPTION
# Description

Extracted from [this open PR commit](https://github.com/docker-mailserver/docker-mailserver/pull/2245/commits/8ebbca3f24dea34375a4fe61232b4bce77da2b30) as it's not required for that PR.

@NorseGaud added this as an improvement for the test logs to include time measurements.

---

For the CI there is an a `CI` ENV that is detected so `bats` uses the `TAP` formatter. If you'd like to swap the test number with the fancy tick/cross symbols for pass/fail, we can additionally add `--pretty` (or --formatter pretty).

Version 1.5.0 of `bats` also [released about a week ago](https://github.com/bats-core/bats-core/releases/tag/v1.5.0).

Let me know if you'd like either of those additions added.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
