### PR TITLE
support symlinked certificates

### DIFF
--- a/target/scripts/helpers/ssl.sh
+++ b/target/scripts/helpers/ssl.sh
@@ -241,13 +241,13 @@ function _setup_ssl
 
       if [[ -n ${SSL_ALT_KEY_PATH} ]] \
       && [[ -n ${SSL_ALT_CERT_PATH} ]] \
-      && [[ ! -f ${SSL_ALT_KEY_PATH} ]] \
-      && [[ ! -f ${SSL_ALT_CERT_PATH} ]]
+      && [[ ! -e ${SSL_ALT_KEY_PATH} ]] \
+      && [[ ! -e ${SSL_ALT_CERT_PATH} ]]
       then
         dms_panic__no_file "(ALT) ${SSL_ALT_KEY_PATH} or ${SSL_ALT_CERT_PATH}" "${SCOPE_SSL_TYPE}"
       fi
 
-      if [[ -f ${SSL_KEY_PATH} ]] && [[ -f ${SSL_CERT_PATH} ]]
+      if [[ -e ${SSL_KEY_PATH} ]] && [[ -e ${SSL_CERT_PATH} ]]
       then
         cp "${SSL_KEY_PATH}" "${PRIVATE_KEY}"
         cp "${SSL_CERT_PATH}" "${CERT_CHAIN}"


### PR DESCRIPTION
# Description

This PR fixes the issue when using `SSL_TYPE=manual` and certificates created by certbot (Letsencrypt) on the host. Certificates created by certbot are symlinked to the actual cert files.
The container startup fails because SSL routines check for files only. This PR adds support for symlinked certificates that are created by certbot.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
