### PR TITLE
improvement: get rid of subshell + `exec` in `helper-functions.sh`

### DIFF
--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -132,7 +132,7 @@ do
   # mark changes as applied
   mv "${CHKSUM_FILE}.new" "${CHKSUM_FILE}"
 
-  sleep 1
+  sleep 2
 done
 
 exit 0

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -50,6 +50,7 @@ do
   # get chksum and check it, no need to lock config yet
   _monitored_files_checksums >"${CHKSUM_FILE}.new"
   cmp --silent -- "${CHKSUM_FILE}" "${CHKSUM_FILE}.new"
+
   # cmp return codes
   # 0 – files are identical
   # 1 – files differ
@@ -60,13 +61,7 @@ do
     create_lock # Shared config safety lock
     CHANGED=$(grep -Fxvf "${CHKSUM_FILE}" "${CHKSUM_FILE}.new" | sed 's/^[^ ]\+  //')
 
-    # Bug alert! This overwrites the alias set by start-mailserver.sh
-    # Take care that changes in one script are propagated to the other
-
-    # ! NEEDS FIX -----------------------------------------
-    # TODO FIX --------------------------------------------
-    # ! NEEDS EXTENSIONS ----------------------------------
-    # TODO Perform updates below conditionally too --------
+    # TODO Perform updates below conditionally too
     # Also note that changes are performed in place and are not atomic
     # We should fix that and write to temporary files, stop, swap and start
 

--- a/target/scripts/helper-functions.sh
+++ b/target/scripts/helper-functions.sh
@@ -231,7 +231,7 @@ function _monitored_files_checksums
   # If a wildcard path pattern (or an empty ENV) would yield an invalid path
   # or no results, `shopt -s nullglob` prevents it from being added.
   shopt -s nullglob
-  local CERT_FILES
+  declare -a CERT_FILES
 
   # React to any cert changes within the following letsencrypt locations:
   CERT_FILES=(

--- a/target/scripts/helper-functions.sh
+++ b/target/scripts/helper-functions.sh
@@ -225,33 +225,33 @@ export -f _notify
 CHKSUM_FILE=/tmp/docker-mailserver-config-chksum
 
 # Compute checksums of monitored files,
-# returned output is lines of hashed content + filepath pairs.
+# returned output on `stdout`: hash + filepath tuple on each line
 function _monitored_files_checksums
 {
   # If a wildcard path pattern (or an empty ENV) would yield an invalid path
   # or no results, `shopt -s nullglob` prevents it from being added.
   shopt -s nullglob
+  local CERT_FILES
 
   # React to any cert changes within the following letsencrypt locations:
-  local CERT_FILES=(
+  CERT_FILES=(
     /etc/letsencrypt/live/"${SSL_DOMAIN}"/*.pem
     /etc/letsencrypt/live/"${HOSTNAME}"/*.pem
     /etc/letsencrypt/live/"${DOMAINNAME}"/*.pem
   )
 
-  # CERT_FILES should expand to separate paths, not a single string;
-  # otherwise fails to generate checksums for these file paths.
-  #shellcheck disable=SC2068
-  (
-    cd /tmp/docker-mailserver || exit 1
-    exec sha512sum 2>/dev/null -- \
-      postfix-accounts.cf \
-      postfix-virtual.cf \
-      postfix-aliases.cf \
-      dovecot-quotas.cf \
-      /etc/letsencrypt/acme.json \
-      ${CERT_FILES[@]}
-  )
+  if [[ ! -d /tmp/docker-mailserver ]]
+  then
+    return 1
+  fi
+
+  sha512sum 2>/dev/null --                     \
+    /tmp/docker-mailserver/postfix-accounts.cf \
+    /tmp/docker-mailserver/postfix-virtual.cf  \
+    /tmp/docker-mailserver/postfix-aliases.cf  \
+    /tmp/docker-mailserver/dovecot-quotas.cf   \
+    /etc/letsencrypt/acme.json                 \
+    "${CERT_FILES[@]}"
 }
 export -f _monitored_files_checksums
 

--- a/test/mail_changedetector.bats
+++ b/test/mail_changedetector.bats
@@ -48,7 +48,7 @@ function teardown_file() {
 
 @test "checking changedetector: can detect changes & between two containers using same config" {
   echo "" >> "$(private_config_path mail_changedetector_one)/postfix-accounts.cf"
-  sleep 15
+  sleep 25
   run docker exec mail_changedetector_one /bin/bash -c "supervisorctl tail -3000 changedetector"
   assert_output --partial "postfix: stopped"
   assert_output --partial "postfix: started"


### PR DESCRIPTION
# Description

The new way of executing `sha512sum` should work as well as the old way
but without the clutter and possible problems the usage of subshells +
exec incurs.

Moreover, there was a misconception about array expansion. Using `""`
around an expanding array (`${ARRAY[@]}`) is quite fine (and actually
the preffered way), not because it makes the expansion _one_ string
(this would be `${ARRAY[*]}`), but it makes sure when elements are
expanded, each element has `""` around them so to speak, i.e. there is
no re-splitting of these elements.

<!-- Link the issue which will be fixed (if any) here: -->
This PR is trying to a be step in uncluttering the changedetector process to find out what is causing the resource leak described in #2348.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Possible bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
