### PR TITLE
setup: added grace period for account creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ NAME
 
 #### Starting for the first time
 
-On first start, you will need to add email accounts (unless you're using LDAP). You have two minutes time before DMS will shut down if there are no accounts. You can add accounts with the following two methods:
+On first start, you will need to add at least one email account (unless you're using LDAP). You have two minutes to do so, otherwise DMS will shutdown and restart. You can add accounts with the following two methods:
 
-1. Use `setup.sh` to help you: `./setup.sh email add <user@domain> <password>`
-2. Execute the complete command yourself: `docker exec -ti <CONTAINER NAME> setup email add <user@domain> <password>`
+1. Use `setup.sh`: `./setup.sh email add <user@domain>`
+2. Run the command directly in the container: `docker exec -ti <CONTAINER NAME> setup email add <user@domain>`
 
 You can then proceed by creating the postmaster alias and by creating DKIM keys.
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ NAME
 
 #### Starting for the first time
 
-On first start, you will likely see an error stating that there are no mail accounts and the container will exit. You must now do one of two things:
+On first start, you will need to add email accounts (unless you're using LDAP). You have two minutes time before DMS will shut down if there are no accounts. You can add accounts with the following two methods:
 
 1. Use `setup.sh` to help you: `./setup.sh email add <user@domain> <password>`. You may need  the `-c` option to provide the local path for persisting configuration (_a directory that mounts to `/tmp/docker-mailserver` inside the container_). This will spin up a new container, mount your configuration volume, and create your first account.
 2. Execute the complete command yourself: `docker run --rm -v "${PWD}/docker-data/dms/config/:/tmp/docker-mailserver/" docker.io/mailserver/docker-mailserver setup email add <user@domain> <password>`. Make sure to mount the correct configuration directory.

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ NAME
 
 On first start, you will need to add email accounts (unless you're using LDAP). You have two minutes time before DMS will shut down if there are no accounts. You can add accounts with the following two methods:
 
-1. Use `setup.sh` to help you: `./setup.sh email add <user@domain> <password>`. You may need  the `-c` option to provide the local path for persisting configuration (_a directory that mounts to `/tmp/docker-mailserver` inside the container_). This will spin up a new container, mount your configuration volume, and create your first account.
-2. Execute the complete command yourself: `docker run --rm -v "${PWD}/docker-data/dms/config/:/tmp/docker-mailserver/" docker.io/mailserver/docker-mailserver setup email add <user@domain> <password>`. Make sure to mount the correct configuration directory.
+1. Use `setup.sh` to help you: `./setup.sh email add <user@domain> <password>`
+2. Execute the complete command yourself: `docker exec -ti <CONTAINER NAME> setup email add <user@domain> <password>`
 
 You can then proceed by creating the postmaster alias and by creating DKIM keys.
 

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -300,11 +300,11 @@ function _setup_dovecot_local_user
   local SLEEP_PERIOD='10'
   for (( COUNTER = 11 ; COUNTER >= 0 ; COUNTER-- ))
   do
-    if grep '@' /tmp/docker-mailserver/postfix-accounts.cf 2>/dev/null | grep -q '|'
+    if [[ $(grep -cE '.+@.+\|' /tmp/docker-mailserver/postfix-accounts.cf) -ge 1 ]]
     then
       return 0
     else
-      _log 'warn' "You need at least 1 email account to start Dovecot ($(( ( COUNTER + 1 ) * SLEEP_PERIOD ))s left for account creation before shutdown)"
+      _log 'warn' "You need at least one email account to start Dovecot ($(( ( COUNTER + 1 ) * SLEEP_PERIOD ))s left for account creation before shutdown)"
       sleep "${SLEEP_PERIOD}"
     fi
   done

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -290,19 +290,26 @@ function _setup_dovecot_local_user
   _log 'debug' 'Setting up Dovecot Local User'
 
   _create_accounts
+  [[ ${ENABLE_LDAP} -eq 1 ]] && return 0
 
   if [[ ! -f /tmp/docker-mailserver/postfix-accounts.cf ]]
   then
-    _log 'trace' "'/tmp/docker-mailserver/postfix-accounts.cf' is not provided. No mail account created."
+    _log 'trace' "'/tmp/docker-mailserver/postfix-accounts.cf' not provided, no mail account created"
   fi
 
-  if ! grep '@' /tmp/docker-mailserver/postfix-accounts.cf 2>/dev/null | grep -q '|'
-  then
-    if [[ ${ENABLE_LDAP} -eq 0 ]]
+  local SLEEP_PERIOD='10'
+  for (( COUNTER = 11 ; COUNTER >= 0 ; COUNTER-- ))
+  do
+    if grep '@' /tmp/docker-mailserver/postfix-accounts.cf 2>/dev/null | grep -q '|'
     then
-      _shutdown 'Unless using LDAP, you need at least 1 email account to start Dovecot'
+      return 0
+    else
+      _log 'warn' "You need at least 1 email account to start Dovecot ($(( ( COUNTER + 1 ) * SLEEP_PERIOD ))s left for account creation before shutdown)"
+      sleep "${SLEEP_PERIOD}"
     fi
-  fi
+  done
+
+  _shutdown 'No accounts provided - Dovecot could not be started'
 }
 
 function _setup_ldap


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

Previously, DMS would shut down immediately if no accounts were provided in an IMAP setup. This change drastically reduces the efforts for beginners, giving them two minutes of time before the container shuts down. This has the effect that setup is drastically simplified.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
