### PR TITLE
Update links to dovecot docs

### DIFF
--- a/config/dovecot.cf
+++ b/config/dovecot.cf
@@ -1,4 +1,4 @@
 # File for additional dovecot configurations.
-# For more informations read http://wiki.dovecot.org/BasicConfiguration
+# For more informations read https://doc.dovecot.org/configuration_manual/quick_configuration/
 
 #mail_max_userip_connections = 50

--- a/docs/content/config/advanced/override-defaults/dovecot.md
+++ b/docs/content/config/advanced/override-defaults/dovecot.md
@@ -5,7 +5,7 @@ title: 'Override the Default Configs | Dovecot'
 ## Add Configuration
 
 The Dovecot default configuration can easily be extended providing a `docker-data/dms/config/dovecot.cf` file.
-[Dovecot documentation](https://wiki.dovecot.org) remains the best place to find configuration options.
+[Dovecot documentation](https://doc.dovecot.org/configuration_manual/) remains the best place to find configuration options.
 
 Your `docker-mailserver` folder should look like this example:
 


### PR DESCRIPTION
# Description

https://wiki.dovecot.org seems stale/outdated.  Various links on the dovecot wiki site indicate docs have moved to https://doc.dovecot.org.  Example: https://wiki.dovecot.org/BasicConfiguration

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)
