### PR TITLE
docs(kubernetes): fix image name in example

### DIFF
--- a/docs/content/config/advanced/kubernetes.md
+++ b/docs/content/config/advanced/kubernetes.md
@@ -176,7 +176,7 @@ spec:
       hostname: mail
       containers:
         - name: mailserver
-          image: docker.io/docker-mailserver/docker-mailserver:latest
+          image: docker.io/mailserver/docker-mailserver:latest
           imagePullPolicy: IfNotPresent
 
           securityContext:


### PR DESCRIPTION
# Description

The current image name is incorrect:

`docker pull docker.io/docker-mailserver/docker-mailserver:latest`

```
Error response from daemon: pull access denied for docker-mailserver/docker-mailserver, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (none)
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works (none)
- [x] New and existing unit tests pass locally with my changes (none)
