### PR TITLE
Fix tiny typo in mailserver.env

### DIFF
--- a/mailserver.env
+++ b/mailserver.env
@@ -33,7 +33,7 @@ ONE_DIR=1
 POSTMASTER_ADDRESS=
 
 # Check for updates on container start and then once a day
-# If an update is available, a mail is send to POSTMASTER_ADDRESS
+# If an update is available, a mail is sent to POSTMASTER_ADDRESS
 # 0 => Update check disabled
 # 1 => Update check enabled
 ENABLE_UPDATE_CHECK=1


### PR DESCRIPTION
# Description

Tiny change to fix spelling in `mailserver.env`

## Checklist:

- [X] My code follows the style guidelines of this project
