### PR TITLE
fix: `ONE_DIR=1` should keep correct permissions for `spool-postfix`

### DIFF
--- a/target/scripts/startup/misc-stack.sh
+++ b/target/scripts/startup/misc-stack.sh
@@ -59,6 +59,21 @@ function _misc_save_states
     chown -R postfix /var/mail-state/lib-postfix
     chown -R postgrey /var/mail-state/lib-postgrey
     chown -R debian-spamd /var/mail-state/lib-spamassassin
-    chown -R postfix /var/mail-state/spool-postfix
+
+    # UID = postfix(101): active, bounce, corrupt, defer, deferred, flush, hold, incoming, maildrop, private, public, saved, trace
+    # UID = root(0): dev, etc, lib, pid, usr
+    # GID = postdrop(103): maildrop, public
+    # GID for all other directories is root(0)
+    # Set most common ownership:
+    chown -R postfix:root /var/mail-state/spool-postfix
+    # These two require the postdrop(103) group:
+    chgrp -R postdrop /var/mail-state/spool-postfix/maildrop
+    chgrp -R postdrop /var/mail-state/spool-postfix/public
+    # These all have root ownership at the src location:
+    chown -R root /var/mail-state/spool-postfix/dev
+    chown -R root /var/mail-state/spool-postfix/etc
+    chown -R root /var/mail-state/spool-postfix/lib
+    chown -R root /var/mail-state/spool-postfix/pid
+    chown -R root /var/mail-state/spool-postfix/usr
   fi
 }


### PR DESCRIPTION
# Description

A [PR in July 2017](https://github.com/docker-mailserver/docker-mailserver/pull/657) contained a fix for this but was rejected due to other changes proposed:

> Fixing permissions problems for `/var/mail-state/spool-postfix` when `ONE_DIR=1`:
> - `spool-postfix/maildrop` and `spool-postfix/public` folders must be owned by group `postdrop`
> - `spool-postfix/[dev/etc/lib/pid/usr]` permissions were not restrictive enough. They should be owned by the `root` user and `root` group.

I have looked at the source destination and the permissions remain the same. This PR carries over the ownership to the `ONE_DIR` location.

An alternative fix in future might be to use `rsync` which can copy over the contents with permissions and everything else retained. I'm not super familiar with the `ONE_DIR` handling myself. I see that it appears to do some cleanup and mostly symlinking (for files?) and moving for directories?

---

I came across this when looking into `postdrop` in regards to `maildrop` while working on [this PR](https://github.com/docker-mailserver/docker-mailserver/pull/2272).

`postdrop`:

- Part of the [Postfix architecture/project](http://www.postfix.org/OVERVIEW.html). Interacts [with the _maildrop queue_](http://www.postfix.org/QSHAPE_README.html#maildrop_queue).
- Lack of permissions can cause [processes like cron to try send mail, but `postdrop` hangs](https://unix.stackexchange.com/questions/109665/what-causes-cron-to-continuously-send-mail-and-how-can-i-disable-it/202190#202190).

---

Fixes #694 #1029 #1179

Affected a [vacation sieve filter in Sep 2018](https://github.com/docker-mailserver/docker-mailserver/issues/1029) and a [sieve filter redirect in June 2019](https://github.com/docker-mailserver/docker-mailserver/issues/1179):

> Have setup a simple sieve file:
> ```
> redirect "x@domain.com";
> keep;
> ```
> 
> When testing I do not get the test emails. In the `sieve.log` for the user being emailed you get "failed to redirect message to `x@domain.com`: Failed to execute sendmail (temporary failure)."

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
