### PR TITLE
ci(fix): Do not trust user controlled input

### DIFF
--- a/.github/workflows/docs-preview-prepare.yml
+++ b/.github/workflows/docs-preview-prepare.yml
@@ -26,7 +26,7 @@ jobs:
       NETLIFY_SITE_PREFIX: pullrequest-${{ github.event.pull_request.number }}
       NETLIFY_SITE_NAME: dms-doc-previews
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4
 
       - name: 'Build with mkdocs-material via Docker'
         working-directory: docs
@@ -53,12 +53,17 @@ jobs:
       # Minimize risk of upload failure by bundling files to a single compressed archive (tar + zstd).
       # Bundles build dir and env file into a compressed archive, nested file paths will be preserved.
       - name: 'Prepare artifact for transfer'
+        env:
+          # As a precaution, reference this value by an interpolated ENV var;
+          # instead of interpolating user controllable input directly in the shell script..
+          # https://github.com/docker-mailserver/docker-mailserver/issues/2332#issuecomment-998326798
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Save ENV for transfer
           {
             echo "PR_HEADSHA=${{ github.event.pull_request.head.sha }}"
             echo "PR_NUMBER=${{ github.event.pull_request.number }}"
-            echo "PR_TITLE=${{ github.event.pull_request.title }}"
+            echo "PR_TITLE=${PR_TITLE}"
             echo "NETLIFY_SITE_PREFIX=${{ env.NETLIFY_SITE_PREFIX }}"
             echo "BUILD_DIR=${{ env.BUILD_DIR }}"
           } >> pr.env

--- a/.github/workflows/docs-preview-prepare.yml
+++ b/.github/workflows/docs-preview-prepare.yml
@@ -26,7 +26,7 @@ jobs:
       NETLIFY_SITE_PREFIX: pullrequest-${{ github.event.pull_request.number }}
       NETLIFY_SITE_NAME: dms-doc-previews
     steps:
-      - uses: actions/checkout@v2.4
+      - uses: actions/checkout@v2.4.0
 
       - name: 'Build with mkdocs-material via Docker'
         working-directory: docs

--- a/.github/workflows/docs-production-deploy.yml
+++ b/.github/workflows/docs-production-deploy.yml
@@ -26,7 +26,7 @@ jobs:
     name: 'Deploy Docs'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.4
+      - uses: actions/checkout@v2.4.0
 
       - name: 'Check if deploy is for a `v<major>.<minor>` tag version instead of `edge`'
         if: startsWith(github.ref, 'refs/tags/')
@@ -75,10 +75,10 @@ jobs:
     needs: deploy
     steps:
       - name: 'Checkout the tagged commit (shallow clone)'
-        uses: actions/checkout@v2.4
+        uses: actions/checkout@v2.4.0
 
       - name: 'Checkout the docs deployment branch to a subdirectory'
-        uses: actions/checkout@v2.4
+        uses: actions/checkout@v2.4.0
         with:
           ref: gh-pages
           path: gh-pages

--- a/.github/workflows/docs-production-deploy.yml
+++ b/.github/workflows/docs-production-deploy.yml
@@ -26,7 +26,7 @@ jobs:
     name: 'Deploy Docs'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4
 
       - name: 'Check if deploy is for a `v<major>.<minor>` tag version instead of `edge`'
         if: startsWith(github.ref, 'refs/tags/')
@@ -75,10 +75,10 @@ jobs:
     needs: deploy
     steps:
       - name: 'Checkout the tagged commit (shallow clone)'
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2.4
 
       - name: 'Checkout the docs deployment branch to a subdirectory'
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2.4
         with:
           ref: gh-pages
           path: gh-pages


### PR DESCRIPTION
# Description

The prepare workflow runs in an untrusted context already and thus should not have anything worthwhile to exploit.

However care should still be taken to avoid interpolating expressions into shell scripts directly that is data a user can control the value of. Especially to avoid any maintainer referencing an existing workflow from copying a risky snippet unaware of different security contexts for workflows.

In this case, as per Github Documentation and referenced issue comment, the PR title is user controllable data, which if directly interpolated into the shell script being run (as it previously was), allows for injecting commands to execute.

---

Additionally bumps the checkout action from `2.3` to `2.4` (_I only did this for the docs workflows, all the others still keep the checkout action at the current `@v2.3.4`_). Let me know if you want me to handle that here or via separate PR (_I thought we had some automation regarding that?_)

The referenced issue regarding the netlify deployment action for our previews does not have a vulnerability that concerns us, and our version of `1.2` now will also use the just released `1.2.3` update that contains the mentioned commits of interest by the user reporting the vulnerability concern, so we're good on that front regardless :+1: 

Fixes #2332

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
