### PR TITLE
refactor: Internal HOSTNAME and DOMAINNAME configuration

### DIFF
--- a/target/scripts/helper-functions.sh
+++ b/target/scripts/helper-functions.sh
@@ -329,7 +329,7 @@ function _obtain_hostname_and_domainname
     if [[ -n ${OVERRIDE_HOSTNAME} ]]
     then
       # Emulates the intended behaviour of `hostname -d`:
-      DOMAINNAME="$(echo "${HOSTNAME}" | cut -d '.' -f2-)"
+      DOMAINNAME="$(echo "${HOSTNAME}" | cut -d '.' -f2-99)"
     else
       # Operates on the FQDN returned from querying `/etc/hosts` or fallback DNS:
       #

--- a/target/scripts/helper-functions.sh
+++ b/target/scripts/helper-functions.sh
@@ -329,7 +329,8 @@ function _obtain_hostname_and_domainname
     if [[ -n ${OVERRIDE_HOSTNAME} ]]
     then
       # Emulates the intended behaviour of `hostname -d`:
-      DOMAINNAME="$(echo "${HOSTNAME}" | cut -d '.' -f2-)"
+      # Assign the HOSTNAME value minus everything up to and including the first `.`
+      DOMAINNAME=${HOSTNAME#*.}
     else
       # Operates on the FQDN returned from querying `/etc/hosts` or fallback DNS:
       #

--- a/target/scripts/helper-functions.sh
+++ b/target/scripts/helper-functions.sh
@@ -324,7 +324,7 @@ function _obtain_hostname_and_domainname
   # `hostname -d` was probably not the correct command for this intention either.
   # Needs further investigation for relevance, and if `/etc/hosts` is important for consumers
   # of this variable or if a more deterministic approach with `cut` should be relied on.
-  if [[ $(_get_label_length "${HOSTNAME}") -gt 2 ]]
+  if [[ $(_get_label_count "${HOSTNAME}") -gt 2 ]]
   then
     if [[ -n ${OVERRIDE_HOSTNAME} ]]
     then

--- a/target/scripts/helper-functions.sh
+++ b/target/scripts/helper-functions.sh
@@ -329,7 +329,7 @@ function _obtain_hostname_and_domainname
     if [[ -n ${OVERRIDE_HOSTNAME} ]]
     then
       # Emulates the intended behaviour of `hostname -d`:
-      DOMAINNAME="$(echo "${HOSTNAME}" | cut -d '.' -f2-99)"
+      DOMAINNAME="$(echo "${HOSTNAME}" | cut -d '.' -f2-)"
     else
       # Operates on the FQDN returned from querying `/etc/hosts` or fallback DNS:
       #

--- a/target/scripts/helper-functions.sh
+++ b/target/scripts/helper-functions.sh
@@ -302,6 +302,13 @@ function _obtain_hostname_and_domainname
 {
   # Normally this value would match the output of `hostname` which mirrors `/proc/sys/kernel/hostname`,
   # However for legacy reasons, the system ENV `HOSTNAME` was replaced here with `hostname -f` instead.
+  #
+  # TODO: Consider changing to `DMS_FQDN`; a more accurate name, and removing the `export`, assuming no
+  # subprocess like postconf would be called that would need access to the same value via `$HOSTNAME` ENV.
+  #
+  # TODO: `OVERRIDE_HOSTNAME` was introduced for non-Docker runtimes that could not configure an explicit hostname.
+  # k8s was the particular runtime in 2017. This does not update `/etc/hosts` or other locations, thus risking
+  # inconsistency with expected behaviour. Investigate if it's safe to remove support. (--net=host also uses this as a workaround)
   export HOSTNAME="${OVERRIDE_HOSTNAME:-"$(hostname -f)"}"
 
   # If the container is misconfigured.. `hostname -f` (which derives it's return value from `/etc/hosts` or DNS query),
@@ -313,14 +320,26 @@ function _obtain_hostname_and_domainname
 
   # If the `HOSTNAME` is more than 2 labels long (eg: mail.example.com),
   # We take the FQDN from it, minus the 1st label (aka _short hostname_, `hostname -s`).
+  #
+  # TODO: For some reason we're explicitly separating out a domain name from our FQDN,
+  # `hostname -d` was probably not the correct command for this intention either.
+  # Needs further investigation for relevance, and if `/etc/hosts` is important for consumers
+  # of this variable or if a more deterministic approach with `cut` should be relied on.
   if [[ $(_get_label_length "${HOSTNAME}") -gt 2 ]]
   then
     if [[ -n ${OVERRIDE_HOSTNAME} ]]
     then
-      # Emulates the intended behaviour of `hostname -d`
+      # Emulates the intended behaviour of `hostname -d`:
       DOMAINNAME="$(echo "${HOSTNAME}" | cut -d '.' -f2-99)"
     else
-      # Operates on the FQDN returned from querying `/etc/hosts` or fallback DNS
+      # Operates on the FQDN returned from querying `/etc/hosts` or fallback DNS:
+      #
+      # Note if you want the actual NIS `domainname`, use the `domainname` command,
+      # or `cat /proc/sys/kernel/domainname`.
+      # Our usage of `domainname` is under consideration as legacy, and not advised
+      # going forward. In future our docs should drop any mention of it.
+
+      #shellcheck disable=SC2034
       DOMAINNAME="$(hostname -d)"
     fi
   fi

--- a/target/scripts/helper-functions.sh
+++ b/target/scripts/helper-functions.sh
@@ -304,6 +304,13 @@ function _obtain_hostname_and_domainname
   # However for legacy reasons, the system ENV `HOSTNAME` was replaced here with `hostname -f` instead.
   export HOSTNAME="${OVERRIDE_HOSTNAME:-"$(hostname -f)"}"
 
+  # If the container is misconfigured.. `hostname -f` (which derives it's return value from `/etc/hosts` or DNS query),
+  # will result in an error that returns an empty value. This warrants a panic.
+  if [[ -z ${HOSTNAME} ]]
+  then
+    dms_panic__misconfigured 'obtain_hostname' '/etc/hosts'
+  fi
+
   # If the `HOSTNAME` is more than 2 labels long (eg: mail.example.com),
   # We take the FQDN from it, minus the 1st label (aka _short hostname_, `hostname -s`).
   if [[ $(_get_label_length "${HOSTNAME}") -gt 2 ]]

--- a/target/scripts/helper-functions.sh
+++ b/target/scripts/helper-functions.sh
@@ -290,10 +290,9 @@ export -f _monitored_files_checksums
 
 # Outputs the DNS label count (delimited by `.`) for the given input string.
 # Useful for determining an FQDN like `mail.example.com` (3), vs `example.com` (2).
-function _get_label_length
+function _get_label_count
 {
-  local INPUT=${1}
-  awk -F '.' '{ print NF }' <<< "${INPUT}"
+  awk -F '.' '{ print NF }' <<< "${1}"
 }
 
 # Sets HOSTNAME and DOMAINNAME globals used throughout the scripts,
@@ -309,7 +308,7 @@ function _obtain_hostname_and_domainname
   # TODO: `OVERRIDE_HOSTNAME` was introduced for non-Docker runtimes that could not configure an explicit hostname.
   # k8s was the particular runtime in 2017. This does not update `/etc/hosts` or other locations, thus risking
   # inconsistency with expected behaviour. Investigate if it's safe to remove support. (--net=host also uses this as a workaround)
-  export HOSTNAME="${OVERRIDE_HOSTNAME:-"$(hostname -f)"}"
+  export HOSTNAME="${OVERRIDE_HOSTNAME:-$(hostname -f)}"
 
   # If the container is misconfigured.. `hostname -f` (which derives it's return value from `/etc/hosts` or DNS query),
   # will result in an error that returns an empty value. This warrants a panic.
@@ -330,7 +329,7 @@ function _obtain_hostname_and_domainname
     if [[ -n ${OVERRIDE_HOSTNAME} ]]
     then
       # Emulates the intended behaviour of `hostname -d`:
-      DOMAINNAME="$(echo "${HOSTNAME}" | cut -d '.' -f2-99)"
+      DOMAINNAME="$(echo "${HOSTNAME}" | cut -d '.' -f2-)"
     else
       # Operates on the FQDN returned from querying `/etc/hosts` or fallback DNS:
       #
@@ -346,7 +345,7 @@ function _obtain_hostname_and_domainname
 
   # Otherwise we assign the same value (eg: example.com):
   # Not an else statement in the previous conditional in the event that `hostname -d` fails.
-  DOMAINNAME="${DOMAINNAME:-"${HOSTNAME}"}"
+  DOMAINNAME="${DOMAINNAME:-${HOSTNAME}}"
 }
 
 # Call this method when you want to panic (emit a 'FATAL' log level error, and exit uncleanly).

--- a/test/mail_hostname.bats
+++ b/test/mail_hostname.bats
@@ -35,9 +35,9 @@ function setup_file() {
     -e PERMIT_DOCKER=network \
     -e DMS_DEBUG=0 \
     -e ENABLE_SRS=1 \
-    -e SRS_DOMAINNAME=srs.my-domain.com \
-    -e DOMAINNAME=my-domain.com \
-    -h unknown.domain.tld \
+    -e SRS_DOMAINNAME='srs.my-domain.com' \
+    --domainname 'my-domain.com' \
+    --hostname 'mail' \
     -t "${NAME}"
 
   PRIVATE_CONFIG_FOUR="$(duplicate_config_for_container . mail_domainname)"
@@ -47,14 +47,14 @@ function setup_file() {
     -e PERMIT_DOCKER=network \
     -e DMS_DEBUG=0 \
     -e ENABLE_SRS=1 \
-    -e DOMAINNAME=my-domain.com \
-    -h unknown.domain.tld \
+    --domainname 'my-domain.com' \
+    --hostname 'mail' \
     -t "${NAME}"
 
   wait_for_smtp_port_in_container mail_override_hostname
-  
+
   wait_for_smtp_port_in_container mail_non_subdomain_hostname
-  
+
   wait_for_smtp_port_in_container mail_srs_domainname
 
   wait_for_smtp_port_in_container mail_domainname


### PR DESCRIPTION
# Description

This has been extracted from https://github.com/docker-mailserver/docker-mailserver/pull/2245 to simplify review.

These changes are the main focus of the original PR where the bulk of the discussion and investigation was oriented around.

Originally reworked by @NorseGaud with heavy refactoring by me afterwards.

---

Commits have been scoped with context via commit messages for ease of reviewing.

Summary of changes:

- Better logical flow, handling and inline documentation.
- Panic when `$HOSTNAME` is misconfigured.
- Heavy inline docs for maintainers to understand and be aware of related functionality.
- `SRS_DOMAINNAME` test should use `--domainname` not ENV `DOMAINNAME` (_reverted this fallback that was added from the [PR that originally introduced `_obtain_hostname_and_domainname`](https://github.com/docker-mailserver/docker-mailserver/pull/2175)_)

There was discussion to consider dropping config ENV `OVERRIDE_HOSTNAME` and the internal `DOMAINNAME` in future, and rename our `HOSTNAME` var to `DMS_FQDN`. Before that happens tests need to be overhauled to more easily perform matrix testing (_different base configs where we can verify tests pass for various scenarios_) to establish confidence in what may likely be a breaking change when introduced. As such that's delayed to a future PR.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
