### PR TITLE
add compatibility for Bash 4 to setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,7 @@ LBLUE="\e[94m"
 RESET="\e[0m"
 
 set -euEo pipefail
-shopt -s inherit_errexit
+shopt -s inherit_errexit 2>/dev/null || true
 trap '__err "${BASH_SOURCE}" "${FUNCNAME[0]:-?}" "${BASH_COMMAND:-?}" "${LINENO:-?}" "${?:-?}"' ERR
 
 function __err


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
The command `shopt -s inherit_errexit` does not work in Bash < 4.4. This
commit fixes the error.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #2518

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
