### PR TITLE
Rootless Podman security update

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ chmod a+x ./setup.sh
    - [_only_ basic `VAR=VAL`](https://docs.docker.com/compose/env-file/) is supported (**do not** quote your values!)
    - variable substitution is **not** supported (e.g. :no_entry_sign: `OVERRIDE_HOSTNAME=$HOSTNAME.$DOMAINNAME` :no_entry_sign:)
 
+**Note:** If you're using podman, make sure to read the related [documentation](https://docker-mailserver.github.io/docker-mailserver/edge/config/advanced/podman/)
+
 ### Get up and running
 
 #### First Things First

--- a/mailserver.env
+++ b/mailserver.env
@@ -46,9 +46,12 @@ UPDATE_CHECK_INTERVAL=1d
 # **WARNING**: Adding the docker network's gateway to the list of trusted hosts, e.g. using the `network` or
 # `connected-networks` option, can create an open relay
 # https://github.com/docker-mailserver/docker-mailserver/issues/1405#issuecomment-590106498
-# empty => localhost only
-# host => Add docker host (ipv4 only)
-# network => Add all docker containers (ipv4 only)
+# The same can happen for rootless podman. To prevent this, set the value to "none" or configure slirp4netns
+# https://github.com/docker-mailserver/docker-mailserver/issues/2377
+# <empty> => localhost and container ip only
+# none => Explicitly force authentication
+# host => Add docker container network (ipv4 only)
+# network => Add all docker container networks (ipv4 only)
 # connected-networks => Add all connected docker networks (ipv4 only)
 PERMIT_DOCKER=
 

--- a/mailserver.env
+++ b/mailserver.env
@@ -48,7 +48,7 @@ UPDATE_CHECK_INTERVAL=1d
 # https://github.com/docker-mailserver/docker-mailserver/issues/1405#issuecomment-590106498
 # The same can happen for rootless podman. To prevent this, set the value to "none" or configure slirp4netns
 # https://github.com/docker-mailserver/docker-mailserver/issues/2377
-# <empty> => localhost and container ip only
+# <empty> => container ip only
 # none => Explicitly force authentication
 # host => Add docker container network (ipv4 only)
 # network => Add all docker container networks (ipv4 only)

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -1155,7 +1155,7 @@ function _setup_docker_permit
 
   case "${PERMIT_DOCKER}" in
     "none" )
-      _notify 'inf' "Clearing my networks"
+      _notify 'inf' "Clearing Postfix's 'mynetworks'"
       postconf -e "mynetworks ="
       ;;
 

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -1154,6 +1154,11 @@ function _setup_docker_permit
   done < <(ip -o -4 addr show type veth | grep -E -o '[0-9\.]+/[0-9]+')
 
   case "${PERMIT_DOCKER}" in
+    "none" )
+      _notify 'inf' "Clearing my networks"
+      postconf -e "mynetworks ="
+      ;;
+
     "host" )
       _notify 'inf' "Adding ${CONTAINER_NETWORK}/16 to my networks"
       postconf -e "$(postconf | grep '^mynetworks =') ${CONTAINER_NETWORK}/16"

--- a/test/permit_docker.bats
+++ b/test/permit_docker.bats
@@ -1,7 +1,7 @@
 load 'test_helper/common'
 
 NON_DEFAULT_DOCKER_MAIL_NETWORK_NAME=non-default-docker-mail-network
-setup() {
+setup_file() {
     docker network create --driver bridge "${NON_DEFAULT_DOCKER_MAIL_NETWORK_NAME}"
 	docker network create --driver bridge "${NON_DEFAULT_DOCKER_MAIL_NETWORK_NAME}2"
 	# use two networks (default ("bridge") and our custom network) to recreate problematic test case where PERMIT_DOCKER=host would not help
@@ -33,12 +33,26 @@ setup() {
 
     # wait until postfix is up
     wait_for_smtp_port_in_container mail_smtponly_second_network
+
+	# create another container that enforces authentication even on local connections
+	docker run -d --name mail_smtponly_force_authentication \
+				-v "${PRIVATE_CONFIG}":/tmp/docker-mailserver \
+				-v "$(pwd)/test/test-files":/tmp/docker-mailserver-test:ro \
+				-e SMTP_ONLY=1 \
+				-e PERMIT_DOCKER=none \
+				-e DMS_DEBUG=0 \
+				-e OVERRIDE_HOSTNAME=mail.my-domain.com \
+				-t "${NAME}"
+
+    # wait until postfix is up
+    wait_for_smtp_port_in_container mail_smtponly_force_authentication
 }
 
-teardown() {
+teardown_file() {
     docker logs mail_smtponly_second_network
     docker rm -f mail_smtponly_second_network \
-		        mail_smtponly_second_network_sender
+		        mail_smtponly_second_network_sender \
+				mail_smtponly_force_authentication
     docker network rm "${NON_DEFAULT_DOCKER_MAIL_NETWORK_NAME}" "${NON_DEFAULT_DOCKER_MAIL_NETWORK_NAME}2"
 }
 
@@ -56,7 +70,17 @@ teardown() {
   # we should be able to send from the other container on the second network!
   run docker exec mail_smtponly_second_network_sender /bin/sh -c "nc mail_smtponly_second_network 25 < /tmp/docker-mailserver-test/email-templates/smtp-only.txt"
   assert_output --partial "250 2.0.0 Ok: queued as "
-
   repeat_until_success_or_timeout 60 run docker exec mail_smtponly_second_network /bin/sh -c 'grep -cE "to=<user2\@external.tld>.*status\=sent" /var/log/mail/mail.log'
+  [[ ${status} -ge 0 ]]
+}
+
+@test "checking PERMIT_DOCKER: none" {
+  run docker exec mail_smtponly_force_authentication /bin/sh -c "postconf -e smtp_host_lookup=no"
+  assert_success
+  run docker exec mail_smtponly_force_authentication /bin/sh -c "/etc/init.d/postfix reload"
+  assert_success
+  # the mailserver should require authentication and a protocol error should occur when using TLS
+  run docker exec mail_smtponly_force_authentication /bin/sh -c "nc localhost 25 < /tmp/docker-mailserver-test/email-templates/smtp-only.txt"
+  assert_output --partial "550 5.5.1 Protocol error"
   [[ ${status} -ge 0 ]]
 }


### PR DESCRIPTION
# Description

This PR includes security related documentation to run docker-mailserver with podman in rootless mode. See the linked issue for more details on the security concerns.

Personally I would like to set `PERMIT_DOCKER=none` to the new default in `mailserver.env` because it enforces authentication even from localhost and therefore is more secure, but this would result in a breaking change for users that have authentication-less setups for their localhost. The decision is up to you :)

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #2377

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
