### PR TITLE
fix: double occurence of `/etc/postfix/regexp`

### DIFF
--- a/target/scripts/helpers/aliases.sh
+++ b/target/scripts/helpers/aliases.sh
@@ -43,9 +43,13 @@ function _handle_postfix_regexp_config
     _notify 'inf' "Adding regexp alias file postfix-regexp.cf"
 
     cp -f /tmp/docker-mailserver/postfix-regexp.cf /etc/postfix/regexp
-    sed -i -E \
-      's|virtual_alias_maps(.*)|virtual_alias_maps\1 pcre:/etc/postfix/regexp|g' \
-      /etc/postfix/main.cf
+
+    if ! grep 'virtual_alias_maps.*pcre:/etc/postfix/regexp' /etc/postfix/main.cf
+    then
+      sed -i -E \
+        's|virtual_alias_maps(.*)|virtual_alias_maps\1 pcre:/etc/postfix/regexp|g' \
+        /etc/postfix/main.cf
+    fi
   fi
 }
 
@@ -53,7 +57,7 @@ function _handle_postfix_aliases_config
 {
   _notify 'inf' 'Configuring root alias'
 
-  echo "root: ${POSTMASTER_ADDRESS}" > /etc/aliases
+  echo "root: ${POSTMASTER_ADDRESS}" >/etc/aliases
 
   if [[ -f /tmp/docker-mailserver/postfix-aliases.cf ]]
   then

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -342,7 +342,7 @@ function _setup_dovecot_local_user
 
 function _setup_ldap
 {
-  _notify 'task' 'Setting up Ldap'
+  _notify 'task' 'Setting up LDAP'
   _notify 'inf' 'Checking for custom configs'
 
   for i in 'users' 'groups' 'aliases' 'domains'
@@ -404,7 +404,7 @@ function _setup_ldap
   # add domainname to vhost
   echo "${DOMAINNAME}" >>/tmp/vhost.tmp
 
-  _notify 'inf' "Enabling dovecot LDAP authentification"
+  _notify 'inf' 'Enabling dovecot LDAP authentification'
 
   sed -i -e '/\!include auth-ldap\.conf\.ext/s/^#//' /etc/dovecot/conf.d/10-auth.conf
   sed -i -e '/\!include auth-passwdfile\.inc/s/^/#/' /etc/dovecot/conf.d/10-auth.conf
@@ -413,20 +413,23 @@ function _setup_ldap
 
   if [[ -f /etc/postfix/ldap-users.cf ]]
   then
-    postconf -e "virtual_mailbox_maps = ldap:/etc/postfix/ldap-users.cf" || \
-    _notify 'inf' "==> Warning: /etc/postfix/ldap-user.cf not found"
+    postconf -e "virtual_mailbox_maps = ldap:/etc/postfix/ldap-users.cf"
+  else
+    _notify 'war' "'/etc/postfix/ldap-user.cf' not found"
   fi
 
   if [[ -f /etc/postfix/ldap-domains.cf ]]
   then
-    postconf -e "virtual_mailbox_domains = /etc/postfix/vhost, ldap:/etc/postfix/ldap-domains.cf" || \
-    _notify 'inf' "==> Warning: /etc/postfix/ldap-domains.cf not found"
+    postconf -e "virtual_mailbox_domains = /etc/postfix/vhost, ldap:/etc/postfix/ldap-domains.cf"
+  else
+    _notify 'war' "'/etc/postfix/ldap-domains.cf' not found"
   fi
 
   if [[ -f /etc/postfix/ldap-aliases.cf ]] && [[ -f /etc/postfix/ldap-groups.cf ]]
   then
-    postconf -e "virtual_alias_maps = ldap:/etc/postfix/ldap-aliases.cf, ldap:/etc/postfix/ldap-groups.cf" || \
-    _notify 'war' "/etc/postfix/ldap-aliases.cf or /etc/postfix/ldap-groups.cf not found"
+    postconf -e "virtual_alias_maps = ldap:/etc/postfix/ldap-aliases.cf, ldap:/etc/postfix/ldap-groups.cf"
+  else
+    _notify 'war' "'/etc/postfix/ldap-aliases.cf' and / or '/etc/postfix/ldap-groups.cf' not found"
   fi
 
   # shellcheck disable=SC2016

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -426,7 +426,7 @@ function _setup_ldap
   if [[ -f /etc/postfix/ldap-aliases.cf ]] && [[ -f /etc/postfix/ldap-groups.cf ]]
   then
     postconf -e "virtual_alias_maps = ldap:/etc/postfix/ldap-aliases.cf, ldap:/etc/postfix/ldap-groups.cf" || \
-    _notify 'inf' "==> Warning: /etc/postfix/ldap-aliases.cf or /etc/postfix/ldap-groups.cf not found"
+    _notify 'war' "/etc/postfix/ldap-aliases.cf or /etc/postfix/ldap-groups.cf not found"
   fi
 
   # shellcheck disable=SC2016

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -415,7 +415,7 @@ function _setup_ldap
   then
     postconf -e "virtual_mailbox_maps = ldap:/etc/postfix/ldap-users.cf"
   else
-    _notify 'war' "'/etc/postfix/ldap-user.cf' not found"
+    _notify 'war' "'/etc/postfix/ldap-users.cf' not found"
   fi
 
   if [[ -f /etc/postfix/ldap-domains.cf ]]


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

`/etc/postfix/regexp` appeared ~~twice~~ in Postfix's `virtual_alias_maps`. This should be corrected now.

PS: It turns out, without this PR, every time a change is detected, `/etc/postfix/regexp` will be added again. So this PR is indeed somewhat important :D

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #2394

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
