### PR TITLE
scripts: loglevel warning message fix

### DIFF
--- a/target/scripts/startup/check-stack.sh
+++ b/target/scripts/startup/check-stack.sh
@@ -34,11 +34,10 @@ function _check_log_level
     return 0
   else
     local DEFAULT_LOG_LEVEL='info'
+    _log 'warn' "Log level '${LOG_LEVEL}' is invalid (falling back to default '${DEFAULT_LOG_LEVEL}')"
 
     # shellcheck disable=SC2034
     VARS[LOG_LEVEL]="${DEFAULT_LOG_LEVEL}"
     LOG_LEVEL="${DEFAULT_LOG_LEVEL}"
-
-    _log 'warn' "Log level '${LOG_LEVEL}' is invalid (falling back to default '${DEFAULT_LOG_LEVEL}')"
   fi
 }


### PR DESCRIPTION
# Description
If the loglevel is invalid (for example `DEBUG`) it will print
> [ WARNING ]  Log level 'info' is invalid (falling back to default 'info')

But the correct message would be
> [ WARNING ]  Log level 'DEBUG' is invalid (falling back to default 'info')

Fixes no open issue.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

- [x] I just used the github online editor to propose this change. No local test.
