### PR TITLE
Build edge image daily

### DIFF
--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -2,7 +2,7 @@ name: "Build Edge on Schedule"
 
 on:
   schedule:
-    - cron: "0 0 * * 5"
+    - cron: "0 0 * * *"
 
 jobs:
   publish:

--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -1,6 +1,7 @@
 name: "Build Edge on Schedule"
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
# Description

This PR changes the scheduled build of the edge image from **weekly** to **daily**.

Why? The last edge image was build some hours ago. I've just merged #2456. This means, users wanting to try :edge which includes the fix, would have to wait one week to do so.

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
