### PR TITLE
macOS bash 5 & zsh doesn't support shopt -s inherit_errexit

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,7 @@ LBLUE="\e[94m"
 RESET="\e[0m"
 
 set -euEo pipefail
-shopt -s inherit_errexit
+shopt -s inherit_errexit 2>/dev/null || true
 trap '__err "${BASH_SOURCE}" "${FUNCNAME[0]:-?}" "${BASH_COMMAND:-?}" "${LINENO:-?}" "${?:-?}"' ERR
 
 function __err

--- a/test/linting/lint.sh
+++ b/test/linting/lint.sh
@@ -1,5 +1,4 @@
 #! /bin/bash
-set -x
 # version   v0.2.0 unstable
 # executed  by Make during CI or manually
 # task      checks files against linting targets
@@ -105,7 +104,7 @@ function _shellcheck
     -not -path './target/docker-configomat/*'
   )"
   # macOS lacks parity for `-executable` but presently produces the same results: https://stackoverflow.com/a/4458361
-  [[ "$(uname)" == "Darwin" ]] && FIND_EXEC="-perm +111 -type l -or" || FIND_EXEC="-executable"
+  [[ "$(uname)" == "Darwin" ]] && FIND_EXEC="-perm -711" || FIND_EXEC="-executable"
   # shellcheck disable=SC2248
   F_BIN="$(find 'target/bin' ${FIND_EXEC} -type f)"
   F_BATS="$(find 'test' -maxdepth 1 -type f -iname '*.bats')"

--- a/test/linting/lint.sh
+++ b/test/linting/lint.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-
+set -x
 # version   v0.2.0 unstable
 # executed  by Make during CI or manually
 # task      checks files against linting targets
@@ -20,7 +20,7 @@ ECLINT_VERSION=2.3.5
 SHELLCHECK_VERSION=0.8.0
 
 set -eEuo pipefail
-shopt -s inherit_errexit
+shopt -s inherit_errexit 2>/dev/null || true
 trap '__log_err "${FUNCNAME[0]:-?}" "${BASH_COMMAND:-?}" ${LINENO:-?} ${?:-?}' ERR
 
 function __log_err


### PR DESCRIPTION
# Description

macOS/ZSH doesn't support shopt -s inherit_errexit

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
