### PR TITLE
chore: Remove invalid/redundant config in Postfix `master.cf`

### DIFF
--- a/target/postfix/master.cf
+++ b/target/postfix/master.cf
@@ -67,19 +67,6 @@ lmtp      unix  -       -       n       -       -       lmtp
 anvil     unix  -       -       y       -       1       anvil
 scache    unix  -       -       y       -       1       scache
 
-maildrop  unix  -       n       n       -       -       pipe
-  flags=DRhu user=vmail argv=/usr/bin/maildrop -d ${recipient}
-uucp      unix  -       n       n       -       -       pipe
-  flags=Fqhu user=uucp argv=uux -r -n -z -a$sender - $nexthop!rmail ($recipient)
-ifmail    unix  -       n       n       -       -       pipe
-  flags=F user=ftn argv=/usr/lib/ifmail/ifmail -r $nexthop ($recipient)
-bsmtp     unix  -       n       n       -       -       pipe
-  flags=Fq. user=bsmtp argv=/usr/lib/bsmtp/bsmtp -t$nexthop -f$sender $recipient
-scalemail-backend unix	-	n	n	-	2	pipe
-  flags=R user=scalemail argv=/usr/lib/scalemail/bin/scalemail-store ${nexthop} ${user} ${extension}
-mailman   unix  -       n       n       -       -       pipe
-  flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
-  ${nexthop} ${user}
 sender-cleanup unix n   -       -       -       0       cleanup
   -o syslog_name=postfix/sender-cleanup
   -o header_checks=pcre:/etc/postfix/maps/sender_header_filter.pcre


### PR DESCRIPTION
# Description

This was all [introduced by the original project author early on](https://github.com/docker-mailserver/docker-mailserver/commit/ef34462e34f2d6a46f8da9dc4c068c2186b8ea54) (April 2015), no explanation for it. Seems safe to remove.

- None of the paths they use as `argv` values exist.
- `uucp` doesn't seem relevant to the project. No justification for it, no issues or PRs in project history or codebase.
- `mailman` is for managing mailing lists, we do have issues requesting support in [May 2020](https://github.com/docker-mailserver/docker-mailserver/issues/1518) and [Nov 2016](https://github.com/docker-mailserver/docker-mailserver/issues/370). Debian 11 Bullseye also [no longer includes a `mailman` package](https://www.debian.org/releases/stable/amd64/release-notes/ch-information.en.html#noteworthy-obsolete-packages), there is `mailman3` and `mailman3-full`, assuming anyone wants to add that, they can add the assumed required `master.cf` line back and any other configuration they need, we don't officially support such.
- Postfix has a [guide for setup with `maildrop`](http://www.postfix.org/MAILDROP_README.html), this is different from the _maildrop queue_ in `/var/spool/postfix/maildrop` that `postdrop` handles AFAIK. Especially since we can see the guide advises setting `virtual_transport` to `maildrop` which we have already configured to be LMTP with Dovecot. As the binary itself doesn't exist at the configured path, if this ever worked it hasn't been for a while presumably.. and no issue or PR github tracker history, nor content in the project files.
- An issue raised by original project author does mention [`scalemail` briefly via log failure](https://github.com/docker-mailserver/docker-mailserver/issues/322), that was back in Sep 2016, I don't know what the setup was like back then and perhaps this was something that was in the image prior to transition to Debian, or they added it themselves. The issue was regarding permissions with `ONE_DIR` ENV, that was AFAIK resolved via the `chown -R` fixes script.
I have not looked through anything else in `master.cf`, just housekeeping.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

Not likely:

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
