### PR TITLE
Use color variables instead of escape codes

### DIFF
--- a/target/bin/addalias
+++ b/target/bin/addalias
@@ -7,24 +7,24 @@ DATABASE='/tmp/docker-mailserver/postfix-virtual.cf'
 
 function __usage
 {
-  printf "\e[35mADDALIAS\e[31m(\e[93m8\e[31m)
+  printf '%s' "${PURPLE}ADDALIAS${RED}(${YELLOW}8${RED})
 
-\e[38;5;214mNAME\e[39m
+${ORANGE}NAME${RESET}
     addalias - add an email alias for an existing user
 
-\e[38;5;214mSYNOPSIS\e[39m
+${ORANGE}SYNOPSIS${RESET}
     ./setup.sh alias add <EMAIL ADDRESS> <RECIPIENT>
 
-\e[38;5;214mOPTIONS\e[39m
-    \e[94mGeneric Program Information\e[39m
+${ORANGE}OPTIONS${RESET}
+    ${BLUE}Generic Program Information${RESET}
         help       Print the usage information.
 
-\e[38;5;214mEXAMPLES\e[39m
-    \e[37m./setup.sh alias add alias-for-me@domain.tld admin@domain.tld\e[39m
+${ORANGE}EXAMPLES${RESET}
+    ${LWHITE}./setup.sh alias add alias-for-me@domain.tld admin@domain.tld${RESET}
         Add the alias alias-for-me@doamin.tld for the existing user
         admin@domain.tld.
 
-\e[38;5;214mEXIT STATUS\e[39m
+${ORANGE}EXIT STATUS${RESET}
     Exit status is 0 if command was successful. If wrong arguments are provided
     or arguments contain errors, the script will exit early with exit status 1.
 

--- a/target/bin/addmailuser
+++ b/target/bin/addmailuser
@@ -9,24 +9,24 @@ DATABASE='/tmp/docker-mailserver/postfix-accounts.cf'
 
 function __usage
 {
-  printf "\e[35mADDMAILUSER\e[31m(\e[93m8\e[31m)
+  printf '%s' "${PURPLE}ADDMAILUSER${RED}(${YELLOW}8${RED})
 
-\e[38;5;214mNAME\e[39m
+${ORANGE}NAME${RESET}
     addmailuser - add an email address (i.e. a user)
 
-\e[38;5;214mSYNOPSIS\e[39m
+${ORANGE}SYNOPSIS${RESET}
     ./setup.sh email add <EMAIL ADDRESS> [<PASSWORD>]
 
-\e[38;5;214mOPTIONS\e[39m
-    \e[94mGeneric Program Information\e[39m
+${ORANGE}OPTIONS${RESET}
+    ${BLUE}Generic Program Information${RESET}
         help       Print the usage information.
 
-\e[38;5;214mEXAMPLES\e[39m
-    \e[37m./setup.sh email add test@domain.tld\e[39m
+${ORANGE}EXAMPLES${RESET}
+    ${LWHITE}./setup.sh email add test@domain.tld${RESET}
         Add the email account test@domain.tld. You will be prompted
         to input a password afterwards since no password was supplied.
 
-\e[38;5;214mEXIT STATUS\e[39m
+${ORANGE}EXIT STATUS${RESET}
     Exit status is 0 if command was successful. If wrong arguments are provided
     or arguments contain errors, the script will exit early with exit status 1.
 

--- a/target/bin/addrelayhost
+++ b/target/bin/addrelayhost
@@ -7,19 +7,19 @@ DATABASE='/tmp/docker-mailserver/postfix-relaymap.cf'
 
 function __usage
 {
-  printf "\e[35mADDRELAYHOST\e[31m(\e[93m8\e[31m)
+  printf '%s' "${PURPLE}ADDRELAYHOST${RED}(${YELLOW}8${RED})
 
-\e[38;5;214mNAME\e[39m
+${ORANGE}NAME${RESET}
     addrelayhost - add an relay host
 
-\e[38;5;214mSYNOPSIS\e[39m
+${ORANGE}SYNOPSIS${RESET}
     ./setup.sh relay add-domain <DOMAIN> <HOST> [<PORT>]
 
-\e[38;5;214mOPTIONS\e[39m
-    \e[94mGeneric Program Information\e[39m
+${ORANGE}OPTIONS${RESET}
+    ${BLUE}Generic Program Information${RESET}
         help       Print the usage information.
 
-\e[38;5;214mEXIT STATUS\e[39m
+${ORANGE}EXIT STATUS${RESET}
     Exit status is 0 if command was successful. If wrong arguments are provided
     or arguments contain errors, the script will exit early with exit status 1.
 

--- a/target/bin/delmailuser
+++ b/target/bin/delmailuser
@@ -15,34 +15,34 @@ MAILDEL='false'
 
 function __usage
 {
-  echo -e "\e[35mDELMAILUSER\e[31m(\e[93m8\e[31m)
+  printf '%s' "${PURPLE}DELMAILUSER${RED}(${YELLOW}8${RED})
 
-\e[38;5;214mNAME\e[39m
+${ORANGE}NAME${RESET}
     delmailuser - delete a user and related data
 
-\e[38;5;214mSYNOPSIS\e[39m
-    ./setup.sh email del [ OPTIONS ] { <MAIL ADDRESS> [<MAIL ADDRESS>\e[31m...\e[39m] \e[31m|\e[39m help }
+${ORANGE}SYNOPSIS${RESET}
+    ./setup.sh email del [ OPTIONS ] { <MAIL ADDRESS> [<MAIL ADDRESS>${RED}...${RESET}] ${RED}|${RESET} help }
 
-\e[38;5;214mDESCRIPTION\e[39m
+${ORANGE}DESCRIPTION${RESET}
     Delete a mail user, aliases, quotas and mail data.
 
-\e[38;5;214mOPTIONS\e[39m
+${ORANGE}OPTIONS${RESET}
     -y
-        Indicate that \e[1mall mail data\e[22m is to be deleted without another prompt.
+        Indicate that ${LWHITE}all mail data${RESET} is to be deleted without another prompt.
 
     -h
         Show this help dialogue.
 
-\e[38;5;214mEXAMPLES\e[39m
-    \e[37m./setup.sh email del woohoo@some-domain.org\e[39m
+${ORANGE}EXAMPLES${RESET}
+    ${LWHITE}./setup.sh email del woohoo@some-domain.org${RESET}
         Delete the mail user, quotas and aliases, but ask
         again whether mailbox data should be deleted.
 
-    \e[37m./setup.sh email del -y test@domain.com test@domain.com\e[39m
+    ${LWHITE}./setup.sh email del -y test@domain.com test@domain.com${RESET}
         Delete all mail data for the users 'test' and do not
         prompt to ask if all mail data should be deleted.
 
-\e[38;5;214mEXIT STATUS\e[39m
+${ORANGE}EXIT STATUS${RESET}
     Exit status is 0 if command was successful, and 1 if there was an error.
 "
 }

--- a/target/bin/open-dkim
+++ b/target/bin/open-dkim
@@ -9,42 +9,42 @@ DOMAINS=
 
 function __usage
 {
-  printf "\e[35mOPEN-DKIM\e[31m(\e[93m8\e[31m)
+  printf '%s' "${PURPLE}OPEN-DKIM${RED}(${YELLOW}8${RED})
 
-\e[38;5;214mNAME\e[39m
+${ORANGE}NAME${RESET}
     open-dkim - configure DomainKeys Identified Mail (DKIM)
 
-\e[38;5;214mSYNOPSIS\e[39m
-    ./setup.sh config dkim [ OPTIONS\e[31m...\e[39m ]
+${ORANGE}SYNOPSIS${RESET}
+    ./setup.sh config dkim [ OPTIONS${RED}...${RESET} ]
 
-\e[38;5;214mDESCRIPTION\e[39m
+${ORANGE}DESCRIPTION${RESET}
     Configures DKIM keys. OPTIONS can be used to configure a more complex setup.
     LDAP setups require these options.
 
-\e[38;5;214mOPTIONS\e[39m
-    \e[94mGeneric Program Information\e[39m
+${ORANGE}OPTIONS${RESET}
+    ${BLUE}Generic Program Information${RESET}
         help       Print the usage information.
 
-    \e[94mConfiguration adjustments\e[39m
+    ${BLUE}Configuration adjustments${RESET}
         keysize    Set the size of the keys to be generated. Possible are 1024, 2024 and 4096 (default).
-        selector   Set a manual selector (default is 'mail') for the key. (\e[96mATTENTION\e[39m: NOT IMPLEMENTED YET!)
+        selector   Set a manual selector (default is 'mail') for the key. (${LCYAN}ATTENTION${RESET}: NOT IMPLEMENTED YET!)
         domain     Provide the domain(s) for which keys are to be generated.
 
-\e[38;5;214mEXAMPLES\e[39m
-    \e[37m./setup.sh config dkim keysize 2048\e[39m
+${ORANGE}EXAMPLES${RESET}
+    ${LWHITE}./setup.sh config dkim keysize 2048${RESET}
         Creates keys of length 2048 bit in a default setup where domains are obtained from
         your accounts.
 
-    \e[37m./setup.sh config dkim keysize 2048 selector 2021-dkim\e[39m
+    ${LWHITE}./setup.sh config dkim keysize 2048 selector 2021-dkim${RESET}
         Creates keys of length 2048 bit in a default setup where domains are obtained from
         your accounts. The DKIM selector used is '2021-dkim'.
 
-    \e[37m./setup.sh config dkim keysize 2048 selector 2021-dkim domain 'whoami.com,whoareyou.org'\e[39m
+    ${LWHITE}./setup.sh config dkim keysize 2048 selector 2021-dkim domain 'whoami.com,whoareyou.org'${RESET}
         Appropriate for an LDAP setup. Creates keys of length 2048 bit in a default setup
         where domains are obtained from your accounts. The DKIM selector used is '2021-dkim'.
         The domains for which DKIM keys are generated are 'whoami.com' and 'whoareyou.org'.
 
-\e[38;5;214mEXIT STATUS\e[39m
+${ORANGE}EXIT STATUS${RESET}
     Exit status is 0 if command was successful. If wrong arguments are provided or arguments contain
     errors, the script will exit early with exit status 2.
 

--- a/target/bin/setup
+++ b/target/bin/setup
@@ -4,20 +4,13 @@ SCRIPT='setup'
 
 set -euE -o pipefail
 
+# shellcheck source=../scripts/helpers/index.sh
+source /usr/local/bin/helpers/index.sh
+
 function _usage
 {
-  local WHITE="\e[37m"
-  local RED="\e[31m"
-  local PURPLE="\e[35m"
-  local YELLOW="\e[93m"
-  local ORANGE="\e[38;5;214m"
-  local CYAN="\e[96m"
-  local BLUE="\e[34m"
-  local LBLUE="\e[94m"
-  local RESET="\e[0m"
-
   # shellcheck disable=SC2059
-  printf "${PURPLE}SETUP${RED}(${YELLOW}1${RED})
+  printf '%s' "${PURPLE}SETUP${RED}(${YELLOW}1${RED})
 
 ${ORANGE}NAME${RESET}
     ${SCRIPT:-${0}} - 'docker-mailserver' Administration & Configuration script

--- a/target/bin/setup
+++ b/target/bin/setup
@@ -28,12 +28,12 @@ ${ORANGE}DESCRIPTION${RESET}
     If it cannot find a running 'docker-mailserver' container, it will attempt to run one using
     any available tags which include 'label=org.opencontainers.image.title=\"docker-mailserver\"'
     and then run the necessary commands. If the tag for the container is not found, this script
-    will pull the '${WHITE}:latest${RESET}' tag of '${WHITE}docker.io/mailserver/docker-mailserver${RESET}'.
+    will pull the '${LWHITE}:latest${RESET}' tag of '${LWHITE}docker.io/mailserver/docker-mailserver${RESET}'.
     This tag refers to the latest release, see the tagging convention in the README under:
     ${BLUE}https://github.com/docker-mailserver/docker-mailserver/blob/master/README.md${RESET}
 
     You will be able to see detailed information about the script you're invoking and their
-    arguments by appending '${WHITE}help${RESET}' after your command. Currently, this does not work with all scripts.
+    arguments by appending '${LWHITE}help${RESET}' after your command. Currently, this does not work with all scripts.
 
 ${RED}[${ORANGE}SUB${RED}]${ORANGE}COMMANDS${RESET}
     ${LBLUE}COMMAND${RESET} email ${RED}:=${RESET}
@@ -71,16 +71,16 @@ ${RED}[${ORANGE}SUB${RED}]${ORANGE}COMMANDS${RESET}
         ${0} debug ${CYAN}show-mail-logs${RESET}
 
 ${ORANGE}EXAMPLES${RESET}
-    ${WHITE}./setup.sh email add test@example.com${RESET}
-        Add the email account ${WHITE}test@example.com${RESET}. You will be prompted
+    ${LWHITE}./setup.sh email add test@example.com${RESET}
+        Add the email account ${LWHITE}test@example.com${RESET}. You will be prompted
         to input a password afterwards since no password was supplied.
 
-    ${WHITE}./setup.sh config dkim keysize 2048 domain 'example.com,not-example.com'${RESET}
+    ${LWHITE}./setup.sh config dkim keysize 2048 domain 'example.com,not-example.com'${RESET}
         Creates keys of length 2048 but in an LDAP setup where domains are not known to
         Postfix by default, so you need to provide them yourself in a comma-separated list.
 
-    ${WHITE}./setup.sh config dkim help${RESET}
-        This will provide you with a detailed explanation on how to use the ${WHITE}
+    ${LWHITE}./setup.sh config dkim help${RESET}
+        This will provide you with a detailed explanation on how to use the ${LWHITE}
         config dkim${RESET} command, showing what arguments can be passed and what they do.
 
 "

--- a/target/scripts/helpers/log.sh
+++ b/target/scripts/helpers/log.sh
@@ -1,11 +1,25 @@
 #! /bin/bash
 
-LOG_RESET='\e[0m'
-LOG_LGRAY='\e[37m'
-LOG_LBLUE='\e[94m'
-LOG_BLUE='\e[34m'
-LOG_LYELLOW='\e[93m'
-LOG_RED='\e[91m'
+# Color variables for global usage
+RED=$(echo -ne     '\e[0;31m')
+GREEN=$(echo -ne   '\e[0;32m')
+YELLOW=$(echo -ne  '\e[0;33m')
+BLUE=$(echo -ne    '\e[0;34m')
+PURPLE=$(echo -ne  '\e[0;35m')
+CYAN=$(echo -ne    '\e[0;36m')
+WHITE=$(echo -ne   '\e[0;37m')
+
+# Light/bold variants
+LRED=$(echo -ne    '\e[1;31m')
+LGREEN=$(echo -ne  '\e[1;32m')
+LYELLOW=$(echo -ne '\e[1;33m')
+LBLUE=$(echo -ne   '\e[1;34m')
+LPURPLE=$(echo -ne '\e[1;35m')
+LCYAN=$(echo -ne   '\e[1;36m')
+LWHITE=$(echo -ne  '\e[1;37m')
+
+ORANGE=$(echo -ne '[38;5;214m')
+RESET=$(echo -ne  '\e[0m')
 
 # ### DMS Logging Functionality
 #
@@ -61,27 +75,27 @@ function _log
   case "${1}" in
     ( 'trace' )
       [[ ${LEVEL_AS_INT} -ge 5 ]] || return 0
-      MESSAGE+="  ${LOG_LGRAY}TRACE  "
+      MESSAGE+="  ${LGRAY}TRACE  "
       ;;
 
     ( 'debug' )
       [[ ${LEVEL_AS_INT} -ge 4 ]] || return 0
-      MESSAGE+="  ${LOG_LBLUE}DEBUG  "
+      MESSAGE+="  ${LBLUE}DEBUG  "
       ;;
 
     ( 'info' )
       [[ ${LEVEL_AS_INT} -ge 3 ]] || return 0
-      MESSAGE+="   ${LOG_BLUE}INF   "
+      MESSAGE+="   ${BLUE}INF   "
       ;;
 
     ( 'warn' )
       [[ ${LEVEL_AS_INT} -ge 2 ]] || return 0
-      MESSAGE+=" ${LOG_LYELLOW}WARNING "
+      MESSAGE+=" ${LYELLOW}WARNING "
       ;;
 
     ( 'error' )
       [[ ${LEVEL_AS_INT} -ge 1 ]] || return 0
-      MESSAGE+="  ${LOG_RED}ERROR  " ;;
+      MESSAGE+="  ${RED}ERROR  " ;;
 
     ( * )
       echo "Call to '_log' with invalid log level argument '${1}'" >&2
@@ -89,7 +103,7 @@ function _log
       ;;
   esac
 
-  MESSAGE+="${LOG_RESET}]  ${2}"
+  MESSAGE+="${RESET}]  ${2}"
 
   if [[ ${1} =~ ^(warn|error)$ ]]
   then

--- a/target/scripts/helpers/log.sh
+++ b/target/scripts/helpers/log.sh
@@ -57,7 +57,7 @@ function _log
   fi
 
   local MESSAGE LEVEL_AS_INT LOG_LEVEL_FALLBACK
-  MESSAGE="${LOG_RESET}["
+  MESSAGE="${RESET}["
 
   if [[ -e /etc/dms-settings ]]
   then

--- a/target/scripts/helpers/log.sh
+++ b/target/scripts/helpers/log.sh
@@ -1,5 +1,8 @@
 #! /bin/bash
 
+# shellcheck disable=SC2291 # Quote repeated spaces to avoid them collapsing into one.
+# shellcheck disable=SC2034 # VAR appears unused.
+
 # Color variables for global usage
 RED=$(echo -ne     '\e[0;31m')
 GREEN=$(echo -ne   '\e[0;32m')
@@ -18,8 +21,8 @@ LPURPLE=$(echo -ne '\e[1;35m')
 LCYAN=$(echo -ne   '\e[1;36m')
 LWHITE=$(echo -ne  '\e[1;37m')
 
-ORANGE=$(echo -ne '[38;5;214m')
-RESET=$(echo -ne  '\e[0m')
+ORANGE=$(echo -ne  '\e[38;5;214m')
+RESET=$(echo -ne   '\e[0m')
 
 # ### DMS Logging Functionality
 #


### PR DESCRIPTION
# Description

This PR streamlines the color usage of the scripts. Color variables are now globally defined in `log.sh`. I did not use a separate file like `colors.sh`, because some scripts only source `log.sh`

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
