### PR TITLE
docs(deps): bump mkdocs-material to v8.1.1

### DIFF
--- a/.github/workflows/scripts/docs/build-docs.sh
+++ b/.github/workflows/scripts/docs/build-docs.sh
@@ -10,7 +10,7 @@ docker run \
   --user "$(id -u):$(id -g)" \
   --volume "${PWD}:/docs" \
   --name "build-docs" \
-  squidfunk/mkdocs-material:8.1.0 build --strict
+  squidfunk/mkdocs-material:8.1.1 build --strict
 
 # Remove unnecessary build artifacts: https://github.com/squidfunk/mkdocs-material/issues/2519
 # site/ is the build output folder.


### PR DESCRIPTION
# Description

Changelog:
- Added support for #only-light and #only-dark image hash fragments
- Fixed copy-to-clipboard adding blank lines when using line anchors
- Fixed code annotation directionality for right-to-left languages
- Fixed header title positioning for right-to-left languages
- Fixed admonition borders for right-to-left languages (8.0.0 regression)
- Fixed footer navigation link positioning (8.0.0 regression)
- Fixed footer navigation title breaking out of container when too long
- Fixed shrinking arrow in navigation title when too long

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
