### PR TITLE
chore: Remove version key from `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
-# `version` key here is optional and no longer required in modern docker-compose versions.
-# version: '3.8'
-
 services:
   mailserver:
     image: docker.io/mailserver/docker-mailserver:latest


### PR DESCRIPTION
# Description

While I chose to keep the version with a note about it not being required, @casperklein has suggested we [remove the version from the example config entirely](https://github.com/docker-mailserver/docker-mailserver/pull/2268#discussion_r739633649).

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)
