### PR TITLE
Use FQDN as REPORT_SENDER default value.

### DIFF
--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -18,7 +18,7 @@ _obtain_hostname_and_domainname
 # These variables must be defined first; They are used as default values for other variables.
 VARS[POSTMASTER_ADDRESS]="${POSTMASTER_ADDRESS:=postmaster@${DOMAINNAME}}"
 VARS[REPORT_RECIPIENT]="${REPORT_RECIPIENT:=${POSTMASTER_ADDRESS}}"
-VARS[REPORT_SENDER]="${REPORT_SENDER:=mailserver-report@${DOMAINNAME}}"
+VARS[REPORT_SENDER]="${REPORT_SENDER:=mailserver-report@$(hostname -f)}"
 
 VARS[AMAVIS_LOGLEVEL]="${AMAVIS_LOGLEVEL:=0}"
 VARS[CLAMAV_MESSAGE_SIZE_LIMIT]="${CLAMAV_MESSAGE_SIZE_LIMIT:=25M}" # 25 MB

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -18,7 +18,7 @@ _obtain_hostname_and_domainname
 # These variables must be defined first; They are used as default values for other variables.
 VARS[POSTMASTER_ADDRESS]="${POSTMASTER_ADDRESS:=postmaster@${DOMAINNAME}}"
 VARS[REPORT_RECIPIENT]="${REPORT_RECIPIENT:=${POSTMASTER_ADDRESS}}"
-VARS[REPORT_SENDER]="${REPORT_SENDER:=mailserver-report@$(hostname -f)}"
+VARS[REPORT_SENDER]="${REPORT_SENDER:=mailserver-report@${HOSTNAME}}"
 
 VARS[AMAVIS_LOGLEVEL]="${AMAVIS_LOGLEVEL:=0}"
 VARS[CLAMAV_MESSAGE_SIZE_LIMIT]="${CLAMAV_MESSAGE_SIZE_LIMIT:=25M}" # 25 MB

--- a/test/mail_with_ldap.bats
+++ b/test/mail_with_ldap.bats
@@ -230,7 +230,7 @@ function teardown_file() {
 
 @test "checking pflogsum delivery" {
   # checking default sender is correctly set when env variable not defined
-  run docker exec mail_with_ldap grep "mailserver-report@$(hostname -f)" /etc/logrotate.d/maillog
+  run docker exec mail_with_ldap grep "mailserver-report@${FQDN_MAIL}" /etc/logrotate.d/maillog
   assert_success
 
   # checking default logrotation setup

--- a/test/mail_with_ldap.bats
+++ b/test/mail_with_ldap.bats
@@ -230,7 +230,7 @@ function teardown_file() {
 
 @test "checking pflogsum delivery" {
   # checking default sender is correctly set when env variable not defined
-  run docker exec mail_with_ldap grep "mailserver-report@${DOMAIN}" /etc/logrotate.d/maillog
+  run docker exec mail_with_ldap grep "mailserver-report@$(hostname -f)" /etc/logrotate.d/maillog
   assert_success
 
   # checking default logrotation setup


### PR DESCRIPTION
# Description

With the merge of #2428, the default sender address was changed.

Let's take our example config:
https://github.com/docker-mailserver/docker-mailserver/blob/b730942b96aec3ab52699b5d927577f42eef0a45/docker-compose.yml#L7-L8

Before: Reports sender address was mailserver-report@mail.example.com
After: Reports sender address is mailserver-report@example.com

This is wrong IMO.

The subject line of the reports are `Logwatch for mail.example.com (Linux)` and `Postfix summary for mail.example.com`. They correctly state the FQDN for which the reports are. The sender address should therefore also be `mail.example.com`.
`mail.example.com` is not necessary the same host as `example.com`, which is another reason for this change.

This PR uses the FQDN of the mailserver as default sender address.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
