### PR TITLE
Fix changedetector restart loop

### DIFF
--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -22,19 +22,19 @@ _obtain_hostname_and_domainname
 
 if ! cd /tmp/docker-mailserver &>/dev/null
 then
-  _exit_with_error "Could not change into '/tmp/docker-mailserver/' directory"
+  _exit_with_error "Could not change into '/tmp/docker-mailserver/' directory" 0
 fi
 
 # check postfix-accounts.cf exist else break
 if [[ ! -f postfix-accounts.cf ]]
 then
-  _exit_with_error "'/tmp/docker-mailserver/postfix-accounts.cf' is missing"
+  _exit_with_error "'/tmp/docker-mailserver/postfix-accounts.cf' is missing" 0
 fi
 
 # verify checksum file exists; must be prepared by start-mailserver.sh
 if [[ ! -f ${CHKSUM_FILE} ]]
 then
-  _exit_with_error "'/tmp/docker-mailserver/${CHKSUM_FILE}' is missing"
+  _exit_with_error "'/tmp/docker-mailserver/${CHKSUM_FILE}' is missing" 0
 fi
 
 REGEX_NEVER_MATCH="(?\!)"

--- a/target/scripts/helpers/error.sh
+++ b/target/scripts/helpers/error.sh
@@ -10,7 +10,7 @@ function _exit_with_error
   fi
 
   _log 'error' 'Aborting'
-  exit ${2:-1}
+  exit "${2:-1}"
 }
 
 # `dms_panic` methods are appropriate when the type of error is a not recoverable,

--- a/target/scripts/helpers/error.sh
+++ b/target/scripts/helpers/error.sh
@@ -10,7 +10,7 @@ function _exit_with_error
   fi
 
   _log 'error' 'Aborting'
-  exit 1
+  exit ${2:-1}
 }
 
 # `dms_panic` methods are appropriate when the type of error is a not recoverable,

--- a/target/supervisor/conf.d/supervisor-app.conf
+++ b/target/supervisor/conf.d/supervisor-app.conf
@@ -119,7 +119,6 @@ command=/usr/local/bin/postfix-wrapper.sh
 startsecs=0
 stopwaitsecs=55
 autostart=false
-autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 command=/usr/local/bin/check-for-changes.sh


### PR DESCRIPTION
# Description

The supervisord [configuration](http://supervisord.org/configuration.html) for changedetector always restarts the service once it exits:

https://github.com/docker-mailserver/docker-mailserver/blob/3cb5668b6f62258d8c21629c0f5e649085e4f0b6/target/supervisor/conf.d/supervisor-app.conf#L76

In case the changedetector service exits with an [error](https://github.com/docker-mailserver/docker-mailserver/blob/3cb5668b6f62258d8c21629c0f5e649085e4f0b6/target/scripts/check-for-changes.sh#L25), it's restarted. This leads to an endless exit and restart loop.

To prevent this, `autorestart=true` has been removed from the configuration. This lets supervisord only restart the service, when it exits with error code >0.

The function `_exit_with_error` now allows to pass a second argument: the exit code.

In case of an error, changedetector exits as before, but will not be restarted by supervisord.

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #2546

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
