### PR TITLE
add env var `LOGWATCH_SENDER`

### DIFF
--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -266,9 +266,9 @@ Recipient address for pflogsumm reports.
 
 ##### PFLOGSUMM_SENDER
 
-From address for pflogsumm reports.
+Sender address (`FROM`) for pflogsumm reports if pflogsumm reports are enabled.
 
-- **not set** => Use REPORT_SENDER or POSTMASTER_ADDRESS
+- **not set** => Use REPORT_SENDER
 - => Specify the sender address
 
 ##### LOGWATCH_INTERVAL
@@ -288,9 +288,9 @@ Recipient address for logwatch reports if they are enabled.
 
 ##### LOGWATCH_SENDER
 
-From address for logwatch reports if they are enabled.
+Sender address (`FROM`) for logwatch reports if logwatch reports are enabled.
 
-- **not set** => Use REPORT_SENDER or POSTMASTER_ADDRESS
+- **not set** => Use REPORT_SENDER
 - => Specify the sender address
 
 ##### REPORT_RECIPIENT (deprecated)

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -286,6 +286,13 @@ Recipient address for logwatch reports if they are enabled.
 - **not set** => Use REPORT_RECIPIENT or POSTMASTER_ADDRESS
 - => Specify the recipient address(es)
 
+##### LOGWATCH_SENDER
+
+From address for logwatch reports if they are enabled.
+
+- **not set** => Use REPORT_SENDER or POSTMASTER_ADDRESS
+- => Specify the sender address
+
 ##### REPORT_RECIPIENT (deprecated)
 
 Enables a report being sent (created by pflogsumm) on a regular basis.

--- a/mailserver.env
+++ b/mailserver.env
@@ -207,6 +207,12 @@ LOGWATCH_INTERVAL=
 # => Specify the recipient address(es)
 LOGWATCH_RECIPIENT=
 
+# From address for logwatch reports if they are enabled.
+#
+# not set => Use REPORT_SENDER or POSTMASTER_ADDRESS
+# => Specify the sender address
+LOGWATCH_SENDER=
+
 # Enables a report being sent (created by pflogsumm) on a regular basis. (deprecated)
 # **0** => Report emails are disabled
 # 1 => Using POSTMASTER_ADDRESS as the recipient

--- a/mailserver.env
+++ b/mailserver.env
@@ -188,9 +188,9 @@ PFLOGSUMM_TRIGGER=
 # => Specify the recipient address(es)
 PFLOGSUMM_RECIPIENT=
 
-# From address for pflogsumm reports.
+# Sender address (`FROM`) for pflogsumm reports if pflogsumm reports are enabled.
 #
-# not set => Use REPORT_SENDER or POSTMASTER_ADDRESS
+# not set => Use REPORT_SENDER
 # => Specify the sender address
 PFLOGSUMM_SENDER=
 
@@ -207,9 +207,9 @@ LOGWATCH_INTERVAL=
 # => Specify the recipient address(es)
 LOGWATCH_RECIPIENT=
 
-# From address for logwatch reports if they are enabled.
+# Sender address (`FROM`) for logwatch reports if logwatch reports are enabled.
 #
-# not set => Use REPORT_SENDER or POSTMASTER_ADDRESS
+# not set => Use REPORT_SENDER
 # => Specify the sender address
 LOGWATCH_SENDER=
 

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -47,6 +47,7 @@ function _setup_default_vars
 
   # update REPORT_SENDER - must be done done after _check_hostname
   REPORT_SENDER="${REPORT_SENDER:=mailserver-report@${HOSTNAME}}"
+  LOGWATCH_SENDER="${LOGWATCH_SENDER:=${REPORT_SENDER}}"
   PFLOGSUMM_SENDER="${PFLOGSUMM_SENDER:=${REPORT_SENDER}}"
 
   # set PFLOGSUMM_TRIGGER here for backwards compatibility
@@ -69,6 +70,7 @@ function _setup_default_vars
   LOGWATCH_RECIPIENT="${LOGWATCH_RECIPIENT:=${REPORT_RECIPIENT}}"
 
   VARS[LOGWATCH_RECIPIENT]="${LOGWATCH_RECIPIENT}"
+  VARS[LOGWATCH_SENDER]="${LOGWATCH_SENDER}"
   VARS[PFLOGSUMM_RECIPIENT]="${PFLOGSUMM_RECIPIENT}"
   VARS[PFLOGSUMM_SENDER]="${PFLOGSUMM_SENDER}"
   VARS[PFLOGSUMM_TRIGGER]="${PFLOGSUMM_TRIGGER}"
@@ -1483,6 +1485,8 @@ function _setup_logwatch
   _notify 'inf' "Enable logwatch reports with recipient ${LOGWATCH_RECIPIENT}"
 
   echo 'LogFile = /var/log/mail/freshclam.log' >>/etc/logwatch/conf/logfiles/clam-update.conf
+
+  echo "MailFrom = ${LOGWATCH_SENDER}" >> /etc/logwatch/conf/logwatch.conf
 
   case "${LOGWATCH_INTERVAL}" in
     'daily' )


### PR DESCRIPTION
# Description

Follow-up to #2360, but using `/etc/logwatch/conf/logwatch.conf` as config file.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

This *might* be considered to be a breaking change if someone relied on the fact that `REPORT_SENDER` wouldn't influence the sender address for logwatch reports. But when I started using this project, I was actually expecting it would.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
