### PR TITLE
Update 'build' doc

### DIFF
--- a/docs/content/examples/tutorials/docker-build.md
+++ b/docs/content/examples/tutorials/docker-build.md
@@ -8,7 +8,7 @@ You'll need to retrieve the git submodules prior to building your own Docker ima
 
 ```sh
 git submodule update --init --recursive
-docker build .
+docker build -t mailserver/docker-mailserver .
 ```
 
 Or, you can clone and retrieve the submodules in one command:


### PR DESCRIPTION
'setup.sh' expects an image named 'mailserver/docker-mailserver:latest' or else it will pull a remote image.

(To some degree whether this change makes sense depends on whether the audience for this page is intended to go on to use the image themselves. If it's for somebody who will use some downstream publishing process perhaps it's not correct.)