### PR TITLE
Improve test, get rid of sleep

### DIFF
--- a/test/mail_ssl_manual.bats
+++ b/test/mail_ssl_manual.bats
@@ -101,11 +101,9 @@ function teardown_file() {
 @test "checking ssl: manual cert changes are picked up by check-for-changes" {
     printf 'someThingsChangedHere' \
       >>"$(pwd)/test/test-files/ssl/${DOMAIN_SSL_MANUAL}/with_ca/ecdsa/key.ecdsa.pem"
-    sleep 15
 
-    run docker exec mail_manual_ssl /bin/bash -c "supervisorctl tail -3000 changedetector"
-    assert_output --partial 'Change detected'
-    assert_output --partial 'Manual certificates have changed'
+    run timeout 15 docker exec mail_manual_ssl bash -c "tail -F /var/log/supervisor/changedetector.log | sed '/Change detected/ q'"
+    assert_success
 
     sed -i '/someThingsChangedHere/d' "$(pwd)/test/test-files/ssl/${DOMAIN_SSL_MANUAL}/with_ca/ecdsa/key.ecdsa.pem"
 }

--- a/test/mail_ssl_manual.bats
+++ b/test/mail_ssl_manual.bats
@@ -102,7 +102,7 @@ function teardown_file() {
     printf 'someThingsChangedHere' \
       >>"$(pwd)/test/test-files/ssl/${DOMAIN_SSL_MANUAL}/with_ca/ecdsa/key.ecdsa.pem"
 
-    run timeout 15 docker exec mail_manual_ssl bash -c "tail -F /var/log/supervisor/changedetector.log | sed '/Change detected/ q'"
+    run timeout 15 docker exec mail_manual_ssl bash -c "tail -F /var/log/supervisor/changedetector.log | sed '/Manual certificates have changed/ q'"
     assert_success
 
     sed -i '/someThingsChangedHere/d' "$(pwd)/test/test-files/ssl/${DOMAIN_SSL_MANUAL}/with_ca/ecdsa/key.ecdsa.pem"


### PR DESCRIPTION
# Description

This PR speeds up the test, by getting rid of `sleep 15`.

Before: The test waits 15 seconds and then checks for the string `Manual certificates have changed` in the changedetector log file.

After: The changedetector log file is constantly monitored until the string is found. If the string is not found within 15 seconds, the test fails.

The test time is reduced to [~6 seconds](https://github.com/docker-mailserver/docker-mailserver/runs/5608390029?check_suite_focus=true#step:8:103).

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
