### PR TITLE
Remove unnecessary `ls` from debug log

### DIFF
--- a/target/scripts/startup/misc-stack.sh
+++ b/target/scripts/startup/misc-stack.sh
@@ -44,7 +44,7 @@ function _misc_save_states
         ln -s "${DEST}" "${FILE}"
       elif [[ -d ${FILE} ]]
       then
-        _notify 'inf' "Moving contents of ${FILE} to ${DEST}:" "$(ls "${FILE}")"
+        _notify 'inf' "Moving contents of ${FILE} to ${DEST}"
         mv "${FILE}" "${DEST}"
         ln -s "${DEST}" "${FILE}"
       else


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

See https://github.com/docker-mailserver/docker-mailserver/pull/2292#issuecomment-967044553

<!-- Link the issue which will be fixed (if any) here: -->
Fixes the problem where the debug log is messy in the `misc-stack.sh` section.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
