### PR TITLE
docs(deps): bump mkdocs-material to new major version 8

### DIFF
--- a/.github/workflows/scripts/docs/build-docs.sh
+++ b/.github/workflows/scripts/docs/build-docs.sh
@@ -10,7 +10,7 @@ docker run \
   --user "$(id -u):$(id -g)" \
   --volume "${PWD}:/docs" \
   --name "build-docs" \
-  squidfunk/mkdocs-material:8.0.2 build --strict
+  squidfunk/mkdocs-material:8.0.3 build --strict
 
 # Remove unnecessary build artifacts: https://github.com/squidfunk/mkdocs-material/issues/2519
 # site/ is the build output folder.

--- a/.github/workflows/scripts/docs/build-docs.sh
+++ b/.github/workflows/scripts/docs/build-docs.sh
@@ -10,7 +10,7 @@ docker run \
   --user "$(id -u):$(id -g)" \
   --volume "${PWD}:/docs" \
   --name "build-docs" \
-  squidfunk/mkdocs-material:7.3.6 build --strict
+  squidfunk/mkdocs-material:8.0.2 build --strict
 
 # Remove unnecessary build artifacts: https://github.com/squidfunk/mkdocs-material/issues/2519
 # site/ is the build output folder.

--- a/.github/workflows/scripts/docs/build-docs.sh
+++ b/.github/workflows/scripts/docs/build-docs.sh
@@ -10,7 +10,7 @@ docker run \
   --user "$(id -u):$(id -g)" \
   --volume "${PWD}:/docs" \
   --name "build-docs" \
-  squidfunk/mkdocs-material:8.0.3 build --strict
+  squidfunk/mkdocs-material:8.0.5 build --strict
 
 # Remove unnecessary build artifacts: https://github.com/squidfunk/mkdocs-material/issues/2519
 # site/ is the build output folder.

--- a/.github/workflows/scripts/docs/build-docs.sh
+++ b/.github/workflows/scripts/docs/build-docs.sh
@@ -10,7 +10,7 @@ docker run \
   --user "$(id -u):$(id -g)" \
   --volume "${PWD}:/docs" \
   --name "build-docs" \
-  squidfunk/mkdocs-material:8.0.5 build --strict
+  squidfunk/mkdocs-material:8.1.0 build --strict
 
 # Remove unnecessary build artifacts: https://github.com/squidfunk/mkdocs-material/issues/2519
 # site/ is the build output folder.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -63,6 +63,7 @@ extra_css:
 extra:
   version:
     provider: mike
+    default: edge
 
 # Various extensions for `mkdocs` are enabled and configured here to extend supported markdown syntax/features.
 markdown_extensions:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -35,6 +35,7 @@ theme:
     - navigation.top
     - navigation.expand
     - navigation.instant
+    - content.code.annotate
   palette:
     # Light mode
     - media: '(prefers-color-scheme: light)'

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -64,7 +64,6 @@ extra_css:
 extra:
   version:
     provider: mike
-    default: edge
 
 # Various extensions for `mkdocs` are enabled and configured here to extend supported markdown syntax/features.
 markdown_extensions:

--- a/docs/overrides/base.html
+++ b/docs/overrides/base.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block outdated %}
+  You're not viewing the latest version.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Click here to go to latest.</strong>
+  </a>
+{% endblock %}

--- a/docs/overrides/base.html
+++ b/docs/overrides/base.html
@@ -1,8 +1,0 @@
-{% extends "base.html" %}
-
-{% block outdated %}
-  You're not viewing the latest version.
-  <a href="{{ '../' ~ base_url }}">
-    <strong>Click here to go to latest.</strong>
-  </a>
-{% endblock %}


### PR DESCRIPTION
# Description

bump mkdocs-material to 8.0.2

Todos:
- [x] We should carefully investigate the preview if something broke (e.g. regarding seealso removal)
- [x] We should investigate new features and if we want them and how to enable (e.g. version warning)

Main changes:
- Added support for code annotations
- Added support for anchor tracking
- Added support for version warning
- Added copyright partial for easier override
- Removed deprecated content tabs legacy implementation
- Removed deprecated seealso admonition type
- Removed deprecated site_keywords setting (unsupported by MkDocs)
- Removed deprecated prebuilt search index support
- Removed deprecated web app manifest – use customization
- Removed extracopyright variable – use new copyright partial
- Removed Disqus integation – use customization
- Switched to :is() selectors for simple selector lists
- Switched autoprefixer from last 4 years to last 2 years
- Improved CSS overall to match modern standards
- Improved CSS variable semantics for fonts
- Improved extensibility by restructuring partials
- Improved handling of details when printing
- Improved keyboard navigation for footnotes

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
