### PR TITLE
docs(deps): bump mkdocs-material to 7.3.6

### DIFF
--- a/.github/workflows/scripts/docs/build-docs.sh
+++ b/.github/workflows/scripts/docs/build-docs.sh
@@ -10,7 +10,7 @@ docker run \
   --user "$(id -u):$(id -g)" \
   --volume "${PWD}:/docs" \
   --name "build-docs" \
-  squidfunk/mkdocs-material:7.3.5 build --strict
+  squidfunk/mkdocs-material:7.3.6 build --strict
 
 # Remove unnecessary build artifacts: https://github.com/squidfunk/mkdocs-material/issues/2519
 # site/ is the build output folder.


### PR DESCRIPTION
# Description
bump mkdocs-material to 7.3.6
We no have the option to use titles for code blocks:
https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#adding-a-title

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
