### PR TITLE
setup.sh: Remove obsolete 'debug inspect' command from usage text

### DIFF
--- a/docs/content/config/setup.sh.md
+++ b/docs/content/config/setup.sh.md
@@ -16,7 +16,7 @@ chmod a+x ./setup.sh
 !!! warning "`setup.sh` for `docker-mailserver` version `v10.1.x` and below"
 
     If you're using `docker-mailserver` version `v10.1.x` or below, you will need to get `setup.sh` with a specific version. Substitute `<VERSION>` with the [tagged release version](https://github.com/docker-mailserver/docker-mailserver/tags) that you're using:
-    
+
     `wget https://raw.githubusercontent.com/docker-mailserver/docker-mailserver/<VERSION>/setup.sh`.
 
 ## Usage
@@ -69,16 +69,15 @@ DESCRIPTION
         ./setup.sh config dkim [ ARGUMENTS... ]
 
     COMMAND relay :=
-        ./setup.sh relay add-domain <DOMAIN> <HOST> [<PORT>]
         ./setup.sh relay add-auth <DOMAIN> <USERNAME> [<PASSWORD>]
+        ./setup.sh relay add-domain <DOMAIN> <HOST> [<PORT>]
         ./setup.sh relay exclude-domain <DOMAIN>
 
     COMMAND debug :=
-        ./setup.sh debug fetchmail
         ./setup.sh debug fail2ban [unban <IP>]
-        ./setup.sh debug show-mail-logs
-        ./setup.sh debug inspect
+        ./setup.sh debug fetchmail
         ./setup.sh debug login <COMMANDS>
+        ./setup.sh debug show-mail-logs
 
 EXAMPLES
     ./setup.sh email add test@example.com

--- a/target/bin/setup
+++ b/target/bin/setup
@@ -63,16 +63,15 @@ ${RED}[${ORANGE}SUB${RED}]${ORANGE}COMMANDS${RESET}
         ${0} config ${CYAN}dkim${RESET} [ ARGUMENTS${RED}...${RESET} ]
 
     ${LBLUE}COMMAND${RESET} relay ${RED}:=${RESET}
-        ${0} relay ${CYAN}add-domain${RESET} <DOMAIN> <HOST> [<PORT>]
         ${0} relay ${CYAN}add-auth${RESET} <DOMAIN> <USERNAME> [<PASSWORD>]
+        ${0} relay ${CYAN}add-domain${RESET} <DOMAIN> <HOST> [<PORT>]
         ${0} relay ${CYAN}exclude-domain${RESET} <DOMAIN>
 
     ${LBLUE}COMMAND${RESET} debug ${RED}:=${RESET}
-        ${0} debug ${CYAN}fetchmail${RESET}
         ${0} debug ${CYAN}fail2ban${RESET} [unban <IP>]
-        ${0} debug ${CYAN}show-mail-logs${RESET}
-        ${0} debug ${CYAN}inspect${RESET}
+        ${0} debug ${CYAN}fetchmail${RESET}
         ${0} debug ${CYAN}login${RESET} <COMMANDS>
+        ${0} debug ${CYAN}show-mail-logs${RESET}
 
 ${ORANGE}EXAMPLES${RESET}
     ${WHITE}./setup.sh email add test@example.com${RESET}


### PR DESCRIPTION
# Description

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #2451

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
