### PR TITLE
log/scripts: introduce proper log level fallback and env getter function

### DIFF
--- a/target/scripts/helpers/log.sh
+++ b/target/scripts/helpers/log.sh
@@ -39,10 +39,11 @@ function _log
     return 1
   fi
 
-  local MESSAGE LEVEL_AS_INT
+  local MESSAGE LEVEL_AS_INT FALLBACK_LOG_LEVEL
   MESSAGE="${LOG_RESET}["
+  FALLBACK_LOG_LEVEL=$(grep "LOG_LEVEL" /etc/dms-settings | cut -d '=' -f 2 | tr -d "'")
 
-  case "${LOG_LEVEL:-}" in
+  case "${LOG_LEVEL:-${FALLBACK_LOG_LEVEL}}" in
     ( 'trace'  ) LEVEL_AS_INT=5 ;;
     ( 'debug'  ) LEVEL_AS_INT=4 ;;
     ( 'warn'   ) LEVEL_AS_INT=2 ;;

--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -11,3 +11,10 @@ function _is_comment
 {
   grep -q -E "^\s*$|^\s*#" <<< "${1}"
 }
+
+# Provide the name of an environment variable to this function
+# and it will return its value stored in /etc/dms-settings
+function _get_dms_env_value
+{
+  grep "${1}" /etc/dms-settings | cut -d '=' -f 2 | tr -d "'"
+}


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

This PR does two small things:

1. The log level, in case it is unset, will now be "calculated" from
   `/etc/dms-settings` and not always default to `info`. This way, we
   can ensure that more often than not, the log level the user chose
   when starting DMS is used everywhere.
2. I noticed that the way I obtained the log level could be used to
   obtain any env variable's log level. I therefore added a function to
   `utils.sh` in case we use it in the future.

The reason for not using the new function from `utils.sh` in `log.sh` is that I would like to preserve `log.sh`'s property of not being dependent of other helper scripts.


## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
