### PR TITLE
tests: disabled "quota exceeded" test

### DIFF
--- a/test/tests.bats
+++ b/test/tests.bats
@@ -860,7 +860,7 @@ EOF
 }
 
 @test "checking quota: warn message received when quota exceeded" {
-  skip 'disabled as it fails randomly: https://github.com/docker-mailserver/docker-mailserver/pull/2508'
+  skip 'disabled as it fails randomly: https://github.com/docker-mailserver/docker-mailserver/pull/2511'
 
   wait_for_changes_to_be_detected_in_container mail
 

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -860,6 +860,8 @@ EOF
 }
 
 @test "checking quota: warn message received when quota exceeded" {
+  skip 'disabled as it fails randomly: https://github.com/docker-mailserver/docker-mailserver/pull/2508'
+
   wait_for_changes_to_be_detected_in_container mail
 
   # create user


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
The "quota exceeded" test is unreliable and failed too often lately for my taste. Therefore, I'd like to disable it because there is no use in having such a test.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
