### PR TITLE
docs(deps): bump mkdocs-material to v8.1.6

### DIFF
--- a/.github/workflows/scripts/docs/build-docs.sh
+++ b/.github/workflows/scripts/docs/build-docs.sh
@@ -10,7 +10,7 @@ docker run \
   --user "$(id -u):$(id -g)" \
   --volume "${PWD}:/docs" \
   --name "build-docs" \
-  squidfunk/mkdocs-material:8.1.1 build --strict
+  squidfunk/mkdocs-material:8.1.6 build --strict
 
 # Remove unnecessary build artifacts: https://github.com/squidfunk/mkdocs-material/issues/2519
 # site/ is the build output folder.


### PR DESCRIPTION
# Description

bump mkdocs-material to v8.1.6 

[Changelog for v8.1.2](https://github.com/squidfunk/mkdocs-material/releases/tag/8.1.2)
[Changelog for v8.1.3](https://github.com/squidfunk/mkdocs-material/releases/tag/8.1.3)
[Changelog for v8.1.4](https://github.com/squidfunk/mkdocs-material/releases/tag/8.1.4)
[Changelog for v8.1.5](https://github.com/squidfunk/mkdocs-material/releases/tag/8.1.5)
[Changelog for v8.1.6](https://github.com/squidfunk/mkdocs-material/releases/tag/8.1.6)

All containing mainly improvements and regression fixes

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
