### PR TITLE
Make TLS tests more reliable

### DIFF
--- a/test/security_tls_cipherlists.bats
+++ b/test/security_tls_cipherlists.bats
@@ -127,7 +127,7 @@ function collect_cipherlist_data() {
         "${NAME}" # Image name
     assert_success
 
-    wait_for_finished_setup_in_container tls_test_cipherlists
+    wait_for_tcp_port_in_container 25 tls_test_cipherlists
     # NOTE: An rDNS query for the container IP will resolve to `<container name>.<network name>.`
 
     # Make directory with test user ownership. Avoids Docker creating with root ownership.
@@ -160,7 +160,7 @@ function compare_cipherlist() {
     local RESULTS_FILE=$2
     local EXPECTED_CIPHERLIST=$3
 
-    run jq '.scanResult[0].fs[] | select(.id=="'"${TARGET_CIPHERLIST}"'") | .finding' "${TLS_RESULTS_DIR}/${RESULTS_FILE}"
+    run jq '.scanResult[0].serverPreferences[] | select(.id=="'"${TARGET_CIPHERLIST}"'") | .finding' "${TLS_RESULTS_DIR}/${RESULTS_FILE}"
     assert_success
     assert_output "${EXPECTED_CIPHERLIST}"
 }


### PR DESCRIPTION
# Description

The TLS tests can fail, if `testssl` starts scanning, while the container is not fully started yet:

<details>
<summary>Failed tests</summary>

```
 ✗ checking tls: cipher list - rsa intermediate [25151]
   (from function `assert_success' in file test/test_helper/bats-assert/src/assert.bash, line 114,
    from function `compare_cipherlist' in file test/security_tls_cipherlists.bats, line 164,
    from function `check_cipherlists' in file test/security_tls_cipherlists.bats, line 176,
    from function `check_ports' in file test/security_tls_cipherlists.bats, line 90,
    in test file test/security_tls_cipherlists.bats, line 47)
     `check_ports 'rsa' 'intermediate'' failed with status 5
   [ TASKLOG ]  mail.example.test is up and running

   -- command failed --
   status : 5
   output : jq: error (at /tmp/results/rsa/intermediate/port_25.json:14): Cannot iterate over null (null)
   --

   tls_test_cipherlists
 ✗ checking tls: cipher list - rsa modern [22107]
   (from function `assert_success' in file test/test_helper/bats-assert/src/assert.bash, line 114,
    from function `compare_cipherlist' in file test/security_tls_cipherlists.bats, line 164,
    from function `check_cipherlists' in file test/security_tls_cipherlists.bats, line 179,
    from function `check_ports' in file test/security_tls_cipherlists.bats, line 90,
    in test file test/security_tls_cipherlists.bats, line 51)
     `check_ports 'rsa' 'modern'' failed with status 5
   [ TASKLOG ]  mail.example.test is up and running

   -- command failed --
   status : 5
   output : jq: error (at /tmp/results/rsa/modern/port_25.json:14): Cannot iterate over null (null)
   --

   tls_test_cipherlists
 ✗ checking tls: cipher list - ecdsa intermediate [22167]
   (from function `assert_success' in file test/test_helper/bats-assert/src/assert.bash, line 114,
    from function `compare_cipherlist' in file test/security_tls_cipherlists.bats, line 164,
    from function `check_cipherlists' in file test/security_tls_cipherlists.bats, line 176,
    from function `check_ports' in file test/security_tls_cipherlists.bats, line 90,
    in test file test/security_tls_cipherlists.bats, line 55)
     `check_ports 'ecdsa' 'intermediate'' failed with status 5
   [ TASKLOG ]  mail.example.test is up and running

   -- command failed --
   status : 5
   output : jq: error (at /tmp/results/ecdsa/intermediate/port_25.json:14): Cannot iterate over null (null)
   --

   tls_test_cipherlists
 ✓ checking tls: cipher list - ecdsa modern [24607]
 ✗ checking tls: cipher list - ecdsa intermediate, with rsa fallback [29217]
   (from function `assert_success' in file test/test_helper/bats-assert/src/assert.bash, line 114,
    from function `compare_cipherlist' in file test/security_tls_cipherlists.bats, line 164,
    from function `check_cipherlists' in file test/security_tls_cipherlists.bats, line 176,
    from function `check_ports' in file test/security_tls_cipherlists.bats, line 90,
    in test file test/security_tls_cipherlists.bats, line 66)
     `check_ports 'ecdsa' 'intermediate' 'rsa'' failed with status 5
   [ TASKLOG ]  mail.example.test is up and running

   -- command failed --
   status : 5
   output : jq: error (at /tmp/results/ecdsa_rsa/intermediate/port_25.json:14): Cannot iterate over null (null)
   --

   tls_test_cipherlists
```

</details>


<details>
<summary>/tmp/results/rsa/intermediate/port_25.json</summary>

```
{
          "Invocation"  : "testssl.sh --quiet --warnings=batch --mode parallel --overwrite --preference --jsonfile-pretty port_25.json --starttls smtp example.test:25",
          "at"          : "b9aba4dd4e0c:/home/testssl/bin/openssl.Linux.x86_64",
          "version"     : "3.1dev ",
          "openssl"     : "OpenSSL 1.0.2-chacha from Jan 18 17:12:17 2019",
          "startTime"   : "1640945987",
          "scanResult"  : [
                            {
                                "id"           : "scanProblem",
                                "severity"     : "FATAL",
                                "finding"      : "Can't connect to '172.21.0.2:25' Make sure a firewall is not between you and your scanning target!"
                           }          ],
                    "scanTime"  : "Scan interrupted"
}
```
</details>

`wait_for_finished_setup_in_container` does not guarantee, that postfix is running and listening on port 25.

`wait_for_tcp_port_in_container` is the better choise.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
