### PR TITLE
scripts: more consistency in `start-mailserver.sh`

### DIFF
--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -277,12 +277,12 @@ function _register_misc_function
 
 _log 'info' "Welcome to docker-mailserver $(</VERSION)"
 
-register_functions
-check
-setup
+_register_functions
+_check
+_setup
 [[ ${LOG_LEVEL} =~ (debug|trace) ]] && print-environment
-fix
-start_misc
+_apply_fixes
+_start_misc
 _start_daemons
 
 # marker to check, if container was restarted

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 
+# ------------------------------------------------------------
 # ? >> Sourcing helpers & stacks
 #      1. Helpers
 #      2. Checks
@@ -28,22 +29,26 @@ source /usr/local/bin/misc-stack.sh
 source /usr/local/bin/daemons-stack.sh
 
 # ------------------------------------------------------------
+# ? << Sourcing helpers & stacks
+# --
+# ? >> Setup Supervisor & DNS names
+# ------------------------------------------------------------
 
 # Setup supervisord as early as possible
 declare -A VARS
 VARS[SUPERVISOR_LOGLEVEL]="${SUPERVISOR_LOGLEVEL:=warn}"
+
 _setup_supervisor
-
-# shellcheck disable=SC2034
-declare -a FUNCS_SETUP FUNCS_FIX FUNCS_CHECK FUNCS_MISC DAEMONS_START
-
 _obtain_hostname_and_domainname
 
 # ------------------------------------------------------------
-# ? <<
+# ? << Setup Supervisor & DNS names
 # --
 # ? >> Setup of default and global values / variables
 # ------------------------------------------------------------
+
+# shellcheck disable=SC2034
+declare -a FUNCS_SETUP FUNCS_FIX FUNCS_CHECK FUNCS_MISC DAEMONS_START
 
 # These variables must be defined first; They are used as default values for other variables.
 VARS[POSTMASTER_ADDRESS]="${POSTMASTER_ADDRESS:=postmaster@${DOMAINNAME}}"
@@ -117,7 +122,7 @@ VARS[VIRUSMAILS_DELETE_DELAY]="${VIRUSMAILS_DELETE_DELAY:=7}"
 # ? >> Registering functions
 # ------------------------------------------------------------
 
-function register_functions
+function _register_functions
 {
   _log 'info' 'Initializing setup'
   _log 'debug' 'Registering functions'
@@ -268,11 +273,8 @@ function _register_misc_function
 
 # ------------------------------------------------------------
 # ? << Registering functions
-
-# ------------------------------------------------------------
-# ? << Sourcing all stacks
 # --
-# ? >> Executing all stacks
+# ? >> Executing all stacks / actual start of DMS
 # ------------------------------------------------------------
 
 _log 'info' "Welcome to docker-mailserver $(</VERSION)"
@@ -285,7 +287,7 @@ _apply_fixes
 _start_misc
 _start_daemons
 
-# marker to check, if container was restarted
+# marker to check if container was restarted
 date >/CONTAINER_START
 
 _log 'info' "${HOSTNAME} is up and running"

--- a/target/scripts/startup/check-stack.sh
+++ b/target/scripts/startup/check-stack.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-function check
+function _check
 {
   _log 'info' 'Checking configuration'
   for FUNC in "${FUNCS_CHECK[@]}"

--- a/target/scripts/startup/fixes-stack.sh
+++ b/target/scripts/startup/fixes-stack.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-function fix
+function _apply_fixes
 {
   _log 'info' 'Post-configuration checks'
   for FUNC in "${FUNCS_FIX[@]}"

--- a/target/scripts/startup/misc-stack.sh
+++ b/target/scripts/startup/misc-stack.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-function start_misc
+function _start_misc
 {
   _log 'info' 'Starting miscellaneous tasks'
   for FUNC in "${FUNCS_MISC[@]}"

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-function setup
+function _setup
 {
   _log 'info' 'Configuring mail server'
   for FUNC in "${FUNCS_SETUP[@]}"


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
This PR makes `start-mailserver.sh` consistent with the function naming scheme and cleans up the comments that describe each section of the script (with the last PRs touching the script, the comments got a bit messed up).

No functionality change, just script consistency.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
