### PR TITLE
make Bash start user-patches.sh

### DIFF
--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -115,12 +115,12 @@ do
 
     if [[ -f /tmp/docker-mailserver/postfix-accounts.cf ]] && [[ ${ENABLE_LDAP} -ne 1 ]]
     then
-      sed -i 's/\r//g' /tmp/docker-mailserver/postfix-accounts.cf &>/dev/null
+      sed -i 's/\r//g' /tmp/docker-mailserver/postfix-accounts.cf
       echo "# WARNING: this file is auto-generated. Modify config/postfix-accounts.cf to edit user list." >/etc/postfix/vmailbox
 
       # Checking that /tmp/docker-mailserver/postfix-accounts.cf ends with a newline
       # shellcheck disable=SC1003
-      sed -i -e '$a\' /tmp/docker-mailserver/postfix-accounts.cf &>/dev/null
+      sed -i -e '$a\' /tmp/docker-mailserver/postfix-accounts.cf
       chown dovecot:dovecot /etc/dovecot/userdb
       chmod 640 /etc/dovecot/userdb
       sed -i -e '/\!include auth-ldap\.conf\.ext/s/^/#/' /etc/dovecot/conf.d/10-auth.conf

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -115,12 +115,12 @@ do
 
     if [[ -f /tmp/docker-mailserver/postfix-accounts.cf ]] && [[ ${ENABLE_LDAP} -ne 1 ]]
     then
-      sed -i 's/\r//g' /tmp/docker-mailserver/postfix-accounts.cf
+      sed -i 's/\r//g' /tmp/docker-mailserver/postfix-accounts.cf &>/dev/null
       echo "# WARNING: this file is auto-generated. Modify config/postfix-accounts.cf to edit user list." >/etc/postfix/vmailbox
 
       # Checking that /tmp/docker-mailserver/postfix-accounts.cf ends with a newline
       # shellcheck disable=SC1003
-      sed -i -e '$a\' /tmp/docker-mailserver/postfix-accounts.cf
+      sed -i -e '$a\' /tmp/docker-mailserver/postfix-accounts.cf &>/dev/null
       chown dovecot:dovecot /etc/dovecot/userdb
       chmod 640 /etc/dovecot/userdb
       sed -i -e '/\!include auth-ldap\.conf\.ext/s/^/#/' /etc/dovecot/conf.d/10-auth.conf

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -1738,11 +1738,7 @@ function _setup_user_patches
   if [[ -f ${USER_PATCHES} ]]
   then
     _notify 'tasklog' 'Applying user patches'
-    if [[ ! -x ${USER_PATCHES} ]]; then
-      _notify 'inf' 'Making user patches script executable'
-      chmod +x "${USER_PATCHES}"
-    fi
-    ${USER_PATCHES}
+    bash "${USER_PATCHES}"
   else
     _notify 'inf' "No optional '/tmp/docker-mailserver/user-patches.sh' provided. Skipping."
   fi


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
This addition is somewhat important for K8s users and _changes nothing_ in terms of functionality. We currently execute the `user-patches.sh` script with a shebang, making it executable beforehand if it wasn't to begin with.

Now, Bash will take the script and execute it. This change has therefore no implications on the actual execution of the `user-patches.sh` script.

**But for Kubernetes** users, this way of executing the script is the most comfortable one because all others are somewhat tiresome or involve unnecessary work! The explanation:

You would mount this script via a `ConfigMap` into the container. These files are by default not executable and one cannot change the permissions. One would need to specify the permissions for this `ConfigMap` but then you'd do this for all files of this `ConfigMap`, which is not necessarily desirable either. By using Bash and supplying it the script, we can solve this problem with ease!

I marked this as high priority because I need this change to be in `:edge` ASAP :D Please review!

<!-- Link the issue which will be fixed (if any) here: -->
Fixes permissions error for Kubernetes users (`user-patches.sh`).

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
