### PR TITLE
Run sedfile tests in container

### DIFF
--- a/target/bin/sedfile
+++ b/target/bin/sedfile
@@ -9,18 +9,10 @@
 # Is a file change expected? --> use 'sedfile --strict -i'
 # Is a file change only on the first container run expected? --> use 'sedfile -i'
 
-if [[ -e /usr/local/bin/helpers/log.sh ]]
-then
-  # shellcheck source=../scripts/helpers/log.sh
-  source /usr/local/bin/helpers/log.sh
-else
-  # when running BATS (unit tests), this file is not located
-  # inside a container; as a consequence, we need to source
-  # from a different location
-  source target/scripts/helpers/log.sh
-fi
-
 set -ueo pipefail
+
+# shellcheck source=../scripts/helpers/log.sh
+source /usr/local/bin/helpers/log.sh
 
 function __usage { echo "Usage: ${0} -i <replace/delete operation> <file>" ; }
 

--- a/test/sedfile.bats
+++ b/test/sedfile.bats
@@ -1,71 +1,88 @@
 load 'test_helper/common'
 
+CONTAINER='sedfile'
+TEST_FILE='/tmp/sedfile-test.txt'
+
 # prepare tests
 function setup_file() {
-  export CONTAINER_START FILE SEDFILE
-  FILE=$(mktemp /tmp/sedfile-test.XXX)
-  SEDFILE="/tmp/sedfile"
+  local PRIVATE_CONFIG
+  PRIVATE_CONFIG="$(duplicate_config_for_container . )"
 
-  # workaround, /CONTAINER_START cannot be used (permission denied)
-  CONTAINER_START="/tmp/CONTAINER_START"
-  cp -a "target/bin/sedfile" "${SEDFILE}"
-  sed -i "s|/CONTAINER_START|${CONTAINER_START}|" "${SEDFILE}"
+  docker run -d --name "${CONTAINER}" \
+  -v "${PRIVATE_CONFIG}":/tmp/docker-mailserver \
+  -h mail.my-domain.com "${NAME}"
 
+  wait_for_finished_setup_in_container "${CONTAINER}"
+}
+
+function setup() {
   # create test file
-  echo 'foo bar' > "${FILE}"
+  docker exec ${CONTAINER} bash -c 'echo "foo bar" > "'"${TEST_FILE}"'"'
 }
 
 @test "checking sedfile parameter count" {
-  run ${SEDFILE}
+  run docker exec ${CONTAINER} sedfile
   assert_failure
   assert_output --partial 'At least three parameters must be given'
 }
 
 @test "checking sedfile substitute success" {
   # change 'bar' to 'baz'
-  run ${SEDFILE} -i 's|bar|baz|' "${FILE}"
+  run docker exec ${CONTAINER} sedfile -i 's|bar|baz|' "${TEST_FILE}"
   assert_success
-  assert_output ""
+  assert_output ''
 
   # file modified?
-  run test "$(< "${FILE}")" == 'foo baz'
+  run docker exec ${CONTAINER} cat "${TEST_FILE}"
   assert_success
+  assert_output 'foo baz'
 }
 
-@test "checking sedfile substitute failure" {
-  run ${SEDFILE} -i 's|bar|baz|' "${FILE}"
+@test "checking sedfile substitute failure (on first container start)" {
+  # delete marker
+  run docker exec ${CONTAINER} rm '/CONTAINER_START'
+  assert_success
+
+  # try to change 'baz' to 'something' and fail
+  run docker exec ${CONTAINER} sedfile -i 's|baz|something|' "${TEST_FILE}"
   assert_failure
-  assert_output --partial "No difference after call to 'sed' in 'sedfile' (sed -i s|bar|baz| /tmp/sedfile-test"
+  assert_output --partial "No difference after call to 'sed' in 'sedfile' (sed -i s|baz|something| /tmp/sedfile-test.txt)"
 
   # file unchanged?
-  run test "$(< "${FILE}")" == 'foo baz'
+  run docker exec ${CONTAINER} cat "${TEST_FILE}"
+  assert_success
+  assert_output 'foo bar'
+
+  # recreate marker
+  run docker exec ${CONTAINER} touch '/CONTAINER_START'
   assert_success
 }
 
-@test "checking sedfile silent failure on substitute" {
-  # create marker to simulate a container restart
-  date > "${CONTAINER_START}"
-
-  run ${SEDFILE} -i 's|bar|baz|' "${FILE}"
+@test "checking sedfile silent failure on substitute (when DMS was restarted)" {
+  # try to change 'baz' to 'something' and fail silently
+  run docker exec ${CONTAINER} sedfile -i 's|baz|something|' "${TEST_FILE}"
   assert_success
-  assert_output ""
+  assert_output ''
 
   # file unchanged?
-  run test "$(< "${FILE}")" == 'foo baz'
+  run docker exec ${CONTAINER} cat "${TEST_FILE}"
   assert_success
+  assert_output 'foo bar'
 }
 
 @test "checking sedfile substitude failure (strict)" {
-  run ${SEDFILE} --strict -i 's|bar|baz|' "${FILE}"
+  # try to change 'baz' to 'something' and fail
+  run docker exec ${CONTAINER} sedfile --strict -i 's|baz|something|' "${TEST_FILE}"
   assert_failure
-  assert_output --partial "No difference after call to 'sed' in 'sedfile' (sed -i s|bar|baz| /tmp/sedfile-test"
+  assert_output --partial "No difference after call to 'sed' in 'sedfile' (sed -i s|baz|something| /tmp/sedfile-test.txt)"
 
   # file unchanged?
-  run test "$(< "${FILE}")" == 'foo baz'
+  run docker exec ${CONTAINER} cat "${TEST_FILE}"
   assert_success
+  assert_output 'foo bar'
 }
 
 # clean up
 function teardown_file() {
-  rm -f "${CONTAINER_START}" "${FILE}" "${SEDFILE}"
+  docker rm -f "${CONTAINER}"
 }

--- a/test/sedfile.bats
+++ b/test/sedfile.bats
@@ -17,67 +17,67 @@ function setup_file() {
 
 function setup() {
   # create test file
-  docker exec ${CONTAINER} bash -c 'echo "foo bar" > "'"${TEST_FILE}"'"'
+  docker exec "${CONTAINER}" bash -c 'echo "foo bar" > "'"${TEST_FILE}"'"'
 }
 
 @test "checking sedfile parameter count" {
-  run docker exec ${CONTAINER} sedfile
+  run docker exec "${CONTAINER}" sedfile
   assert_failure
   assert_output --partial 'At least three parameters must be given'
 }
 
 @test "checking sedfile substitute success" {
   # change 'bar' to 'baz'
-  run docker exec ${CONTAINER} sedfile -i 's|bar|baz|' "${TEST_FILE}"
+  run docker exec "${CONTAINER}" sedfile -i 's|bar|baz|' "${TEST_FILE}"
   assert_success
   assert_output ''
 
   # file modified?
-  run docker exec ${CONTAINER} cat "${TEST_FILE}"
+  run docker exec "${CONTAINER}" cat "${TEST_FILE}"
   assert_success
   assert_output 'foo baz'
 }
 
 @test "checking sedfile substitute failure (on first container start)" {
   # delete marker
-  run docker exec ${CONTAINER} rm '/CONTAINER_START'
+  run docker exec "${CONTAINER}" rm '/CONTAINER_START'
   assert_success
 
   # try to change 'baz' to 'something' and fail
-  run docker exec ${CONTAINER} sedfile -i 's|baz|something|' "${TEST_FILE}"
+  run docker exec "${CONTAINER}" sedfile -i 's|baz|something|' "${TEST_FILE}"
   assert_failure
   assert_output --partial "No difference after call to 'sed' in 'sedfile' (sed -i s|baz|something| /tmp/sedfile-test.txt)"
 
   # file unchanged?
-  run docker exec ${CONTAINER} cat "${TEST_FILE}"
+  run docker exec "${CONTAINER}" cat "${TEST_FILE}"
   assert_success
   assert_output 'foo bar'
 
   # recreate marker
-  run docker exec ${CONTAINER} touch '/CONTAINER_START'
+  run docker exec "${CONTAINER}" touch '/CONTAINER_START'
   assert_success
 }
 
 @test "checking sedfile silent failure on substitute (when DMS was restarted)" {
   # try to change 'baz' to 'something' and fail silently
-  run docker exec ${CONTAINER} sedfile -i 's|baz|something|' "${TEST_FILE}"
+  run docker exec "${CONTAINER}" sedfile -i 's|baz|something|' "${TEST_FILE}"
   assert_success
   assert_output ''
 
   # file unchanged?
-  run docker exec ${CONTAINER} cat "${TEST_FILE}"
+  run docker exec "${CONTAINER}" cat "${TEST_FILE}"
   assert_success
   assert_output 'foo bar'
 }
 
 @test "checking sedfile substitude failure (strict)" {
   # try to change 'baz' to 'something' and fail
-  run docker exec ${CONTAINER} sedfile --strict -i 's|baz|something|' "${TEST_FILE}"
+  run docker exec "${CONTAINER}" sedfile --strict -i 's|baz|something|' "${TEST_FILE}"
   assert_failure
   assert_output --partial "No difference after call to 'sed' in 'sedfile' (sed -i s|baz|something| /tmp/sedfile-test.txt)"
 
   # file unchanged?
-  run docker exec ${CONTAINER} cat "${TEST_FILE}"
+  run docker exec "${CONTAINER}" cat "${TEST_FILE}"
   assert_success
   assert_output 'foo bar'
 }


### PR DESCRIPTION
# Description

This PR adjusts the `sedfile` tests to run inside a container. This allows the removal of the workaround inside `sedfile`.

Fixes: https://github.com/docker-mailserver/docker-mailserver/pull/2507#discussion_r835865532

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
