### PR TITLE
docs(podman): Fix broken links and add version hints

### DIFF
--- a/docs/content/config/advanced/podman.md
+++ b/docs/content/config/advanced/podman.md
@@ -128,7 +128,7 @@ You must also add the ENV `NETWORK_INTERFACE=tap0`, because Podman uses a [hard-
 
 !!! note
 
-    `podman-compose` is not compatible with configuration.
+    `podman-compose` is not compatible with this configuration.
 
 ### Self-start in Rootless Mode
 

--- a/docs/content/config/advanced/podman.md
+++ b/docs/content/config/advanced/podman.md
@@ -170,3 +170,6 @@ firewall-cmd --reload
 ```
 
 Just map all the privilege port with non-privilege port you set in docker-compose.yml before as root user.
+
+[rootless::podman]: https://github.com/containers/podman/blob/v3.4.1/docs/source/markdown/podman-run.1.md#--networkmode---net
+[rootless::podman::interface]: https://github.com/containers/podman/blob/v3.4.1/libpod/networking_slirp4netns.go#L264


### PR DESCRIPTION
# Description

This is a follow up of #2393, where I accidentally added broken links to the podman documentation.

In addition to this fix, I've added some version hints to the changes introduced in the aforementioned PR to circumvent issues like [this](https://github.com/docker-mailserver/docker-mailserver/issues/2411#issuecomment-1043542552)

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
