### PR TITLE
tests(fix): Align with upstream `testssl` field name change

### DIFF
--- a/test/security_tls_cipherlists.bats
+++ b/test/security_tls_cipherlists.bats
@@ -160,7 +160,7 @@ function compare_cipherlist() {
     local RESULTS_FILE=$2
     local EXPECTED_CIPHERLIST=$3
 
-    run jq '.scanResult[0].fs[] | select(.id=="'"${TARGET_CIPHERLIST}"'") | .finding' "${TLS_RESULTS_DIR}/${RESULTS_FILE}"
+    run jq '.scanResult[0].serverPreferences[] | select(.id=="'"${TARGET_CIPHERLIST}"'") | .finding' "${TLS_RESULTS_DIR}/${RESULTS_FILE}"
     assert_success
     assert_output "${EXPECTED_CIPHERLIST}"
 }


### PR DESCRIPTION
# Description

The field name to check in JSON output was [recently changed for the cipherlist results](https://github.com/drwetter/testssl.sh/pull/2064), causing tests to fail.

---

This should resolve the current test failure for [an open PR](https://github.com/docker-mailserver/docker-mailserver/pull/2342). Although the change was 3 weeks ago, it's only appearing now I think as releases (or updated builds of `3.1-dev` rather) being published to DockerHub was handled manually, they [now have a paid subscription for automated builds](https://github.com/drwetter/testssl.sh/issues/1939#issuecomment-1003390156) which was announced in the past 12 hours, with new image updates.

It's unclear when the `3.2` release will arrive, but [`3.0` has seen a final / non-rc release back in October](https://github.com/drwetter/testssl.sh/releases/tag/v3.0), it's apparently [missing out on all of this from `3.1-dev`](https://github.com/drwetter/testssl.sh/blob/3.1dev/CHANGELOG.md), but seems to be compatible with our tests if you'd rather we switch to that stable tag instead of the rolling release `3.1-dev`. Both images received the JSON field change as a fix,so that change is required regardless.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
