### PR TITLE
scripts: renamed function `_errex` -> `_exit_with_error`

### DIFF
--- a/target/bin/addalias
+++ b/target/bin/addalias
@@ -36,12 +36,12 @@ function __usage
 EMAIL="${1}"
 RECIPIENT="${2}"
 
-[[ -z ${EMAIL} ]] && { __usage ; _errex 'No alias specified' ; }
-[[ -z ${RECIPIENT} ]] && { __usage ; _errex 'No recipient specified' ; }
+[[ -z ${EMAIL} ]] && { __usage ; _exit_with_error 'No alias specified' ; }
+[[ -z ${RECIPIENT} ]] && { __usage ; _exit_with_error 'No recipient specified' ; }
 
 grep \
   -qi "^$(_escape "${EMAIL}")[a-zA-Z@.\ ]*$(_escape "${RECIPIENT}")" \
-  "${DATABASE}" 2>/dev/null && _errex "Alias \"${EMAIL} ${RECIPIENT}\" already exists"
+  "${DATABASE}" 2>/dev/null && _exit_with_error "Alias \"${EMAIL} ${RECIPIENT}\" already exists"
 
 if grep -qi "^$(_escape "${EMAIL}")" "${DATABASE}" 2>/dev/null
 then

--- a/target/bin/addmailuser
+++ b/target/bin/addmailuser
@@ -39,8 +39,8 @@ FULL_EMAIL="${1}"
 shift
 PASSWD="${*}"
 
-[[ -z ${FULL_EMAIL} ]] && { __usage ; _errex 'No username specified' ; }
-[[ ${FULL_EMAIL} =~ .*\@.* ]] || { __usage ; _errex 'Username must include the domain' ; }
+[[ -z ${FULL_EMAIL} ]] && { __usage ; _exit_with_error 'No username specified' ; }
+[[ ${FULL_EMAIL} =~ .*\@.* ]] || { __usage ; _exit_with_error 'Username must include the domain' ; }
 
 touch "${DATABASE}"
 _create_lock # Protect config file with lock to avoid race conditions
@@ -54,7 +54,7 @@ if [[ -z ${PASSWD} ]]
 then
   read -r -s -p "Enter Password: " PASSWD
   echo
-  [[ -z ${PASSWD} ]] && _errex "Password must not be empty"
+  [[ -z ${PASSWD} ]] && _exit_with_error "Password must not be empty"
 fi
 
 HASH="$(doveadm pw -s SHA512-CRYPT -u "${FULL_EMAIL}" -p "${PASSWD}")"

--- a/target/bin/addrelayhost
+++ b/target/bin/addrelayhost
@@ -32,8 +32,8 @@ DOMAIN="${1}"
 HOST="${2}"
 PORT="${3}"
 
-[[ -z ${DOMAIN} ]] && { __usage ; _errex 'No domain specified' ; }
-[[ -z ${HOST} ]] && { __usage ; _errex 'No relay host specified' ; }
+[[ -z ${DOMAIN} ]] && { __usage ; _exit_with_error 'No domain specified' ; }
+[[ -z ${HOST} ]] && { __usage ; _exit_with_error 'No relay host specified' ; }
 [[ -z ${PORT} ]] && PORT=25
 
 if grep -qi "^@${DOMAIN}" "${DATABASE}" 2>/dev/null

--- a/target/bin/addsaslpassword
+++ b/target/bin/addsaslpassword
@@ -13,14 +13,14 @@ DOMAIN="${1}"
 USER="${2}"
 PASSWD="${3}"
 
-[[ -z ${DOMAIN} ]] && { __usage ; _errex 'No domain specified' ; }
-[[ -z ${USER} ]] && { __usage ; _errex 'No username specified' ; }
+[[ -z ${DOMAIN} ]] && { __usage ; _exit_with_error 'No domain specified' ; }
+[[ -z ${USER} ]] && { __usage ; _exit_with_error 'No username specified' ; }
 
 if [[ -z ${PASSWD} ]]
 then
   read -r -s -p "Enter Password: " PASSWD
   echo
-  [[ -z ${PASSWD} ]] && _errex 'Password must not be empty'
+  [[ -z ${PASSWD} ]] && _exit_with_error 'Password must not be empty'
 fi
 
 if grep -qi "^@${DOMAIN}" "${DATABASE}" 2>/dev/null

--- a/target/bin/delalias
+++ b/target/bin/delalias
@@ -12,8 +12,8 @@ function __usage { echo "Usage: delalias <alias@domain> <recipient@other>" ; }
 
 [[ ${1:-} == 'help' ]] && { __usage ; exit 0 ; }
 
-[[ -z ${EMAIL} ]] && { __usage ; _errex "Error: No alias specified" ; }
-[[ -z ${RECIPIENT} ]] && { __usage ; _errex "Error: No recipient specified" ; }
+[[ -z ${EMAIL} ]] && { __usage ; _exit_with_error "Error: No alias specified" ; }
+[[ -z ${RECIPIENT} ]] && { __usage ; _exit_with_error "Error: No recipient specified" ; }
 [[ -s ${DATABASE} ]] || exit 0
 
 sed -i \

--- a/target/bin/delmailuser
+++ b/target/bin/delmailuser
@@ -67,14 +67,14 @@ do
 
     * )
       __usage
-      _errex "The option ${OPT} is unknown."
+      _exit_with_error "The option ${OPT} is unknown."
       ;;
 
   esac
 done
 shift $((OPTIND-1))
 
-[[ -z ${*} ]] && { __usage ; _errex "No user specifed" ; }
+[[ -z ${*} ]] && { __usage ; _exit_with_error "No user specifed" ; }
 [[ -s ${DATABASE} ]] || exit 0
 
 if ! ${MAILDEL}
@@ -155,6 +155,6 @@ use 'sudo docker exec mailserver rm -R /var/mail/${DOMAIN}/${USER}'"
     ERROR=true
   fi
 
-  ${ERROR} && _errex 'See the messages above.'
+  ${ERROR} && _exit_with_error 'See the messages above.'
 done
 exit 0

--- a/target/bin/delquota
+++ b/target/bin/delquota
@@ -12,13 +12,13 @@ function __usage { echo "Usage: delquota <username@domain>" ; }
 
 USER="${1}"
 
-[[ -z ${USER} ]]  && { __usage ; _errex "No username specified" ; }
-[[ ${USER} =~ .*\@.* ]] || { __usage ; _errex "Username must include the domain"; }
+[[ -z ${USER} ]]  && { __usage ; _exit_with_error "No username specified" ; }
+[[ ${USER} =~ .*\@.* ]] || { __usage ; _exit_with_error "Username must include the domain"; }
 
 if ! grep -qE "^${USER}\|" "${USER_DATABASE}"
 then
   __usage
-  _errex "user ${USER} does not exist"
+  _exit_with_error "user ${USER} does not exist"
 fi
 
 [[ -s ${DATABASE} ]] || exit 0

--- a/target/bin/excluderelaydomain
+++ b/target/bin/excluderelaydomain
@@ -9,7 +9,7 @@ DOMAIN="${1}"
 
 function usage { echo "Usage: excluderelayhost <domain>" ; }
 
-[[ -z ${DOMAIN} ]] && { usage ; _errex "no domain specified" ; }
+[[ -z ${DOMAIN} ]] && { usage ; _exit_with_error "no domain specified" ; }
 
 if grep -qi "^@${DOMAIN}" "${DATABASE}" 2>/dev/null
 then

--- a/target/bin/fail2ban
+++ b/target/bin/fail2ban
@@ -75,7 +75,7 @@ else
 
     *)
       usage
-      _errex "unknown command: ${1}"
+      _exit_with_error "unknown command: ${1}"
       ;;
 
   esac

--- a/target/bin/listalias
+++ b/target/bin/listalias
@@ -5,8 +5,8 @@ source /usr/local/bin/helpers/index.sh
 
 DATABASE=${DATABASE:-/tmp/docker-mailserver/postfix-virtual.cf}
 
-[[ -f ${DATABASE} ]] || _errex "Error: No postfix-virtual.cf file"
-[[ -s ${DATABASE} ]] || _errex "Error: Empty postfix-virtual.cf - no aliases have been added"
+[[ -f ${DATABASE} ]] || _exit_with_error "Error: No postfix-virtual.cf file"
+[[ -s ${DATABASE} ]] || _exit_with_error "Error: Empty postfix-virtual.cf - no aliases have been added"
 
 grep -v "^\s*$\|^\s*\#" "${DATABASE}"
 exit 0

--- a/target/bin/listmailuser
+++ b/target/bin/listmailuser
@@ -23,8 +23,8 @@ function dovecot_quota_to_hr()
 DATABASE="/tmp/docker-mailserver/postfix-accounts.cf"
 ALIASES="/tmp/docker-mailserver/postfix-virtual.cf"
 
-[[ -f ${DATABASE} ]] || _errex "Error: No postfix-accounts.cf file"
-[[ -s ${DATABASE} ]] || _errex "Error: Empty postfix-accounts.cf - no accounts have been added"
+[[ -f ${DATABASE} ]] || _exit_with_error "Error: No postfix-accounts.cf file"
+[[ -s ${DATABASE} ]] || _exit_with_error "Error: Empty postfix-accounts.cf - no accounts have been added"
 
 while read -r LINE
 do

--- a/target/bin/postfix-summary
+++ b/target/bin/postfix-summary
@@ -7,7 +7,7 @@ HOSTNAME=${1}
 RECIPIENT=${2}
 SENDER=${3}
 
-[[ -x /usr/sbin/pflogsumm ]] || _errex "Critical: /usr/sbin/pflogsumm not found"
+[[ -x /usr/sbin/pflogsumm ]] || _exit_with_error "Critical: /usr/sbin/pflogsumm not found"
 
 # The case that the mail.log.1 file isn't readable shouldn't
 # actually be possible with logrotate not rotating empty files..

--- a/target/bin/report-pflogsumm-yesterday
+++ b/target/bin/report-pflogsumm-yesterday
@@ -11,7 +11,7 @@ HOSTNAME=${1}
 RECIPIENT=${2}
 SENDER=${3}
 
-[[ -x /usr/sbin/pflogsumm ]] || _errex "Critical: /usr/sbin/pflogsumm not found"
+[[ -x /usr/sbin/pflogsumm ]] || _exit_with_error "Critical: /usr/sbin/pflogsumm not found"
 
 # shellcheck disable=SC2046
 BODY=$(gzip -cdfq $(ls -tr /var/log/mail/mail.log*) | /usr/sbin/pflogsumm --problems_first -d yesterday)

--- a/target/bin/restrict-access
+++ b/target/bin/restrict-access
@@ -8,7 +8,7 @@ USER="${3}"
 
 function usage  {	echo "Usage: ${0} <add|del|list> <send|receive> [<email@domain.com>]" ; }
 
-[[ -z ${MODE} ]] && _errex "missing parameters: <add|del|list> <send|receive> [<email@domain.com>]"
+[[ -z ${MODE} ]] && _exit_with_error "missing parameters: <add|del|list> <send|receive> [<email@domain.com>]"
 
 case ${2} in
   send)
@@ -19,7 +19,7 @@ case ${2} in
     ;;
   *)
     usage
-    _errex "missing parameters. Specify \"send\" or \"receive\""
+    _exit_with_error "missing parameters. Specify \"send\" or \"receive\""
     ;;
 esac
 
@@ -27,12 +27,12 @@ if [[ -z ${USER} ]] && [[ ${MODE} != list ]]
 then
   read -r -p "User(user@domain.com): " USER
   echo
-  [[ -z ${USER} ]] && _errex "User must not be empty"
+  [[ -z ${USER} ]] && _exit_with_error "User must not be empty"
 fi
 
 case ${MODE} in
   add)
-    grep -qi "^$(_escape "${USER}")" "${DATABASE}" 2>/dev/null && _errex "User \"${USER}\" already denied to ${2} mails"
+    grep -qi "^$(_escape "${USER}")" "${DATABASE}" 2>/dev/null && _exit_with_error "User \"${USER}\" already denied to ${2} mails"
 
     if [[ ! -f ${DATABASE} ]]
     then
@@ -48,7 +48,7 @@ case ${MODE} in
   ;;
 
   del)
-    sed -ie "/^$(_escape "${USER}")/d" "${DATABASE}" 2>/dev/null || _errex "User \"${USER}\" not found."
+    sed -ie "/^$(_escape "${USER}")/d" "${DATABASE}" 2>/dev/null || _exit_with_error "User \"${USER}\" not found."
   ;;
 
   list)
@@ -56,7 +56,7 @@ case ${MODE} in
     ;;
   *)
     usage
-    _errex "missing mode. Specify \"add\", \"del\" or \"list\""
+    _exit_with_error "missing mode. Specify \"add\", \"del\" or \"list\""
   ;;
 
 esac

--- a/target/bin/setquota
+++ b/target/bin/setquota
@@ -17,19 +17,19 @@ QUOTA="${*}"
 
 function usage  { echo "Usage: setquota <user@domain> [<quota>]" ; }
 
-[[ -z ${USER} ]] && { usage ; _errex "no username specified" ; }
-[[ ${USER} =~ .*\@.* ]] || { usage ; _errex "username must include the domain" ; }
+[[ -z ${USER} ]] && { usage ; _exit_with_error "no username specified" ; }
+[[ ${USER} =~ .*\@.* ]] || { usage ; _exit_with_error "username must include the domain" ; }
 
 if ! grep -qE "^${USER}\|" "${USER_DATABASE}"
 then
-  usage; _errex "user ${USER} does not exist"
+  usage; _exit_with_error "user ${USER} does not exist"
 fi
 
 # check quota
 if [[ -n ${QUOTA} ]] && ! echo "${QUOTA}" | grep -qE "^([0-9]+(B|k|M|G|T)|0)\$"
 then
   usage
-  _errex "invalid quota format. e.g. 302M (B (byte), k (kilobyte), M (megabyte), G (gigabyte) or T (terabyte))"
+  _exit_with_error "invalid quota format. e.g. 302M (B (byte), k (kilobyte), M (megabyte), G (gigabyte) or T (terabyte))"
 fi
 
 _create_lock # Protect config file with lock to avoid race conditions
@@ -39,14 +39,14 @@ if [[ -z ${QUOTA} ]]
 then
   read -r -s "Enter quota (e.g. 10M): " QUOTA
   echo
-  [[ -z "${QUOTA}" ]] && _errex "Quota must not be empty. Use 0 for unlimited quota"
+  [[ -z "${QUOTA}" ]] && _exit_with_error "Quota must not be empty. Use 0 for unlimited quota"
 fi
 
 # check quota
 if [[ -n ${QUOTA} ]] && ! echo "${QUOTA}" | grep -qE "^([0-9]+(B|k|M|G|T)|0)\$"
 then
   usage
-  _errex "invalid quota format. e.g. 302M (B (byte), k (kilobyte), M (megabyte), G (gigabyte) or T (terabyte))"
+  _exit_with_error "invalid quota format. e.g. 302M (B (byte), k (kilobyte), M (megabyte), G (gigabyte) or T (terabyte))"
 fi
 
 delquota "${USER}"

--- a/target/bin/updatemailuser
+++ b/target/bin/updatemailuser
@@ -16,18 +16,18 @@ PASSWD="${*}"
 
 function usage  {	echo "Usage: updatemailuser <user@domain.tld> [password]" ; }
 
-[[ -z ${USER} ]] && { usage ; _errex "no username specified" ; }
+[[ -z ${USER} ]] && { usage ; _exit_with_error "no username specified" ; }
 
 if [[ -z ${PASSWD} ]]
 then
   read -r -s -p "Enter Password: " PASSWD
   echo
-  [[ -z ${PASSWD} ]] && _errex "Password must not be empty"
+  [[ -z ${PASSWD} ]] && _exit_with_error "Password must not be empty"
 fi
 
 HASH="$(doveadm pw -s SHA512-CRYPT -u "${USER}" -p "${PASSWD}")"
 
 touch "${DATABASE}"
 _create_lock # Protect config file with lock to avoid race conditions
-grep -qi "^$(_escape "${USER}")|" "${DATABASE}" 2>/dev/null || _errex "User \"${USER}\" does not exist"
+grep -qi "^$(_escape "${USER}")|" "${DATABASE}" 2>/dev/null || _exit_with_error "User \"${USER}\" does not exist"
 sed -i "s ^""${USER}""|.* ""${USER}""|""${HASH}"" " "${DATABASE}"

--- a/target/scripts/helpers/error.sh
+++ b/target/scripts/helpers/error.sh
@@ -1,12 +1,12 @@
 #! /bin/bash
 
-function _errex
+function _exit_with_error
 {
   if [[ -n ${1+set} ]]
   then
     _log 'error' "${1}"
   else
-    _log 'error' "Call to '_errex' is missing a message to log"
+    _log 'error' "Call to '_exit_with_error' is missing a message to log"
   fi
 
   _log 'error' 'Aborting'

--- a/target/scripts/helpers/lock.sh
+++ b/target/scripts/helpers/lock.sh
@@ -31,7 +31,7 @@ function _create_lock
 function _remove_lock
 {
   LOCK_FILE="${LOCK_FILE:-"/tmp/docker-mailserver/${SCRIPT_NAME}.lock"}"
-  [[ -z "${LOCK_ID}" ]] && _errex "Cannot remove ${LOCK_FILE} as there is no LOCK_ID set"
+  [[ -z "${LOCK_ID}" ]] && _exit_with_error "Cannot remove ${LOCK_FILE} as there is no LOCK_ID set"
   if [[ -e "${LOCK_FILE}" ]] && grep -q "${LOCK_ID}" "${LOCK_FILE}" # Ensure we don't delete a lock that's not ours
   then
     rm -f "${LOCK_FILE}"


### PR DESCRIPTION
# Description

To maintainers, it is clear what `_errex` is, because we're working with
it frequently. The nameing choice, however, was (IMHO) no good. It is
needlessly short (why abbreviate error) and does not communicate its
functionality very well.

Now, it's very clear and yet not too long.## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
