### PR TITLE
fix: Restore detection of letsencrypt certificate file changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## `v10.3.0`
 
+**WARNING:** This release had a small regression affecting the detection of changes for certificates provisioned in `/etc/letsencrypt` with the config ENV `SSL_TYPE=letsencrypt`, unless you use Traefik's `acme.json`. If you rely on this functionality to restart Postfix and Dovecot when updating your cert files, this will not work and it is advised to upgrade to `v10.4.0` or newer prior to renewal of your certificates.
+
 - **[fix]** The Dovecot `userdb` will now additionally create "dummy" accounts for basic alias maps (_alias maps to a single real account managed by Dovecot, relaying to external providers aren't affected_) when `ENABLE_QUOTAS=1` (default) as a workaround for Postfix `quota-status` plugin querying Dovecot with inbound mail for a user, which Postfix uses to reject mail if quota has been exceeded (_to avoid risk of blacklisting from spammers abusing backscatter_) [#2248](https://github.com/docker-mailserver/docker-mailserver/pull/2248)
     - **NOTE:** If using aliases that map to another alias or multiple addresses, _this remains a risk_.
 - **[fix]** `setup email list` command will no longer attempt to query Dovecot quota status when `ENABLE_QUOTAS` is disabled [#2264](https://github.com/docker-mailserver/docker-mailserver/pull/2264)

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -73,7 +73,7 @@ do
     # `acme.json` is only relevant to Traefik, and is where it stores the certificates it manages.
     # When a change is detected it's assumed to be a possible cert renewal that needs to be
     # extracted for `docker-mailserver` services to adjust to.
-    if [[ ${CHANGED} =~ '/etc/letsencrypt/acme.json' ]]
+    if [[ ${CHANGED} =~ /etc/letsencrypt/acme.json ]]
     then
       _notify 'inf' "'/etc/letsencrypt/acme.json' has changed, extracting certs.."
 

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -79,7 +79,7 @@ do
 
       # This breaks early as we only need the first successful extraction.
       # For more details see the `SSL_TYPE=letsencrypt` case handling in `setup-stack.sh`.
-      # 
+      #
       # NOTE: HOSTNAME is set via `helper-functions.sh`, it is not the original system HOSTNAME ENV anymore.
       # TODO: SSL_DOMAIN is Traefik specific, it no longer seems relevant and should be considered for removal.
       FQDN_LIST=("${SSL_DOMAIN}" "${HOSTNAME}" "${DOMAINNAME}")

--- a/target/scripts/helper-functions.sh
+++ b/target/scripts/helper-functions.sh
@@ -187,9 +187,9 @@ function _extract_certs_from_acme
 }
 export -f _extract_certs_from_acme
 
-# Remove the `*.` prefix if it exists
+# Remove the `*.` prefix if it exists, else returns the input value
 function _strip_wildcard_prefix {
-  [[ "${1}" == "*."* ]] && echo "${1:2}"
+  [[ "${1}" == "*."* ]] && echo "${1:2}" || echo "${1}"
 }
 
 # ? --------------------------------------------- Notifications

--- a/target/scripts/helper-functions.sh
+++ b/target/scripts/helper-functions.sh
@@ -224,7 +224,8 @@ export -f _notify
 # shellcheck disable=SC2034
 CHKSUM_FILE=/tmp/docker-mailserver-config-chksum
 
-# Compute checksums of monitored files.
+# Compute checksums of monitored files,
+# returned output is lines of hashed content + filepath pairs.
 function _monitored_files_checksums
 {
   # If a wildcard path pattern (or an empty ENV) would yield an invalid path
@@ -232,13 +233,11 @@ function _monitored_files_checksums
   shopt -s nullglob
 
   # React to any cert changes within the following letsencrypt locations:
-  local DYNAMIC_FILES
-  for FILE in /etc/letsencrypt/live/"${SSL_DOMAIN}"/*.pem \
-              /etc/letsencrypt/live/"${HOSTNAME}"/*.pem   \
-              /etc/letsencrypt/live/"${DOMAINNAME}"/*.pem
-  do
-    DYNAMIC_FILES="${DYNAMIC_FILES} ${FILE}"
-  done
+  local CERT_FILES=(
+    /etc/letsencrypt/live/"${SSL_DOMAIN}"/*.pem
+    /etc/letsencrypt/live/"${HOSTNAME}"/*.pem
+    /etc/letsencrypt/live/"${DOMAINNAME}"/*.pem
+  )
 
   (
     cd /tmp/docker-mailserver || exit 1
@@ -248,7 +247,7 @@ function _monitored_files_checksums
       postfix-aliases.cf \
       dovecot-quotas.cf \
       /etc/letsencrypt/acme.json \
-      "${DYNAMIC_FILES}"
+      ${CERT_FILES[@]}
   )
 }
 export -f _monitored_files_checksums

--- a/target/scripts/helper-functions.sh
+++ b/target/scripts/helper-functions.sh
@@ -239,6 +239,9 @@ function _monitored_files_checksums
     /etc/letsencrypt/live/"${DOMAINNAME}"/*.pem
   )
 
+  # CERT_FILES should expand to separate paths, not a single string;
+  # otherwise fails to generate checksums for these file paths.
+  #shellcheck disable=SC2068
   (
     cd /tmp/docker-mailserver || exit 1
     exec sha512sum 2>/dev/null -- \

--- a/test/mail_changedetector.bats
+++ b/test/mail_changedetector.bats
@@ -49,12 +49,12 @@ function teardown_file() {
 @test "checking changedetector: can detect changes & between two containers using same config" {
   echo "" >> "$(private_config_path mail_changedetector_one)/postfix-accounts.cf"
   sleep 15
-  run docker exec mail_changedetector_one /bin/bash -c "supervisorctl tail changedetector"
+  run docker exec mail_changedetector_one /bin/bash -c "supervisorctl tail -3000 changedetector"
   assert_output --partial "postfix: stopped"
   assert_output --partial "postfix: started"
   assert_output --partial "Change detected"
   assert_output --partial "Removed lock"
-  run docker exec mail_changedetector_two /bin/bash -c "supervisorctl tail changedetector"
+  run docker exec mail_changedetector_two /bin/bash -c "supervisorctl tail -3000 changedetector"
   assert_output --partial "postfix: stopped"
   assert_output --partial "postfix: started"
   assert_output --partial "Change detected"


### PR DESCRIPTION
# Description

The `DYNAMIC_FILES` var was quote wrapped, treating all filepaths to create checksums for as a single string that would be ignored instead of processed individually.

Removed the quotes, and changed the for loop to an array which accomplishes the same goal.

This was discovered while investigating [#2321](https://github.com/docker-mailserver/docker-mailserver/issues/2321#issuecomment-994491231), but it's unclear if this will fix that issue.

---

This bug was introduced in https://github.com/docker-mailserver/docker-mailserver/pull/2279 with the `v10.3.0` release.

~~We may want to branch that release tag and cherry pick this commit from master to publish a bugfix (_as we've already merged `v11` changes to master, the bugfix branch is the only way to backport it I think?_).~~ (**RESOLVED:** Decision was to release in `v10.4.0` with the Debian upgrade)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

It'd probably be a good idea to add a test that verifies the cert path is in the checksum file, I'm just a bit pressed on time and resources currently but wanted to get this fix raised while I could spare the time.

If there's no rush to merge I can sort out tests within 7 days depending on how events pan out on my end :sweat_smile: 
