### PR TITLE
relieve some pain: restart `check-for-changes.sh` regularly

### DIFF
--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -131,7 +131,7 @@ do
   # mark changes as applied
   mv "${CHKSUM_FILE}.new" "${CHKSUM_FILE}"
 
-  sleep 10
+  sleep 2
 done
 
 exit 0

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -60,12 +60,7 @@ do
     create_lock # Shared config safety lock
     CHANGED=$(grep -Fxvf "${CHKSUM_FILE}" "${CHKSUM_FILE}.new" | sed 's/^[^ ]\+  //')
 
-    # Bug alert! This overwrites the alias set by start-mailserver.sh
-    # Take care that changes in one script are propagated to the other
-
     # ! NEEDS FIX -----------------------------------------
-    # TODO FIX --------------------------------------------
-    # ! NEEDS EXTENSIONS ----------------------------------
     # TODO Perform updates below conditionally too --------
     # Also note that changes are performed in place and are not atomic
     # We should fix that and write to temporary files, stop, swap and start
@@ -82,8 +77,7 @@ do
       #
       # NOTE: HOSTNAME is set via `helper-functions.sh`, it is not the original system HOSTNAME ENV anymore.
       # TODO: SSL_DOMAIN is Traefik specific, it no longer seems relevant and should be considered for removal.
-      FQDN_LIST=("${SSL_DOMAIN}" "${HOSTNAME}" "${DOMAINNAME}")
-      for CERT_DOMAIN in "${FQDN_LIST[@]}"
+      for CERT_DOMAIN in "${SSL_DOMAIN}" "${HOSTNAME}" "${DOMAINNAME}"
       do
         _notify 'inf' "Attempting to extract for '${CERT_DOMAIN}'"
 
@@ -137,7 +131,7 @@ do
   # mark changes as applied
   mv "${CHKSUM_FILE}.new" "${CHKSUM_FILE}"
 
-  sleep 1
+  sleep 10
 done
 
 exit 0

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -159,8 +159,9 @@ function register_functions
   # ? >> Fixes
 
   _register_fix_function '_fix_var_mail_permissions'
-  [[ ${ENABLE_AMAVIS} -eq 1 ]] && _register_fix_function '_fix_var_amavis_permissions'
+  _register_fix_function '_fix_restart_changedetector_daily'
 
+  [[ ${ENABLE_AMAVIS} -eq 1 ]] && _register_fix_function '_fix_var_amavis_permissions'
   [[ ${ENABLE_CLAMAV} -eq 0 ]] && _register_fix_function '_fix_cleanup_clamav'
   [[ ${ENABLE_SPAMASSASSIN} -eq 0 ]] &&	_register_fix_function '_fix_cleanup_spamassassin'
 

--- a/target/scripts/startup/fixes-stack.sh
+++ b/target/scripts/startup/fixes-stack.sh
@@ -58,5 +58,8 @@ function _fix_cleanup_spamassassin
 function _fix_restart_changedetector_daily
 {
   _notify 'task' 'Making sure the changedetector is restarted daily'
-  echo 'supervisorctl restart changedetector' >/etc/cron.daily/restart_changedetector
+  local CRON_CHANGEDETECTOR_FILE=/etc/cron.daily/restart_changedetector
+
+  printf '#! /bin/bash\n\nsupervisorctl restart changedetector\n' >"${CRON_CHANGEDETECTOR_FILE}"
+  chmod +x "${CRON_CHANGEDETECTOR_FILE}"
 }

--- a/target/scripts/startup/fixes-stack.sh
+++ b/target/scripts/startup/fixes-stack.sh
@@ -54,3 +54,9 @@ function _fix_cleanup_spamassassin
     [[ ! -f /CONTAINER_START ]] && _notify 'err' 'Failed to remove SpamAssassin configuration'
   }
 }
+
+function _fix_restart_changedetector_daily
+{
+  _notify 'task' 'Making sure the changedetector is restarted daily'
+  echo 'supervisorctl restart changedetector' >/etc/cron.daily/restart_changedetector
+}


### PR DESCRIPTION
# Description

The script does not need to run every single second. This is not to say
that there is huge resource usage due to running every second, but every
~~ten~~ two seconds is more than enough. ~~This _should_ act like a plaster when
it comes to #2348 -~~ I KNOW THIS IS **NOT** A FIX. ~~But this way, people
can first of all stay on Debian 11 and DMS 10.4.0, secondly, we may get
some more feedback on this mysterious issue due to people staying in DMS
10.4.0.~~ Restarting the script will provide a new PID and should in theory stop the resource leakage. Not sure whether we want to go through with it though, as this will also disguise the error at hand to some degree.

Independently of #2348, increasing the timeout is a very valid concern I had, and on my deployment, I already raised it.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes nothing, but _should_ increase the time before DMS starts using all the RAM on a system.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
