### PR TITLE
check-for-changes wait for settle

### DIFF
--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -48,108 +48,129 @@ sleep 10
 
 _notify 'inf' "$(_log_date) check-for-changes is ready"
 
+# used to check for if changes have settled
+CMP_RESULT=
+LAST_CMP_RESULT=
+
 while true
 do
   # get chksum and check it, no need to lock config yet
   _monitored_files_checksums >"${CHKSUM_FILE}.new"
-  cmp --silent -- "${CHKSUM_FILE}" "${CHKSUM_FILE}.new"
 
-  # cmp return codes
-  # 0 – files are identical
-  # 1 – files differ
-  # 2 – inaccessible or missing argument
-  if [[ ${?} -eq 1 ]]
+  CMP_RESULT=$(cmp -- "${CHKSUM_FILE}" "${CHKSUM_FILE}.new")
+  if [[ -n "${CMP_RESULT}" ]] # If there is a difference between checksum files
   then
-    _notify 'inf' "$(_log_date) Change detected"
-    _create_lock # Shared config safety lock
-    CHANGED=$(grep -Fxvf "${CHKSUM_FILE}" "${CHKSUM_FILE}.new" | sed 's/^[^ ]\+  //')
-
-    # TODO Perform updates below conditionally too
-    # Also note that changes are performed in place and are not atomic
-    # We should fix that and write to temporary files, stop, swap and start
-
-    if [[ ${SSL_TYPE} == 'manual' ]]
+    # If the current run's CMP_RESULT is equal to the LAST_CMP_RESULT, changes have settled and we can safely proceed
+    # This prevents multiple restarts of postfix from happening all at once and causing problems or delays
+    if [[ "${CMP_RESULT}" == "${LAST_CMP_RESULT}" ]]
     then
-      # only run the SSL setup again if certificates have really changed.
-      if [[ ${CHANGED} =~ ${SSL_CERT_PATH:-${REGEX_NEVER_MATCH}} ]]     \
-      || [[ ${CHANGED} =~ ${SSL_KEY_PATH:-${REGEX_NEVER_MATCH}} ]]      \
-      || [[ ${CHANGED} =~ ${SSL_ALT_CERT_PATH:-${REGEX_NEVER_MATCH}} ]] \
-      || [[ ${CHANGED} =~ ${SSL_ALT_KEY_PATH:-${REGEX_NEVER_MATCH}} ]]
+
+      _notify 'inf' "${LOG_DATE} Changes settled... Applying changes and restarting services..."
+      _create_lock # Shared config safety lock
+      CHANGED=$(grep -Fxvf "${CHKSUM_FILE}" "${CHKSUM_FILE}.new" | sed 's/^[^ ]\+  //')
+
+      # TODO Perform updates below conditionally too
+      # Also note that changes are performed in place and are not atomic
+      # We should fix that and write to temporary files, stop, swap and start
+
+      if [[ ${SSL_TYPE} == 'manual' ]]
       then
-        _notify 'inf' "Manual certificates have changed, extracting certs.."
-        # we need to run the SSL setup again, because the
-        # certificates DMS is working with are copies of
-        # the (now changed) files
-        _setup_ssl
-      fi
-    # `acme.json` is only relevant to Traefik, and is where it stores the certificates it manages.
-    # When a change is detected it's assumed to be a possible cert renewal that needs to be
-    # extracted for `docker-mailserver` services to adjust to.
-    elif [[ ${CHANGED} =~ /etc/letsencrypt/acme.json ]]
-    then
-      _notify 'inf' "'/etc/letsencrypt/acme.json' has changed, extracting certs.."
-
-      # This breaks early as we only need the first successful extraction.
-      # For more details see the `SSL_TYPE=letsencrypt` case handling in `setup-stack.sh`.
-      #
-      # NOTE: HOSTNAME is set via `helpers/dns.sh`, it is not the original system HOSTNAME ENV anymore.
-      # TODO: SSL_DOMAIN is Traefik specific, it no longer seems relevant and should be considered for removal.
-      FQDN_LIST=("${SSL_DOMAIN}" "${HOSTNAME}" "${DOMAINNAME}")
-      for CERT_DOMAIN in "${FQDN_LIST[@]}"
-      do
-        _notify 'inf' "Attempting to extract for '${CERT_DOMAIN}'"
-
-        if _extract_certs_from_acme "${CERT_DOMAIN}"
+        # only run the SSL setup again if certificates have really changed.
+        if [[ ${CHANGED} =~ ${SSL_CERT_PATH:-${REGEX_NEVER_MATCH}} ]]     \
+        || [[ ${CHANGED} =~ ${SSL_KEY_PATH:-${REGEX_NEVER_MATCH}} ]]      \
+        || [[ ${CHANGED} =~ ${SSL_ALT_CERT_PATH:-${REGEX_NEVER_MATCH}} ]] \
+        || [[ ${CHANGED} =~ ${SSL_ALT_KEY_PATH:-${REGEX_NEVER_MATCH}} ]]
         then
-          # Prevent an unnecessary change detection from the newly extracted cert files by updating their hashes in advance:
-          CERT_DOMAIN=$(_strip_wildcard_prefix "${CERT_DOMAIN}")
-          ACME_CERT_DIR="/etc/letsencrypt/live/${CERT_DOMAIN}"
-
-          sed -i "\|${ACME_CERT_DIR}|d" "${CHKSUM_FILE}.new"
-          sha512sum "${ACME_CERT_DIR}"/*.pem >> "${CHKSUM_FILE}.new"
-
-          break
+          _notify 'inf' "Manual certificates have changed, extracting certs.."
+          # we need to run the SSL setup again, because the
+          # certificates DMS is working with are copies of
+          # the (now changed) files
+          _setup_ssl
         fi
-      done
+      # `acme.json` is only relevant to Traefik, and is where it stores the certificates it manages.
+      # When a change is detected it's assumed to be a possible cert renewal that needs to be
+      # extracted for `docker-mailserver` services to adjust to.
+      elif [[ ${CHANGED} =~ /etc/letsencrypt/acme.json ]]
+      then
+        _notify 'inf' "'/etc/letsencrypt/acme.json' has changed, extracting certs.."
+
+        # This breaks early as we only need the first successful extraction.
+        # For more details see the `SSL_TYPE=letsencrypt` case handling in `setup-stack.sh`.
+        #
+        # NOTE: HOSTNAME is set via `helpers/dns.sh`, it is not the original system HOSTNAME ENV anymore.
+        # TODO: SSL_DOMAIN is Traefik specific, it no longer seems relevant and should be considered for removal.
+        FQDN_LIST=("${SSL_DOMAIN}" "${HOSTNAME}" "${DOMAINNAME}")
+        for CERT_DOMAIN in "${FQDN_LIST[@]}"
+        do
+          _notify 'inf' "Attempting to extract for '${CERT_DOMAIN}'"
+
+          if _extract_certs_from_acme "${CERT_DOMAIN}"
+          then
+            # Prevent an unnecessary change detection from the newly extracted cert files by updating their hashes in advance:
+            CERT_DOMAIN=$(_strip_wildcard_prefix "${CERT_DOMAIN}")
+            ACME_CERT_DIR="/etc/letsencrypt/live/${CERT_DOMAIN}"
+
+            sed -i "\|${ACME_CERT_DIR}|d" "${CHKSUM_FILE}.new"
+            sha512sum "${ACME_CERT_DIR}"/*.pem >> "${CHKSUM_FILE}.new"
+
+            break
+          fi
+        done
+      fi
+
+      # If monitored certificate files in /etc/letsencrypt/live have changed and no `acme.json` is in use,
+      # They presently have no special handling other than to trigger a change that will restart Postfix/Dovecot.
+      # TODO: That should be all that's required, unless the cert file paths have also changed (Postfix/Dovecot configs then need to be updated).
+
+      # regenerate postfix accounts
+      [[ ${SMTP_ONLY} -ne 1 ]] && _create_accounts
+
+      _rebuild_relayhost
+
+      # regenerate postix aliases
+      _create_aliases
+
+      # regenerate /etc/postfix/vhost
+      # NOTE: If later adding support for LDAP with change detection and this method is called,
+      # be sure to mimic `setup-stack.sh:_setup_ldap` which appends to `/tmp/vhost.tmp`.
+      _create_postfix_vhost
+
+      if find /var/mail -maxdepth 3 -a \( \! -user 5000 -o \! -group 5000 \) | read -r
+      then
+        chown -R 5000:5000 /var/mail
+      fi
+
+      _notify 'inf' "Restarting services due to detected changes.."
+
+      supervisorctl restart postfix
+
+      # prevent restart of dovecot when smtp_only=1
+      echo "SMTP_ONLY: ${SMTP_ONLY}"
+      [[ ${SMTP_ONLY} -ne 1 ]] && supervisorctl restart dovecot
+
+      _remove_lock
+      _notify 'inf' "$(_log_date) Completed handling of detected change"
+
+      LAST_CMP_RESULT=
+      CMP_RESULT=
+
+    else # The files differ...
+      _notify 'inf' "${LOG_DATE} Changes detected... Ensuring changes have settled before proceeding..."
+      LAST_CMP_RESULT="${CMP_RESULT}"
+      sleep 3 # The longer the sleep here, the more time there is for users to make changes before a full restart
+      continue
     fi
 
-    # If monitored certificate files in /etc/letsencrypt/live have changed and no `acme.json` is in use,
-    # They presently have no special handling other than to trigger a change that will restart Postfix/Dovecot.
-    # TODO: That should be all that's required, unless the cert file paths have also changed (Postfix/Dovecot configs then need to be updated).
-
-    # regenerate postfix accounts
-    [[ ${SMTP_ONLY} -ne 1 ]] && _create_accounts
-
-    _rebuild_relayhost
-
-    # regenerate postix aliases
-    _create_aliases
-
-    # regenerate /etc/postfix/vhost
-    # NOTE: If later adding support for LDAP with change detection and this method is called,
-    # be sure to mimic `setup-stack.sh:_setup_ldap` which appends to `/tmp/vhost.tmp`.
-    _create_postfix_vhost
-
-    if find /var/mail -maxdepth 3 -a \( \! -user 5000 -o \! -group 5000 \) | read -r
-    then
-      chown -R 5000:5000 /var/mail
-    fi
-
-    _notify 'inf' "Restarting services due to detected changes.."
-
-    supervisorctl restart postfix
-
-    # prevent restart of dovecot when smtp_only=1
-    [[ ${SMTP_ONLY} -ne 1 ]] && supervisorctl restart dovecot
-
-    _remove_lock
-    _notify 'inf' "$(_log_date) Completed handling of detected change"
+  else # Checksum files don't differ
+    LAST_CMP_RESULT=
+    continue
   fi
 
   # mark changes as applied
   mv "${CHKSUM_FILE}.new" "${CHKSUM_FILE}"
 
   sleep 2
+  
 done
 
 exit 0

--- a/test/mail_ssl_letsencrypt.bats
+++ b/test/mail_ssl_letsencrypt.bats
@@ -257,7 +257,9 @@ function _should_extract_on_changes() {
 
   # Expected log lines from the changedetector service:
   run $(_get_service_logs 'changedetector')
-  assert_output --partial 'Change detected'
+  assert_output --partial 'Changes detected'
+  sleep 10
+  assert_output --partial 'Changes settled'
   assert_output --partial "'/etc/letsencrypt/acme.json' has changed, extracting certs"
   assert_output --partial "_extract_certs_from_acme | Certificate successfully extracted for '${EXPECTED_DOMAIN}'"
   assert_output --partial 'Restarting services due to detected changes'


### PR DESCRIPTION
Original PR this was split from: https://github.com/docker-mailserver/docker-mailserver/pull/2157

Goal: Have check-for-changes.sh wait for changes to "settle" (checksum comparison has to not have changed over two different checks with 5-second gaps between) before modifying and restarting anything.

Why: The eventual API (https://github.com/docker-mailserver/docker-mailserver-admin/issues/3) will allow users to make frequent changes to the config and we don't want them triggering service restarts until those requests/changes settle down.



