### PR TITLE
Fix OpenDMARC verification

### DIFF
--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -148,8 +148,8 @@ function _setup_dmarc_hostname
 {
   _notify 'task' 'Setting up dmarc'
   sed -i -e \
-    "s|^AuthservID.*$|AuthservID          '${HOSTNAME}'|g" \
-    -e "s|^TrustedAuthservIDs.*$|TrustedAuthservIDs  '${HOSTNAME}'|g" \
+    "s|^AuthservID.*$|AuthservID          ${HOSTNAME}|g" \
+    -e "s|^TrustedAuthservIDs.*$|TrustedAuthservIDs  ${HOSTNAME}|g" \
     /etc/opendmarc.conf
 }
 


### PR DESCRIPTION
# Description

Removes the quotation marks around the hostname in opendmarc.conf .
OpenDMARC includes the quotation marks in the hostname, and therefore the hostname no longer matches the header added by OpenDKIM. OpenDMARC then ignores the header and fails the authentication.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
