### PR TITLE
refactor: letsencrypt implicit location discovery

### DIFF
--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -66,6 +66,10 @@ do
     # Also note that changes are performed in place and are not atomic
     # We should fix that and write to temporary files, stop, swap and start
 
+    # _setup_ssl is required for:
+    # manual - copy to internal DMS_TLS_PATH (/etc/dms/tls) that Postfix and Dovecot are configured to use.
+    # acme.json - presently uses /etc/letsencrypt/live/<FQDN> instead of DMS_TLS_PATH,
+    # path may change requiring Postfix/Dovecot config update.
     if [[ ${SSL_TYPE} == 'manual' ]]
     then
       # only run the SSL setup again if certificates have really changed.
@@ -75,9 +79,6 @@ do
       || [[ ${CHANGED} =~ ${SSL_ALT_KEY_PATH:-${REGEX_NEVER_MATCH}} ]]
       then
         _log_with_date 'debug' 'Manual certificates have changed - extracting certificates'
-        # we need to run the SSL setup again, because the
-        # certificates DMS is working with are copies of
-        # the (now changed) files
         _setup_ssl
       fi
     # `acme.json` is only relevant to Traefik, and is where it stores the certificates it manages.
@@ -113,7 +114,6 @@ do
 
     # If monitored certificate files in /etc/letsencrypt/live have changed and no `acme.json` is in use,
     # They presently have no special handling other than to trigger a change that will restart Postfix/Dovecot.
-    # TODO: That should be all that's required, unless the cert file paths have also changed (Postfix/Dovecot configs then need to be updated).
 
     # regenerate postfix accounts
     [[ ${SMTP_ONLY} -ne 1 ]] && _create_accounts

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -135,13 +135,12 @@ function _check_for_changes
 
   # mark changes as applied
   mv "${CHKSUM_FILE}.new" "${CHKSUM_FILE}"
-
-  sleep 2
 }
 
 while true
 do
   _check_for_changes
+  sleep 2
 done
 
 exit 0

--- a/target/scripts/helpers/ssl.sh
+++ b/target/scripts/helpers/ssl.sh
@@ -396,11 +396,11 @@ function _find_letsencrypt_domain
   then
     LETSENCRYPT_DOMAIN=${DOMAINNAME}
   else
-    _log 'warn' "Cannot find a valid DOMAIN for '/etc/letsencrypt/live/<DOMAIN>/', tried: '${SSL_DOMAIN}', '${HOSTNAME}', '${DOMAINNAME}'"
+    _log 'error' "Cannot find a valid DOMAIN for '/etc/letsencrypt/live/<DOMAIN>/', tried: '${SSL_DOMAIN}', '${HOSTNAME}', '${DOMAINNAME}'"
     dms_panic__misconfigured 'LETSENCRYPT_DOMAIN' '_find_letsencrypt_domain'
   fi
 
-  return "${LETSENCRYPT_DOMAIN}"
+  echo "${LETSENCRYPT_DOMAIN}"
 }
 
 # Verify the FQDN folder also includes a valid private key (`privkey.pem` for Certbot, `key.pem` for extraction by Traefik)
@@ -421,11 +421,11 @@ function _find_letsencrypt_key
   then
     LETSENCRYPT_KEY='key'
   else
-    _log 'warn' "Cannot find key file ('privkey.pem' or 'key.pem') in '/etc/letsencrypt/live/${LETSENCRYPT_DOMAIN}/'"
+    _log 'error' "Cannot find key file ('privkey.pem' or 'key.pem') in '/etc/letsencrypt/live/${LETSENCRYPT_DOMAIN}/'"
     dms_panic__misconfigured 'LETSENCRYPT_KEY' '_find_letsencrypt_key'
   fi
 
-  return "${LETSENCRYPT_KEY}"
+  echo "${LETSENCRYPT_KEY}"
 }
 
 function _extract_certs_from_acme

--- a/test/mail_ssl_letsencrypt.bats
+++ b/test/mail_ssl_letsencrypt.bats
@@ -59,7 +59,7 @@ function teardown() {
   #test hostname has certificate files
   _should_have_valid_config "${TARGET_DOMAIN}" 'privkey.pem' 'fullchain.pem'
   _should_succesfully_negotiate_tls "${TARGET_DOMAIN}"
-  _should_not_have_fqdn_in_cert 'example.test'
+  _should_not_support_fqdn_in_cert 'example.test'
 }
 
 
@@ -79,7 +79,7 @@ function teardown() {
   #test domain has certificate files
   _should_have_valid_config "${TARGET_DOMAIN}" 'privkey.pem' 'fullchain.pem'
   _should_succesfully_negotiate_tls "${TARGET_DOMAIN}"
-  _should_not_have_fqdn_in_cert 'mail.example.test'
+  _should_not_support_fqdn_in_cert 'mail.example.test'
 }
 
 # When using `acme.json` (Traefik) - a wildcard cert `*.example.test` (SSL_DOMAIN)
@@ -170,7 +170,7 @@ function teardown() {
     # Verify this works for wildcard certs, it should use `*.example.test` for `mail.example.test` (NOT `example.test`):
     _should_succesfully_negotiate_tls 'mail.example.test'
     # WARNING: This should fail...but requires resolving the above TODO.
-    # _should_not_have_fqdn_in_cert 'example.test'
+    # _should_not_support_fqdn_in_cert 'example.test'
   }
 
   _prepare


### PR DESCRIPTION
# Description

Small refactor to better support `check-for-changes.sh` functionality.

These changes should allow some additional test coverage to be enabled. This implements _Option B_ I described [in comment for a PR](https://github.com/docker-mailserver/docker-mailserver/pull/2524#issuecomment-1086750378) trying to enable that additional coverage.

- Changes to `ssl.sh` is minimal, effectively lifting the logic out of `_setup_ssl` to separate methods so that `check-for-changes.sh` can use one.
- `check-for-changes.sh` is primarily simplifying the logic by dropping the loop and inner conditional statement (_so some lines only have indentation changes_), calling `_setup_ssl` and `_find_letsencrypt_domain` instead. A separate commit improves relevant maintainer comments.
- Unnecessary to this PR is wrapping the change detection into a function that the loop calls instead of inlined. I did this to use `local` annotation.

<details>
<summary>All commit messages for easy reference</summary>

> **chore: Extract letsencrypt logic into methods**
> This allows other scripts to share the functionality to discover the correct letsencrypt folder from the 3 possible locations (where specific order is important).
> 
> As these methods should now return a string value, the `return 1` after a panic is now dropped.
> 
> ~~The `_find_letsencrypt_key` method can take a domain as an arg, otherwise it will retrieve the internal domain the same way as a fallback, which is slightly inefficient to repeat but should be a non-issue.~~ (No longer the case)

> **chore: Update comments**
> The todo is resolved with this PR; `_setup_ssl` will be called by both cert conditional statements, the purpose for each is better documented for maintainers.

> **refactor: Defer most logic to helper/ssl.sh**
> The loop is no longer required, extraction is delegated to `_setup_ssl` now.
> 
> For the change event prevention, we retrieve the relevant FQDN via the new helper method, beyond that it's just indentation diff.

> **chore: Appease the lint gods**
> The lint warning for the unused optional parameter could alternatively be resolved by prepending `#shellcheck disable=SC2120` to the function definition.
> As there are no other consumers, I changed to a required arg with a hard failure instead of providing a fallback.
> 
> `check-for-changes.sh` adjusted to allow locally scoped var declarations by wrapping a function. Presently no loop control flow is needed so this seems fine. Made it clear that `CHANGED` is local and `CHKSUM_FILE` is not.
> 
> The panic scope arg doesn't need `SSL_TYPE` for added context, it's clearly`letsencrypt`, removed.

</details>

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
