### PR TITLE
fix: do not add accounts that already exists to account files

### DIFF
--- a/target/scripts/helpers/accounts.sh
+++ b/target/scripts/helpers/accounts.sh
@@ -56,12 +56,23 @@ function _create_accounts
         _notify 'inf' "Creating user '${USER}' for domain '${DOMAIN}' with attributes '${USER_ATTRIBUTES}'"
       fi
 
-      echo "${LOGIN} ${DOMAIN}/${USER}/" >> /etc/postfix/vmailbox
+      local POSTFIX_VMAILBOX_LINE DOVECOT_USERDB_LINE
+
+      POSTFIX_VMAILBOX_LINE="${LOGIN} ${DOMAIN}/${USER}/"
+      if ! grep "${POSTFIX_VMAILBOX_LINE}" /etc/postfix/vmailbox &>/dev/null
+      then
+        echo "${POSTFIX_VMAILBOX_LINE}" >>/etc/postfix/vmailbox
+      fi
+
       # Dovecot's userdb has the following format
       # user:password:uid:gid:(gecos):home:(shell):extra_fields
-      echo \
-        "${LOGIN}:${PASS}:5000:5000::/var/mail/${DOMAIN}/${USER}::${USER_ATTRIBUTES}" \
-        >>/etc/dovecot/userdb
+      DOVECOT_USERDB_LINE="${LOGIN}:${PASS}:5000:5000::/var/mail/${DOMAIN}/${USER}::${USER_ATTRIBUTES}"
+      if ! grep "${DOVECOT_USERDB_LINE}" /etc/dovecot/userdb &>/dev/null
+      then
+        echo \
+          "${LOGIN}:${PASS}:5000:5000::/var/mail/${DOMAIN}/${USER}::${USER_ATTRIBUTES}" \
+          >>/etc/dovecot/userdb
+      fi
 
       mkdir -p "/var/mail/${DOMAIN}/${USER}"
 


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
Includes a fix with which users are not added to the accounts files of Postfix and Dovecot if they are already present.


<!-- Link the issue which will be fixed (if any) here: -->
Fixes #2416

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
