### PR TITLE
Removed Dovecot stats configuration for old statistics plugin

### DIFF
--- a/target/dovecot/60-stats.conf
+++ b/target/dovecot/60-stats.conf
@@ -11,15 +11,3 @@ service stats {
     mode = 0
   }
 }
-
-service old-stats {
-  fifo_listener old-stats-mail {
-    mode = 0
-  }
-  fifo_listener old-stats-user {
-    mode = 0
-  }
-  unix_listener old-stats {
-    mode = 0
-  }
-}


### PR DESCRIPTION
# Description

(Running the latest `:edge` image.)

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

I accepted the `v10.4` PR too fast and got the paycheck :D I just went over my logs and saw the line

``` TXT
dovecot: auth: Error: stats: open(old-stats-user) failed: No such file or directory
```

so I had a look again. Turns out, the old stats plugin is deprecated and it suffices to disable the new Dovecot stats. The old stats plugin was opt-in (via `mail_plugins = $mail_plugins imap_quota`) but we have **not** configured this anywhere so the old stats were never active. I guess Dovecot gets confused when it encounters the config for the old plugin which is not even enabled.

Nothing serious but nothing that should be in your log either. I would like to see this in `v10.4` so there is no actual (semi-)regression on a stable release tag. Maybe someone can even confirm?

Sources: <https://doc.dovecot.org/installation_guide/upgrading/from-2.2-to-2.3/?highlight=stats%20plugin>

<!-- Link the issue which will be fixed (if any) here: -->
Fixes a semi-regression introduced in #2292

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
