### PR TITLE
chore: Drop `setup.sh` DATABASE fallback ENV

### DIFF
--- a/target/bin/addalias
+++ b/target/bin/addalias
@@ -3,7 +3,7 @@
 # shellcheck source=../scripts/helpers/index.sh
 source /usr/local/bin/helpers/index.sh
 
-DATABASE=${DATABASE:-/tmp/docker-mailserver/postfix-virtual.cf}
+DATABASE='/tmp/docker-mailserver/postfix-virtual.cf'
 
 function __usage
 {

--- a/target/bin/addmailuser
+++ b/target/bin/addmailuser
@@ -5,7 +5,7 @@
 # shellcheck source=../scripts/helpers/index.sh
 source /usr/local/bin/helpers/index.sh
 
-DATABASE=${DATABASE:-/tmp/docker-mailserver/postfix-accounts.cf}
+DATABASE='/tmp/docker-mailserver/postfix-accounts.cf'
 
 function __usage
 {

--- a/target/bin/addrelayhost
+++ b/target/bin/addrelayhost
@@ -3,7 +3,7 @@
 # shellcheck source=../scripts/helpers/index.sh
 source /usr/local/bin/helpers/index.sh
 
-DATABASE=${DATABASE:-/tmp/docker-mailserver/postfix-relaymap.cf}
+DATABASE='/tmp/docker-mailserver/postfix-relaymap.cf'
 
 function __usage
 {

--- a/target/bin/addsaslpassword
+++ b/target/bin/addsaslpassword
@@ -3,7 +3,7 @@
 # shellcheck source=../scripts/helpers/index.sh
 source /usr/local/bin/helpers/index.sh
 
-DATABASE=${DATABASE:-/tmp/docker-mailserver/postfix-sasl-password.cf}
+DATABASE='/tmp/docker-mailserver/postfix-sasl-password.cf'
 
 function __usage { echo "Usage: addsaslpassword <domain> <username> <password>" ; }
 

--- a/target/bin/delalias
+++ b/target/bin/delalias
@@ -3,7 +3,7 @@
 # shellcheck source=../scripts/helpers/index.sh
 source /usr/local/bin/helpers/index.sh
 
-DATABASE=${DATABASE:-/tmp/docker-mailserver/postfix-virtual.cf}
+DATABASE='/tmp/docker-mailserver/postfix-virtual.cf'
 
 EMAIL="${1}"
 RECIPIENT="${2}"

--- a/target/bin/delmailuser
+++ b/target/bin/delmailuser
@@ -9,9 +9,9 @@
 source /usr/local/bin/helpers/index.sh
 
 DATABASE='/tmp/docker-mailserver/postfix-accounts.cf'
-ALIAS_DATABASE="/tmp/docker-mailserver/postfix-virtual.cf"
-QUOTA_DATABASE="/tmp/docker-mailserver/dovecot-quotas.cf"
-MAILDEL=false
+ALIAS_DATABASE='/tmp/docker-mailserver/postfix-virtual.cf'
+QUOTA_DATABASE='/tmp/docker-mailserver/dovecot-quotas.cf'
+MAILDEL='false'
 
 function __usage
 {

--- a/target/bin/delmailuser
+++ b/target/bin/delmailuser
@@ -8,7 +8,7 @@
 # shellcheck source=../scripts/helpers/index.sh
 source /usr/local/bin/helpers/index.sh
 
-DATABASE=${DATABASE:-/tmp/docker-mailserver/postfix-accounts.cf}
+DATABASE='/tmp/docker-mailserver/postfix-accounts.cf'
 ALIAS_DATABASE="/tmp/docker-mailserver/postfix-virtual.cf"
 QUOTA_DATABASE="/tmp/docker-mailserver/dovecot-quotas.cf"
 MAILDEL=false

--- a/target/bin/delquota
+++ b/target/bin/delquota
@@ -3,7 +3,7 @@
 # shellcheck source=../scripts/helpers/index.sh
 source /usr/local/bin/helpers/index.sh
 
-DATABASE=${DATABASE:-/tmp/docker-mailserver/dovecot-quotas.cf}
+DATABASE='/tmp/docker-mailserver/dovecot-quotas.cf'
 USER_DATABASE=${USER_DATABASE:-/tmp/docker-mailserver/postfix-accounts.cf}
 
 function __usage { echo 'Usage: delquota <username@domain>' ; }

--- a/target/bin/delquota
+++ b/target/bin/delquota
@@ -4,7 +4,7 @@
 source /usr/local/bin/helpers/index.sh
 
 DATABASE='/tmp/docker-mailserver/dovecot-quotas.cf'
-USER_DATABASE=${USER_DATABASE:-/tmp/docker-mailserver/postfix-accounts.cf}
+USER_DATABASE='/tmp/docker-mailserver/postfix-accounts.cf'
 
 function __usage { echo 'Usage: delquota <username@domain>' ; }
 

--- a/target/bin/excluderelaydomain
+++ b/target/bin/excluderelaydomain
@@ -3,7 +3,7 @@
 # shellcheck source=../scripts/helpers/index.sh
 source /usr/local/bin/helpers/index.sh
 
-DATABASE=${DATABASE:-/tmp/docker-mailserver/postfix-relaymap.cf}
+DATABASE='/tmp/docker-mailserver/postfix-relaymap.cf'
 
 DOMAIN="${1}"
 

--- a/target/bin/listalias
+++ b/target/bin/listalias
@@ -3,7 +3,7 @@
 # shellcheck source=../scripts/helpers/index.sh
 source /usr/local/bin/helpers/index.sh
 
-DATABASE=${DATABASE:-/tmp/docker-mailserver/postfix-virtual.cf}
+DATABASE='/tmp/docker-mailserver/postfix-virtual.cf'
 
 [[ -f ${DATABASE} ]] || _exit_with_error "No 'postfix-virtual.cf' file"
 [[ -s ${DATABASE} ]] || _exit_with_error "Empty 'postfix-virtual.cf' - no aliases have been added"

--- a/target/bin/setquota
+++ b/target/bin/setquota
@@ -8,7 +8,7 @@
 # shellcheck source=../scripts/helpers/index.sh
 source /usr/local/bin/helpers/index.sh
 
-DATABASE=${DATABASE:-/tmp/docker-mailserver/dovecot-quotas.cf}
+DATABASE='/tmp/docker-mailserver/dovecot-quotas.cf'
 USER_DATABASE=${USER_DATABASE:-/tmp/docker-mailserver/postfix-accounts.cf}
 
 USER="${1}"

--- a/target/bin/setquota
+++ b/target/bin/setquota
@@ -9,7 +9,7 @@
 source /usr/local/bin/helpers/index.sh
 
 DATABASE='/tmp/docker-mailserver/dovecot-quotas.cf'
-USER_DATABASE=${USER_DATABASE:-/tmp/docker-mailserver/postfix-accounts.cf}
+USER_DATABASE='/tmp/docker-mailserver/postfix-accounts.cf'
 
 USER="${1}"
 shift

--- a/target/bin/updatemailuser
+++ b/target/bin/updatemailuser
@@ -8,7 +8,7 @@
 # shellcheck source=../scripts/helpers/index.sh
 source /usr/local/bin/helpers/index.sh
 
-DATABASE=${DATABASE:-/tmp/docker-mailserver/postfix-accounts.cf}
+DATABASE='/tmp/docker-mailserver/postfix-accounts.cf'
 
 USER="${1}"
 shift


### PR DESCRIPTION
# Description

The `DATABASE` ENV fallback was added in [this Dec 2016 PR](https://github.com/docker-mailserver/docker-mailserver/pull/441), no justification was provided.

Likewise for [`USER_DATABASE` in `delquota` and `addquota` files in Apr 2020](https://github.com/docker-mailserver/docker-mailserver/pull/1469) which was probably based on the earlier existing convention used for `DATABASE`.

---

Neither are in usage by our tests or detailed in documentation.

These are being dropped as a [recent PR](https://github.com/docker-mailserver/docker-mailserver/pull/2535) adapted existing scripts where `DATABASE` with an ENV fallback would be conflicting with usage elsewhere unless providing a temporary ENV when calling the command.

Until an actual use-case requires this, it's probably best to drop such support.