### PR TITLE
Fix harmless startup errors

### DIFF
--- a/target/bin/delmailuser
+++ b/target/bin/delmailuser
@@ -101,7 +101,7 @@ do
 
   if [[ -f ${DATABASE} ]]
   then
-    if ! sedfile -i "/^${EMAIL}|/d" "${DATABASE}"
+    if ! sedfile --strict -i "/^${EMAIL}|/d" "${DATABASE}"
     then
       echo "${UNESCAPED_EMAIL} couldn't be deleted in ${DATABASE}." >&2
       ERROR=true
@@ -126,7 +126,7 @@ do
   # remove quota directives
   if [[ -f ${QUOTA_DATABASE} ]]
   then
-    if ! sedfile -i -e "/^${EMAIL}:.*$/d" "${QUOTA_DATABASE}"
+    if ! sedfile --strict -i -e "/^${EMAIL}:.*$/d" "${QUOTA_DATABASE}"
     then
       echo "Quota for ${UNESCAPED_EMAIL} couldn't be deleted in ${QUOTA_DATABASE}." >&2
     fi

--- a/target/bin/sedfile
+++ b/target/bin/sedfile
@@ -14,19 +14,20 @@ set -ueo pipefail
 HASHTOOL="sha1sum"
 SKIP_ERROR=0
 
+if [[ $# -lt 3 ]]
+then
+  echo "Error:  At least, three parameters must be given."
+  echo "Syntax: sedfile -i <replace/delete operation> <file>"
+  echo
+  exit 1
+fi >&2
+
 [[ -f /CONTAINER_START ]] && SKIP_ERROR=1 # Hide error, if container was restarted.
 if [[ "${1}" == "--strict" ]]         # Show error every time.
 then
   SKIP_ERROR=0
   shift
 fi
-
-if [[ $# -lt 1 ]]
-then
-  echo "Error: No file given."
-  echo
-  exit 1
-fi >&2
 
 # get last argument
 FILE=${*: -1}

--- a/target/bin/sedfile
+++ b/target/bin/sedfile
@@ -9,7 +9,7 @@ set -ueo pipefail
 HASHTOOL="sha1sum"
 SKIP_ERROR=0
 
-[[ -f /FIRST_START ]] && SKIP_ERROR=1 # Hide error, if container was restarted.
+[[ -f /CONTAINER_START ]] && SKIP_ERROR=1 # Hide error, if container was restarted.
 if [[ "${1}" == "--strict" ]]         # Show error every time.
 then
   SKIP_ERROR=0

--- a/target/bin/sedfile
+++ b/target/bin/sedfile
@@ -4,6 +4,11 @@
 # Error output is surpressed, when container is restarted to avoid harmless error messages.
 # Use "--strict" as first parameter, to fail regardless of the container state (fresh or restarted).
 
+# When to use sedfile?
+# Is a file change optional? --> use regular 'sed -i'
+# Is a file change expected? --> use 'sedfile --strict -i'
+# Is a file change only on the first container run expected? --> use 'sedfile -i'
+
 set -ueo pipefail
 
 HASHTOOL="sha1sum"

--- a/target/bin/sedfile
+++ b/target/bin/sedfile
@@ -1,10 +1,20 @@
 #!/bin/bash
 
-# wrapper for 'sed -i': fail if file was not modified by sed
+# Wrapper for 'sed -i': fail if file was not modified by sed and container was not restarted.
+# Error output is surpressed, when container is restarted to avoid harmless error messages.
+# Use "--strict" as first parameter, to fail regardless of the container state (fresh or restarted).
 
 set -ueo pipefail
 
 HASHTOOL="sha1sum"
+SKIP_ERROR=0
+
+[[ -f /FIRST_START ]] && SKIP_ERROR=1 # Hide error, if container was restarted.
+if [[ "${1}" == "--strict" ]]         # Show error every time.
+then
+  SKIP_ERROR=0
+  shift
+fi
 
 if [[ $# -lt 1 ]]
 then
@@ -21,9 +31,10 @@ sed "$@"
 NEW=$(${HASHTOOL} "${FILE}")
 
 # fail if file was not modified
-if [[ ${OLD} == "${NEW}" ]]
+if [[ ${OLD} == "${NEW}" ]] && [[ ${SKIP_ERROR} -eq 0 ]]
 then
   echo "Error: sed $*"
   exit 1
 fi >&2
+
 exit 0

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -264,7 +264,7 @@ start_misc
 start_daemons
 
 # marker to check, if container was restarted
-date > /FIRST_START
+date > /CONTAINER_START
 
 _notify 'tasklog' "${HOSTNAME} is up and running"
 

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -263,7 +263,7 @@ fix
 start_misc
 start_daemons
 
-# marker for sedfile wrapper
+# marker to check, if container was restarted
 date > /FIRST_START
 
 _notify 'tasklog' "${HOSTNAME} is up and running"

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -263,6 +263,9 @@ fix
 start_misc
 start_daemons
 
+# marker for sedfile wrapper
+date > /FIRST_START
+
 _notify 'tasklog' "${HOSTNAME} is up and running"
 
 touch /var/log/mail/mail.log

--- a/target/scripts/startup/fixes-stack.sh
+++ b/target/scripts/startup/fixes-stack.sh
@@ -40,11 +40,17 @@ function _fix_var_amavis_permissions
 function _fix_cleanup_clamav
 {
   _notify 'task' 'Cleaning up disabled ClamAV'
-  rm /etc/logrotate.d/clamav-* /etc/cron.d/clamav-freshclam || _notify 'err' 'Failed to remove ClamAV configuration'
+  rm /etc/logrotate.d/clamav-* /etc/cron.d/clamav-freshclam || {
+    # show error only first container start
+    [[ ! -f /FIRST_START ]] && _notify 'err' 'Failed to remove ClamAV configuration'
+  }
 }
 
 function _fix_cleanup_spamassassin
 {
   _notify 'task' 'Cleaning up disabled SpamAssassin'
-  rm /etc/cron.daily/spamassassin || _notify 'err' 'Failed to remove SpamAssassin configuration'
+  rm /etc/cron.daily/spamassassin || {
+    # show error only first container start
+    [[ ! -f /FIRST_START ]] && _notify 'err' 'Failed to remove SpamAssassin configuration'
+  }
 }

--- a/target/scripts/startup/fixes-stack.sh
+++ b/target/scripts/startup/fixes-stack.sh
@@ -40,7 +40,7 @@ function _fix_var_amavis_permissions
 function _fix_cleanup_clamav
 {
   _notify 'task' 'Cleaning up disabled ClamAV'
-  rm /etc/logrotate.d/clamav-* /etc/cron.d/clamav-freshclam || {
+  rm /etc/logrotate.d/clamav-* /etc/cron.d/clamav-freshclam 2>/dev/null || {
     # show error only on first container start
     [[ ! -f /CONTAINER_START ]] && _notify 'err' 'Failed to remove ClamAV configuration'
   }
@@ -49,7 +49,7 @@ function _fix_cleanup_clamav
 function _fix_cleanup_spamassassin
 {
   _notify 'task' 'Cleaning up disabled SpamAssassin'
-  rm /etc/cron.daily/spamassassin || {
+  rm /etc/cron.daily/spamassassin 2>/dev/null || {
     # show error only on first container start
     [[ ! -f /CONTAINER_START ]] && _notify 'err' 'Failed to remove SpamAssassin configuration'
   }

--- a/target/scripts/startup/fixes-stack.sh
+++ b/target/scripts/startup/fixes-stack.sh
@@ -42,7 +42,7 @@ function _fix_cleanup_clamav
   _notify 'task' 'Cleaning up disabled ClamAV'
   rm /etc/logrotate.d/clamav-* /etc/cron.d/clamav-freshclam || {
     # show error only on first container start
-    [[ ! -f /FIRST_START ]] && _notify 'err' 'Failed to remove ClamAV configuration'
+    [[ ! -f /CONTAINER_START ]] && _notify 'err' 'Failed to remove ClamAV configuration'
   }
 }
 
@@ -51,6 +51,6 @@ function _fix_cleanup_spamassassin
   _notify 'task' 'Cleaning up disabled SpamAssassin'
   rm /etc/cron.daily/spamassassin || {
     # show error only on first container start
-    [[ ! -f /FIRST_START ]] && _notify 'err' 'Failed to remove SpamAssassin configuration'
+    [[ ! -f /CONTAINER_START ]] && _notify 'err' 'Failed to remove SpamAssassin configuration'
   }
 }

--- a/target/scripts/startup/fixes-stack.sh
+++ b/target/scripts/startup/fixes-stack.sh
@@ -41,7 +41,7 @@ function _fix_cleanup_clamav
 {
   _notify 'task' 'Cleaning up disabled ClamAV'
   rm /etc/logrotate.d/clamav-* /etc/cron.d/clamav-freshclam || {
-    # show error only first container start
+    # show error only on first container start
     [[ ! -f /FIRST_START ]] && _notify 'err' 'Failed to remove ClamAV configuration'
   }
 }
@@ -50,7 +50,7 @@ function _fix_cleanup_spamassassin
 {
   _notify 'task' 'Cleaning up disabled SpamAssassin'
   rm /etc/cron.daily/spamassassin || {
-    # show error only first container start
+    # show error only on first container start
     [[ ! -f /FIRST_START ]] && _notify 'err' 'Failed to remove SpamAssassin configuration'
   }
 }


### PR DESCRIPTION
# Description

When restarting the container (`docker restart mailserver`), depending on someones setup, the following errors may be displayed:

```
rm: cannot remove '/etc/cron.d/clamav-freshclam': No such file or directory

Error: sed -i /^smtpd_recipient_restrictions = / s/, reject_rbl_client zen.spamhaus.org// /etc/postfix/main.cf
Error: sed -i -r -e s|^(MinProtocol).*|\1 = TLSv1| -e s|^(CipherString).*|\1 = DEFAULT@SECLEVEL=1| /usr/lib/ssl/openssl.cnf
Error: sed -i -r s|^(smtpd_tls_chain_files =).*|\1 /etc/dms/tls/key /etc/dms/tls/cert| /etc/postfix/main.cf
Error: sed -i -r -e s|^(ssl_key =).*|\1 </etc/dms/tls/key| -e s|^(ssl_cert =).*|\1 </etc/dms/tls/cert| /etc/dovecot/conf.d/10-ssl.conf
```

These errors are harmless and are only triggered, because the file deletion/modification already took place on the first container start.

To bypass this, a marker file `CONTAINER_START` is created after the container has started.

`sedfile` checks if that file exists. If so, no error is displayed on a failure.
There may be circumstances, where `sedfile` should fail, regardless of the container state (fresh or restarted). For that, pass `--strict` as first parameter to `sedfile`. At the moment this is only the case for the `delmailuser` script.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
