### PR TITLE
setup.sh/setup: show usage when no argument is given

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -236,4 +236,5 @@ function _main
   return 0
 }
 
+[[ -z ${1:-} ]] && set 'help'
 _main "${@}"

--- a/target/bin/setup
+++ b/target/bin/setup
@@ -167,4 +167,9 @@ function _main
   esac
 }
 
-_main "${@}"
+if [[ $# -eq 0 ]]
+then
+  _usage
+else
+  _main "${@}"
+fi

--- a/target/bin/setup
+++ b/target/bin/setup
@@ -167,7 +167,7 @@ function _main
   esac
 }
 
-if [[ $# -eq 0 ]]
+if [[ -z ${1:-} ]]
 then
   _usage
 else

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -936,10 +936,10 @@ EOF
 # --- setup.sh ----------------------------------
 # -----------------------------------------------
 
-@test "checking setup.sh: exit with error when no arguments provided" {
+@test "checking setup.sh: show usage when no arguments provided" {
   run ./setup.sh
-  assert_failure
-  assert_line --index 0 --partial "The command '' is invalid."
+  assert_success
+  assert_output --partial "This is the main administration script that you use for all your interactions with"
 }
 
 @test "checking setup.sh: exit with error when wrong arguments provided" {


### PR DESCRIPTION
# Description

When running `setup.sh` without arguments, this is shown:

```
The command '' is invalid.
Use `./setup.sh help` to get an overview of all commands.
```

Then the user typically runs `./setup.sh help` to see the available commands. This PR saves a user this additional step, by assuming 'help', when no argument is given.

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
