### PR TITLE
log: adjust level and message(s) slightly

### DIFF
--- a/target/scripts/helpers/ssl.sh
+++ b/target/scripts/helpers/ssl.sh
@@ -351,7 +351,7 @@ function _setup_ssl
       ;;
 
     ( '' ) # No SSL/TLS certificate used/required, plaintext auth permitted over insecure connections
-      _log 'warn' "(INSECURE!) SSL configured with plain text access. DO NOT USE FOR PRODUCTION DEPLOYMENT."
+      _log 'warn' "!! INSECURE !! SSL configured with plain text access - DO NOT USE FOR PRODUCTION DEPLOYMENT"
       # Untested. Not officially supported.
 
       # Postfix configuration:

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -881,11 +881,11 @@ function _setup_security_stack
   # SpamAssassin
   if [[ ${ENABLE_SPAMASSASSIN} -eq 0 ]]
   then
-    _log 'warn' "Spamassassin is disabled. You can enable it with 'ENABLE_SPAMASSASSIN=1'"
+    _log 'debug' 'SpamAssassin is disabled'
     echo "@bypass_spam_checks_maps = (1);" >>"${DMS_AMAVIS_FILE}"
   elif [[ ${ENABLE_SPAMASSASSIN} -eq 1 ]]
   then
-    _log 'debug' "Enabling and configuring spamassassin"
+    _log 'debug' "Enabling and configuring SpamAssassin"
 
     # shellcheck disable=SC2016
     sed -i -r 's|^\$sa_tag_level_deflt (.*);|\$sa_tag_level_deflt = '"${SA_TAG}"';|g' /etc/amavis/conf.d/20-debian_defaults
@@ -969,7 +969,7 @@ EOM
   # ClamAV
   if [[ ${ENABLE_CLAMAV} -eq 0 ]]
   then
-    _log 'info' "ClamAV is disabled"
+    _log 'debug' "ClamAV is disabled"
     echo '@bypass_virus_checks_maps = (1);' >>"${DMS_AMAVIS_FILE}"
   elif [[ ${ENABLE_CLAMAV} -eq 1 ]]
   then


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

Small follow-up where I found some log levels that I thought should be changed. Disabling ClamAV and SA is perfectly fine, and should not be logged with the same level as something like `Welcome to docker-mailserver <VERSION>`. Another small adjustment to the SSL insecure message, nothing big though. **I swear this is the last log adjustment PR in a while :D**

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
