### PR TITLE
Add ban feature to fail2ban script

### DIFF
--- a/config-examples/fail2ban-jail.cf
+++ b/config-examples/fail2ban-jail.cf
@@ -34,3 +34,4 @@ enabled = true
 [custom]
 enabled = true
 bantime = 180d
+port = smtp,pop3,pop3s,imap,imaps,submission,465,sieve

--- a/config-examples/fail2ban-jail.cf
+++ b/config-examples/fail2ban-jail.cf
@@ -1,21 +1,33 @@
 [DEFAULT]
 
 # "bantime" is the number of seconds that a host is banned.
-#bantime  = 10m
+bantime = 3h
 
 # A host is banned if it has generated "maxretry" during the last "findtime"
 # seconds.
-#findtime  = 10m
+findtime = 10m
 
 # "maxretry" is the number of failures before a host get banned.
-#maxretry = 5
+maxretry = 3
 
 # "ignoreip" can be a list of IP addresses, CIDR masks or DNS hosts. Fail2ban
 # will not ban a host which matches an address in this list. Several addresses
 # can be defined using space (and/or comma) separator.
-#ignoreip = 127.0.0.1/8
+ignoreip = 127.0.0.1/8
 
-# Default ban action
-# nftables-multiport:	block IP only on affected port
-# nftables-allports:	block IP on all ports
-#banaction = nftables-allports
+# default ban action
+# nftables-multiport: block IP only on affected port
+# nftables-allports:  block IP on all ports
+banaction = nftables-allports
+
+[dovecot]
+enabled = true
+
+[postfix]
+enabled = true
+
+[postfix-sasl]
+enabled = true
+
+[custom]
+enabled = true

--- a/config-examples/fail2ban-jail.cf
+++ b/config-examples/fail2ban-jail.cf
@@ -31,3 +31,4 @@ enabled = true
 
 [custom]
 enabled = true
+bantime = 180d

--- a/config-examples/fail2ban-jail.cf
+++ b/config-examples/fail2ban-jail.cf
@@ -34,4 +34,4 @@ enabled = true
 [custom]
 enabled = true
 bantime = 180d
-port = smtp,pop3,pop3s,imap,imaps,submission,465,sieve
+port = smtp,pop3,pop3s,imap,imaps,submission,submissions,sieve

--- a/config-examples/fail2ban-jail.cf
+++ b/config-examples/fail2ban-jail.cf
@@ -29,6 +29,8 @@ enabled = true
 [postfix-sasl]
 enabled = true
 
+# This jail is used for manual bans.
+# To ban an IP address use: setup.sh fail2ban ban <IP>
 [custom]
 enabled = true
 bantime = 180d

--- a/docs/content/config/security/fail2ban.md
+++ b/docs/content/config/security/fail2ban.md
@@ -97,7 +97,7 @@ You can also manage and list the banned IPs with the [`setup.sh`][docs-setupsh] 
 ### List bans
 
 ```sh
-./setup.sh debug fail2ban
+./setup.sh fail2ban
 ```
 
 ### Un-ban
@@ -105,7 +105,7 @@ You can also manage and list the banned IPs with the [`setup.sh`][docs-setupsh] 
 Here `192.168.1.15` is our banned IP.
 
 ```sh
-./setup.sh debug fail2ban unban 192.168.1.15
+./setup.sh fail2ban unban 192.168.1.15
 ```
 
 [docs-setupsh]: ../setup.sh.md

--- a/docs/content/config/setup.sh.md
+++ b/docs/content/config/setup.sh.md
@@ -73,8 +73,12 @@ DESCRIPTION
         ./setup.sh relay add-domain <DOMAIN> <HOST> [<PORT>]
         ./setup.sh relay exclude-domain <DOMAIN>
 
+    COMMAND fail2ban =
+        ./setup.sh fail2ban
+        ./setup.sh fail2ban ban <IP>
+        ./setup.sh fail2ban unban <IP>
+
     COMMAND debug :=
-        ./setup.sh debug fail2ban [unban <IP>]
         ./setup.sh debug fetchmail
         ./setup.sh debug login <COMMANDS>
         ./setup.sh debug show-mail-logs

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -427,6 +427,17 @@ sed -i 's/rimap -r/rimap/' /etc/supervisor/conf.d/saslauth.conf
 supervisorctl update
 ```
 
+### How to ban custom IP addresses with Fail2ban
+
+Use the following command:
+
+```bash
+./setup.sh fail2ban ban <IP>
+```
+
+The default bantime is 180 days. This value can be [customized][fail2ban-customize].
+
+[fail2ban-customize]: ./config/security/fail2ban.md
 [docs-maintenance]: ./config/advanced/maintenance/update-and-cleanup.md
 [docs-userpatches]: ./config/advanced/override-defaults/user-patches.md
 [github-issue-95]: https://github.com/docker-mailserver/docker-mailserver/issues/95

--- a/target/bin/fail2ban
+++ b/target/bin/fail2ban
@@ -3,7 +3,11 @@
 # shellcheck source=../scripts/helpers/index.sh
 source /usr/local/bin/helpers/index.sh
 
-function __usage { echo "Usage: ${0} [<unban> <ip-address|network|hostname>]" ; }
+function __usage {
+  echo "Usage: ${0}" ;
+  echo "       ${0} ban <IP>" ;
+  echo "       ${0} unban <IP>" ;
+}
 
 unset JAILS
 declare -a JAILS
@@ -40,14 +44,14 @@ else
       shift
       if [[ -n ${1} ]]
       then
-        RESULT=$(fail2ban-client set custom banip ${*})
+        RESULT=$(fail2ban-client set custom banip "${@}")
         if [[ $RESULT -lt 1 ]]
         then
           _log 'error' "Banning '${*}' failed. Already banned?"
         fi
 
       else
-        _log 'warn' "You need to specify an IP address: Run './setup.sh fail2ban ban <ip-address|network|hostname>'"
+        _log 'warn' "You need to specify an IP address: Run './setup.sh fail2ban ban <IP>'"
         exit 0
       fi
       ;;
@@ -59,7 +63,7 @@ else
 
         for JAIL in "${JAILS[@]}"
         do
-          RESULT=$(fail2ban-client set "${JAIL}" unbanip ${*} 2>&1)
+          RESULT=$(fail2ban-client set "${JAIL}" unbanip "${@}" 2>&1)
 
           [[ ${RESULT} != *"is not banned"* ]] && [[ ${RESULT} != *"NOK"* ]] && echo -e "Unbanned IP from ${JAIL}: ${RESULT}"
         done

--- a/target/bin/fail2ban
+++ b/target/bin/fail2ban
@@ -45,7 +45,7 @@ else
       if [[ -n ${1} ]]
       then
         RESULT=$(fail2ban-client set custom banip "${@}")
-        if [[ $RESULT -lt 1 ]]
+        if [[ ${RESULT} -lt 1 ]]
         then
           _log 'error' "Banning '${*}' failed. Already banned?"
         fi

--- a/target/bin/fail2ban
+++ b/target/bin/fail2ban
@@ -45,8 +45,10 @@ else
       if [[ -n ${1} ]]
       then
         RESULT=$(fail2ban-client set custom banip "${@}")
-        if [[ ${RESULT} -lt 1 ]]
+        if [[ ${RESULT} -gt 0 ]]
         then
+          echo "Banned custom IP: ${RESULT}"
+        else
           _log 'error' "Banning '${*}' failed. Already banned?"
         fi
 
@@ -65,7 +67,7 @@ else
         do
           RESULT=$(fail2ban-client set "${JAIL}" unbanip "${@}" 2>&1)
 
-          [[ ${RESULT} != *"is not banned"* ]] && [[ ${RESULT} != *"NOK"* ]] && echo -e "Unbanned IP from ${JAIL}: ${RESULT}"
+          [[ ${RESULT} != *"is not banned"* ]] && [[ ${RESULT} != *"NOK"* ]] && echo "Unbanned IP from ${JAIL}: ${RESULT}"
         done
 
       else

--- a/target/bin/fail2ban
+++ b/target/bin/fail2ban
@@ -3,11 +3,7 @@
 # shellcheck source=../scripts/helpers/index.sh
 source /usr/local/bin/helpers/index.sh
 
-function __usage {
-  echo "Usage: ${0}" ;
-  echo "       ${0} ban <IP>" ;
-  echo "       ${0} unban <IP>" ;
-}
+function __usage { echo "Usage: ./setup.sh fail2ban [<ban|unban> <IP>]" ; }
 
 unset JAILS
 declare -a JAILS
@@ -39,6 +35,8 @@ then
 else
 
   case "${1}" in
+
+    ( 'help' ) __usage ; exit ;;
 
     ( 'ban' )
       shift

--- a/target/bin/fail2ban
+++ b/target/bin/fail2ban
@@ -3,7 +3,7 @@
 # shellcheck source=../scripts/helpers/index.sh
 source /usr/local/bin/helpers/index.sh
 
-function __usage { echo "Usage: ${0} [<unban> <ip-address>]" ; }
+function __usage { echo "Usage: ${0} [<unban> <ip-address|network|hostname>]" ; }
 
 unset JAILS
 declare -a JAILS
@@ -36,6 +36,22 @@ else
 
   case "${1}" in
 
+    ( 'ban' )
+      shift
+      if [[ -n ${1} ]]
+      then
+        RESULT=$(fail2ban-client set custom banip ${*})
+        if [[ $RESULT -lt 1 ]]
+        then
+          _log 'error' "Banning '${*}' failed. Already banned?"
+        fi
+
+      else
+        _log 'warn' "You need to specify an IP address: Run './setup.sh fail2ban ban <ip-address|network|hostname>'"
+        exit 0
+      fi
+      ;;
+
     ( 'unban' )
       shift
       if [[ -n ${1} ]]
@@ -43,13 +59,13 @@ else
 
         for JAIL in "${JAILS[@]}"
         do
-          RESULT="$(fail2ban-client set "${JAIL}" unbanip "${@}" 2>&1)"
+          RESULT=$(fail2ban-client set "${JAIL}" unbanip ${*} 2>&1)
 
           [[ ${RESULT} != *"is not banned"* ]] && [[ ${RESULT} != *"NOK"* ]] && echo -e "Unbanned IP from ${JAIL}: ${RESULT}"
         done
 
       else
-        _log 'warn' "You need to specify an IP address: Run './setup.sh debug fail2ban' to get a list of banned IP addresses"
+        _log 'warn' "You need to specify an IP address: Run './setup.sh fail2ban' to get a list of banned IP addresses"
         exit 0
       fi
       ;;

--- a/target/bin/setup
+++ b/target/bin/setup
@@ -68,7 +68,7 @@ ${RED}[${ORANGE}SUB${RED}]${ORANGE}COMMANDS${RESET}
         ${0} relay ${CYAN}exclude-domain${RESET} <DOMAIN>
 
     ${LBLUE}COMMAND${RESET} fail2ban ${RED}:=${RESET}
-        ${0} fail2ban ${CYAN}${RESET}
+        ${0} fail2ban ${RESET}
         ${0} fail2ban ${CYAN}ban${RESET} <IP>
         ${0} fail2ban ${CYAN}unban${RESET} <IP>
 

--- a/target/bin/setup
+++ b/target/bin/setup
@@ -148,13 +148,7 @@ function _main
       esac
       ;;
 
-    ( fail2ban )
-      case ${2:-} in
-        ( ban            ) shift 2; fail2ban ban "${@}" ;;
-        ( unban          ) shift 2; fail2ban unban "${@}" ;;
-        ( *              ) fail2ban ;;
-      esac
-      ;;
+    ( fail2ban ) shift 1 ; fail2ban "${@}" ;;
 
     ( debug )
       case ${2:-} in

--- a/target/bin/setup
+++ b/target/bin/setup
@@ -67,8 +67,12 @@ ${RED}[${ORANGE}SUB${RED}]${ORANGE}COMMANDS${RESET}
         ${0} relay ${CYAN}add-domain${RESET} <DOMAIN> <HOST> [<PORT>]
         ${0} relay ${CYAN}exclude-domain${RESET} <DOMAIN>
 
+    ${LBLUE}COMMAND${RESET} fail2ban ${RED}:=${RESET}
+        ${0} fail2ban ${CYAN}${RESET}
+        ${0} fail2ban ${CYAN}ban${RESET} <IP>
+        ${0} fail2ban ${CYAN}unban${RESET} <IP>
+
     ${LBLUE}COMMAND${RESET} debug ${RED}:=${RESET}
-        ${0} debug ${CYAN}fail2ban${RESET} [unban <IP>]
         ${0} debug ${CYAN}fetchmail${RESET}
         ${0} debug ${CYAN}login${RESET} <COMMANDS>
         ${0} debug ${CYAN}show-mail-logs${RESET}
@@ -144,10 +148,17 @@ function _main
       esac
       ;;
 
+    ( fail2ban )
+      case ${2:-} in
+        ( ban            ) shift 2; fail2ban ban "${@}" ;;
+        ( unban          ) shift 2; fail2ban unban "${@}" ;;
+        ( *              ) fail2ban ;;
+      esac
+      ;;
+
     ( debug )
       case ${2:-} in
         ( fetchmail      ) debug-fetchmail ;;
-        ( fail2ban       ) shift 2 ; fail2ban "${@}" ;;
         ( show-mail-logs ) cat /var/log/mail/mail.log ;;
         ( login          )
           shift 2

--- a/target/fail2ban/jail.local
+++ b/target/fail2ban/jail.local
@@ -34,3 +34,4 @@ enabled = true
 [custom]
 enabled = true
 bantime = 180d
+port = smtp,pop3,pop3s,imap,imaps,submission,465,sieve

--- a/target/fail2ban/jail.local
+++ b/target/fail2ban/jail.local
@@ -31,3 +31,4 @@ enabled = true
 
 [custom]
 enabled = true
+bantime = 180d

--- a/target/fail2ban/jail.local
+++ b/target/fail2ban/jail.local
@@ -28,3 +28,6 @@ enabled = true
 
 [postfix-sasl]
 enabled = true
+
+[custom]
+enabled = true

--- a/target/fail2ban/jail.local
+++ b/target/fail2ban/jail.local
@@ -34,4 +34,4 @@ enabled = true
 [custom]
 enabled = true
 bantime = 180d
-port = smtp,pop3,pop3s,imap,imaps,submission,465,sieve
+port = smtp,pop3,pop3s,imap,imaps,submission,submissions,sieve

--- a/target/fail2ban/jail.local
+++ b/target/fail2ban/jail.local
@@ -29,6 +29,8 @@ enabled = true
 [postfix-sasl]
 enabled = true
 
+# This jail is used for manual bans.
+# To ban an IP address use: setup.sh fail2ban ban <IP>
 [custom]
 enabled = true
 bantime = 180d

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -1142,10 +1142,14 @@ function _setup_user_patches
 function _setup_fail2ban
 {
   _log 'debug' 'Setting up Fail2Ban'
+
   if [[ ${FAIL2BAN_BLOCKTYPE} != 'reject' ]]
   then
     echo -e '[Init]\nblocktype = drop' >/etc/fail2ban/action.d/nftables-common.local
   fi
+
+  echo -e '[custom]\nenabled = true' >/etc/fail2ban/jail.d/custom.conf
+  echo -e '[Definition]'             >/etc/fail2ban/filter.d/custom.conf
 }
 
 function _setup_dnsbl_disable

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -1148,8 +1148,7 @@ function _setup_fail2ban
     echo -e '[Init]\nblocktype = drop' >/etc/fail2ban/action.d/nftables-common.local
   fi
 
-  echo -e '[custom]\nenabled = true' >/etc/fail2ban/jail.d/custom.conf
-  echo -e '[Definition]'             >/etc/fail2ban/filter.d/custom.conf
+  echo '[Definition]' >/etc/fail2ban/filter.d/custom.conf
 }
 
 function _setup_dnsbl_disable

--- a/test/mail_fail2ban.bats
+++ b/test/mail_fail2ban.bats
@@ -120,7 +120,7 @@ function teardown_file() {
 # debug
 #
 
-@test "checking setup.sh: setup.sh debug fail2ban" {
+@test "checking setup.sh: setup.sh fail2ban" {
 
   run docker exec mail_fail2ban /bin/sh -c "fail2ban-client set dovecot banip 192.0.66.4"
   run docker exec mail_fail2ban /bin/sh -c "fail2ban-client set dovecot banip 192.0.66.5"

--- a/test/mail_fail2ban.bats
+++ b/test/mail_fail2ban.bats
@@ -116,9 +116,19 @@ function teardown_file() {
   refute_output "${FAIL_AUTH_MAILER_IP}"
 }
 
-#
-# debug
-#
+@test "checking fail2ban ban" {
+  run docker exec mail_fail2ban fail2ban ban 192.0.66.7
+  assert_success
+  assert_output "Banned custom IP: 1"
+
+  run docker exec mail_fail2ban fail2ban
+  assert_success
+  assert_output --regexp "^Banned in custom:.*192\.0\.66\.7$"
+
+  run docker exec mail_fail2ban fail2ban unban 192.0.66.7
+  assert_success
+  assert_output --partial "Unbanned IP from custom: 1"
+}
 
 @test "checking setup.sh: setup.sh fail2ban" {
 
@@ -127,21 +137,20 @@ function teardown_file() {
 
   sleep 10
 
-  run ./setup.sh -c mail_fail2ban debug fail2ban
-  assert_output --partial 'Banned in dovecot:'
-  assert_output --partial '192.0.66.5'
-  assert_output --partial '192.0.66.4'
+  run ./setup.sh -c mail_fail2ban fail2ban
+  assert_output --regexp '^Banned in dovecot:.*192\.0\.66\.4'
+  assert_output --regexp '^Banned in dovecot:.*192\.0\.66\.5'
 
-  run ./setup.sh -c mail_fail2ban debug fail2ban unban 192.0.66.4
+  run ./setup.sh -c mail_fail2ban fail2ban unban 192.0.66.4
   assert_output --partial "Unbanned IP from dovecot: 1"
 
-  run ./setup.sh -c mail_fail2ban debug fail2ban
-  assert_output --regexp "^Banned in dovecot:.*192.0.66.5.*"
+  run ./setup.sh -c mail_fail2ban fail2ban
+  assert_output --regexp "^Banned in dovecot:.*192\.0\.66\.5"
 
-  run ./setup.sh -c mail_fail2ban debug fail2ban unban 192.0.66.5
+  run ./setup.sh -c mail_fail2ban fail2ban unban 192.0.66.5
   assert_output --partial "Unbanned IP from dovecot: 1"
 
-  run ./setup.sh -c mail_fail2ban debug fail2ban unban
+  run ./setup.sh -c mail_fail2ban fail2ban unban
   assert_output --partial "You need to specify an IP address: Run"
 }
 

--- a/test/mail_fail2ban.bats
+++ b/test/mail_fail2ban.bats
@@ -123,7 +123,7 @@ function teardown_file() {
 
   run docker exec mail_fail2ban fail2ban
   assert_success
-  assert_output --regexp "^Banned in custom:.*192\.0\.66\.7$"
+  assert_output --regexp "Banned in custom:.*192\.0\.66\.7"
 
   run docker exec mail_fail2ban fail2ban unban 192.0.66.7
   assert_success


### PR DESCRIPTION
# Description

This PR adds a new "ban" option to the [fail2ban](https://github.com/docker-mailserver/docker-mailserver/blob/master/target/bin/fail2ban) script. This allows to easily block custom IPs with fail2ban:

`./setup.sh failban ban <IP>`

The default bantime is 180 days, but can be adjusted easily like other fail2ban settings.

`setup.sh`: fail2ban was moved from the "debug" section to it's own fail2ban section:

`setup.sh debug fail2ban` --> `setup.sh fail2ban`

While adding the necessary changes to `config-examples/fail2ban-jail.cf`, I've also synced all values there, with our default settings.

A new fail2ban test was added and the existing ones were improved.

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->


## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
