### PR TITLE
Updated ShellCheck to `0.8.0` and Hadolint to `2.8.0`

### DIFF
--- a/.github/workflows/docs-preview-prepare.yml
+++ b/.github/workflows/docs-preview-prepare.yml
@@ -55,12 +55,13 @@ jobs:
       - name: 'Prepare artifact for transfer'
         run: |
           # Save ENV for transfer
-          echo "PR_HEADSHA=${{ github.event.pull_request.head.sha }}" >> pr.env
-          echo "PR_NUMBER=${{ github.event.pull_request.number }}"    >> pr.env
-          echo "PR_TITLE=${{ github.event.pull_request.title }}"      >> pr.env
-          echo "NETLIFY_SITE_PREFIX=${{ env.NETLIFY_SITE_PREFIX }}"   >> pr.env
-          echo "BUILD_DIR=${{ env.BUILD_DIR }}"                       >> pr.env
-
+          {
+            echo "PR_HEADSHA=${{ github.event.pull_request.head.sha }}"
+            echo "PR_NUMBER=${{ github.event.pull_request.number }}"
+            echo "PR_TITLE=${{ github.event.pull_request.title }}"
+            echo "NETLIFY_SITE_PREFIX=${{ env.NETLIFY_SITE_PREFIX }}"
+            echo "BUILD_DIR=${{ env.BUILD_DIR }}"
+          } >> pr.env
           tar --zstd -cf artifact.tar.zst pr.env ${{ env.BUILD_DIR }}
 
       - name: 'Upload artifact for workflow transfer'

--- a/.github/workflows/handle_stalled.yml
+++ b/.github/workflows/handle_stalled.yml
@@ -36,5 +36,5 @@ jobs:
             - a maintainer removes the `meta/stale` label or adds the `stale-bot/ignore` label
             - new activity occurs, such as a new comment
           close-pr-label: "meta/closed due to age or inactivity"
-          closed-pr-message: >
+          close-pr-message: >
             This PR was closed due to inactivity.

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           make shellcheck
         env:
-          SHELLCHECK_VERSION: 0.7.2
+          SHELLCHECK_VERSION: 0.8.0
 
       - name: ECLint
         run: |

--- a/setup.sh
+++ b/setup.sh
@@ -26,6 +26,7 @@ LBLUE="\e[94m"
 RESET="\e[0m"
 
 set -euEo pipefail
+shopt -s inherit_errexit
 trap '__err "${BASH_SOURCE}" "${FUNCNAME[0]:-?}" "${BASH_COMMAND:-?}" "${LINENO:-?}" "${?:-?}"' ERR
 
 function __err

--- a/target/bin/listmailuser
+++ b/target/bin/listmailuser
@@ -8,7 +8,7 @@
 
 function dovecot_quota_to_hr()
 {
-  if [ "${1}" == "-" ]
+  if [[ ${1} == "-" ]]
   then
     echo "~"
   else

--- a/target/bin/setquota
+++ b/target/bin/setquota
@@ -35,7 +35,8 @@ fi
 create_lock # Protect config file with lock to avoid race conditions
 
 touch "${DATABASE}"
-if [ -z "${QUOTA}" ]; then
+if [[ -z "${QUOTA}" ]]
+then
   read -r -s "Enter quota (e.g. 10M): " QUOTA
   echo
   [[ -z "${QUOTA}" ]] && errex "Quota must not be empty. Use 0 for unlimited quota"

--- a/target/bin/setquota
+++ b/target/bin/setquota
@@ -35,7 +35,7 @@ fi
 create_lock # Protect config file with lock to avoid race conditions
 
 touch "${DATABASE}"
-if [[ -z "${QUOTA}" ]]
+if [[ -z ${QUOTA} ]]
 then
   read -r -s "Enter quota (e.g. 10M): " QUOTA
   echo

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -54,7 +54,7 @@ do
   # 0 – files are identical
   # 1 – files differ
   # 2 – inaccessible or missing argument
-  if [ $? -eq 1 ]
+  if [[ ${?} -eq 1 ]]
   then
     _notify 'inf' "$(_log_date) Change detected"
     create_lock # Shared config safety lock

--- a/target/scripts/helpers/relay.sh
+++ b/target/scripts/helpers/relay.sh
@@ -69,7 +69,7 @@ function _populate_relayhost_map
     # note: won't detect domains when lhs has spaces (but who does that?!)
     sed -n '/^\s*[^#[:space:]]/ s/^[^@|]*@\([^|]\+\)|.*$/\1/p' /tmp/docker-mailserver/postfix-accounts.cf
 
-    [ -f /tmp/docker-mailserver/postfix-virtual.cf ] && sed -n '/^\s*[^#[:space:]]/ s/^\s*[^@[:space:]]*@\(\S\+\)\s.*/\1/p' /tmp/docker-mailserver/postfix-virtual.cf
+    [[ -f /tmp/docker-mailserver/postfix-virtual.cf ]] && sed -n '/^\s*[^#[:space:]]/ s/^\s*[^@[:space:]]*@\(\S\+\)\s.*/\1/p' /tmp/docker-mailserver/postfix-virtual.cf
   } | while read -r DOMAIN
   do
     # DOMAIN not already present *and* not ignored

--- a/test/linting/lint.sh
+++ b/test/linting/lint.sh
@@ -15,11 +15,12 @@ fi
 SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 REPO_ROOT="$(realpath "${SCRIPT_DIR}"/../../)"
 
-HADOLINT_VERSION=2.4.1
+HADOLINT_VERSION=2.8.0
 ECLINT_VERSION=2.3.5
-SHELLCHECK_VERSION=0.7.2
+SHELLCHECK_VERSION=0.8.0
 
 set -eEuo pipefail
+shopt -s inherit_errexit
 trap '__log_err "${FUNCNAME[0]:-?}" "${BASH_COMMAND:-?}" ${LINENO:-?} ${?:-?}' ERR
 
 function __log_err
@@ -121,6 +122,9 @@ function _shellcheck
     --wiki-link-count=50
     --enable=all
     --exclude=SC2154
+    --exclude=SC2310
+    --exclude=SC2311
+    --exclude=SC2312
     --source-path=SCRIPTDIR
     "${F_SH} ${F_BIN} ${F_BATS}"
   )

--- a/test/mail_smtponly.bats
+++ b/test/mail_smtponly.bats
@@ -68,7 +68,7 @@ function teardown_file() {
   run docker exec mail_smtponly /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/smtp-only.txt"
   assert_success
   run docker exec mail_smtponly /bin/sh -c 'grep -cE "to=<user2\@external.tld>.*status\=sent" /var/log/mail/mail.log'
-  [ "${status}" -ge 0 ]
+  [[ "${status}" -ge 0 ]]
 }
 
 #

--- a/test/mail_smtponly.bats
+++ b/test/mail_smtponly.bats
@@ -68,7 +68,7 @@ function teardown_file() {
   run docker exec mail_smtponly /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/smtp-only.txt"
   assert_success
   run docker exec mail_smtponly /bin/sh -c 'grep -cE "to=<user2\@external.tld>.*status\=sent" /var/log/mail/mail.log'
-  [[ "${status}" -ge 0 ]]
+  [[ ${status} -ge 0 ]]
 }
 
 #

--- a/test/permit_docker.bats
+++ b/test/permit_docker.bats
@@ -58,5 +58,5 @@ teardown() {
   assert_output --partial "250 2.0.0 Ok: queued as "
 
   repeat_until_success_or_timeout 60 run docker exec mail_smtponly_second_network /bin/sh -c 'grep -cE "to=<user2\@external.tld>.*status\=sent" /var/log/mail/mail.log'
-  [ "${status}" -ge 0 ]
+  [[ "${status}" -ge 0 ]]
 }

--- a/test/permit_docker.bats
+++ b/test/permit_docker.bats
@@ -58,5 +58,5 @@ teardown() {
   assert_output --partial "250 2.0.0 Ok: queued as "
 
   repeat_until_success_or_timeout 60 run docker exec mail_smtponly_second_network /bin/sh -c 'grep -cE "to=<user2\@external.tld>.*status\=sent" /var/log/mail/mail.log'
-  [[ "${status}" -ge 0 ]]
+  [[ ${status} -ge 0 ]]
 }

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -614,7 +614,7 @@ EOF
 
   run docker exec mail /bin/sh -c "grep '^user3@domain\.tld|' -i /tmp/docker-mailserver/postfix-accounts.cf"
   assert_success
-  [ -n "${output}" ]
+  [[ -n ${output} ]]
 }
 
 @test "checking accounts: auser3 should have been added to /tmp/docker-mailserver/postfix-accounts.cf" {
@@ -622,7 +622,7 @@ EOF
 
   run docker exec mail /bin/sh -c "grep '^auser3@domain\.tld|' -i /tmp/docker-mailserver/postfix-accounts.cf"
   assert_success
-  [ -n "${output}" ]
+  [[ -n ${output} ]]
 }
 
 @test "checking accounts: a.ser3 should have been added to /tmp/docker-mailserver/postfix-accounts.cf" {
@@ -630,7 +630,7 @@ EOF
 
   run docker exec mail /bin/sh -c "grep '^a\.ser3@domain\.tld|' -i /tmp/docker-mailserver/postfix-accounts.cf"
   assert_success
-  [ -n "${output}" ]
+  [[ -n ${output} ]]
 }
 
 @test "checking accounts: user3 should have been removed from /tmp/docker-mailserver/postfix-accounts.cf but not auser3" {
@@ -638,11 +638,11 @@ EOF
 
   run docker exec mail /bin/sh -c "grep '^user3@domain\.tld' -i /tmp/docker-mailserver/postfix-accounts.cf"
   assert_failure
-  [ -z "${output}" ]
+  [[ -z ${output} ]]
 
   run docker exec mail /bin/sh -c "grep '^auser3@domain\.tld' -i /tmp/docker-mailserver/postfix-accounts.cf"
   assert_success
-  [ -n "${output}" ]
+  [[ -n ${output} ]]
 }
 
 @test "checking user updating password for user in /tmp/docker-mailserver/postfix-accounts.cf" {
@@ -654,7 +654,7 @@ EOF
   sleep 2
   changepass=$(docker exec mail /bin/sh -c "grep '^user4@domain\.tld' -i /tmp/docker-mailserver/postfix-accounts.cf")
 
-  [ "${initialpass}" != "${changepass}" ]
+  [[ ${initialpass} != "${changepass}" ]]
 
   docker exec mail /bin/sh -c "delmailuser -y auser3@domain.tld"
 
@@ -678,7 +678,7 @@ EOF
     -v "$(duplicate_config_for_container without-accounts/ without-accounts-deleting-user)":/tmp/docker-mailserver/ \
     "${IMAGE_NAME:?}" /bin/sh -c 'delmailuser -y user3@domain.tld'
   assert_success
-  [ -z "${output}" ]
+  [[ -n ${output} ]]
 }
 
 @test "checking accounts: user3 should have been added to /tmp/docker-mailserver/postfix-accounts.cf even when that file does not exist" {
@@ -692,7 +692,7 @@ EOF
     -v "${PRIVATE_CONFIG}/without-accounts/":/tmp/docker-mailserver/ \
     "${IMAGE_NAME:?}" /bin/sh -c 'grep user3@domain.tld -i /tmp/docker-mailserver/postfix-accounts.cf'
   assert_success
-  [ -n "${output}" ]
+  [[ -n ${output} ]]
 }
 
 
@@ -956,7 +956,7 @@ EOF
   assert_success
 
   value=$(grep setup_email_add@example.com "$(private_config_path mail)/postfix-accounts.cf" | awk -F '|' '{print $1}')
-  [ "${value}" = "setup_email_add@example.com" ]
+  [[ ${value} = "setup_email_add@example.com" ]]
   assert_success
 
   wait_for_changes_to_be_detected_in_container mail
@@ -979,15 +979,15 @@ EOF
   assert_success
 
   initialpass=$(grep lorem@impsum.org "$(private_config_path mail)/postfix-accounts.cf" | awk -F '|' '{print $2}')
-  [ "${initialpass}" != "" ]
+  [[ ${initialpass} != "" ]]
   assert_success
 
   run ./setup.sh -c mail email update lorem@impsum.org my password
   assert_success
 
   updatepass=$(grep lorem@impsum.org "$(private_config_path mail)/postfix-accounts.cf" | awk -F '|' '{print $2}')
-  [ "${updatepass}" != "" ]
-  [ "${initialpass}" != "${updatepass}" ]
+  [[ ${updatepass} != "" ]]
+  [[ ${initialpass} != "${updatepass}" ]]
 
   docker exec mail doveadm pw -t "${updatepass}" -p 'my password' | grep 'verified'
   assert_success

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -678,7 +678,7 @@ EOF
     -v "$(duplicate_config_for_container without-accounts/ without-accounts-deleting-user)":/tmp/docker-mailserver/ \
     "${IMAGE_NAME:?}" /bin/sh -c 'delmailuser -y user3@domain.tld'
   assert_success
-  [[ -n ${output} ]]
+  [[ -z ${output} ]]
 }
 
 @test "checking accounts: user3 should have been added to /tmp/docker-mailserver/postfix-accounts.cf even when that file does not exist" {
@@ -956,7 +956,7 @@ EOF
   assert_success
 
   value=$(grep setup_email_add@example.com "$(private_config_path mail)/postfix-accounts.cf" | awk -F '|' '{print $1}')
-  [[ ${value} = "setup_email_add@example.com" ]]
+  [[ ${value} == "setup_email_add@example.com" ]]
   assert_success
 
   wait_for_changes_to_be_detected_in_container mail


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

Just updated the linter versions and fixed a few errors I found on the way. Not sure why there is no new 2.4.0 EdiitorConfig-Checker Image.


<!-- Link the issue which will be fixed (if any) here: -->
Fixes #

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
