### PR TITLE
fix: broken link in docs

### DIFF
--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -725,4 +725,4 @@ you to replace both instead of just the envelope sender.
 [docs-tls-letsencrypt]: ./security/ssl.md#lets-encrypt-recommended
 [docs-tls-manual]: ./security/ssl.md#bring-your-own-certificates
 [docs-tls-selfsigned]: ./security/ssl.md#self-signed-certificates
-[docs-accounts]: ./config/user-management/accounts.md#notes
+[docs-accounts]: ./user-management/accounts.md#notes

--- a/docs/content/config/user-management/accounts.md
+++ b/docs/content/config/user-management/accounts.md
@@ -41,7 +41,7 @@ You will then be asked for a password, and be given back the data for a new acco
 
 - `imap-quota` is enabled and allow clients to query their mailbox usage.
 - When the mailbox is deleted, the quota directive is deleted as well.
-- Dovecot quotas support LDAP, **but it's not implemented** (_PR are welcome!_).
+- Dovecot quotas support LDAP, **but it's not implemented** (_PRs are welcome!_).
 
 [docs-setupsh]: ../setup.sh.md
 [github-issue-552]: https://github.com/docker-mailserver/docker-mailserver/issues/552


### PR DESCRIPTION
# Description

Fixes a broken link in documentation.

https://docker-mailserver.github.io/docker-mailserver/edge/config/environment/#enable_quotas currently links to https://docker-mailserver.github.io/docker-mailserver/edge/config/environment/config/user-management/accounts.md#notes

This PR correctly links to https://pullrequest-2270--dms-doc-previews.netlify.app/config/user-management/accounts/#notes now 

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
