### PR TITLE
documentation: `DOCKER_HOST` missing `unix://`

### DIFF
--- a/docs/content/config/advanced/podman.md
+++ b/docs/content/config/advanced/podman.md
@@ -91,7 +91,7 @@ services:
 Then, setup your `mailserver.env` file follow the documentation and use docker-compose to start the container.
 
 ```bash
-export DOCKER_HOST="unix:/var/run/user/1000/podman/podman.sock"
+export DOCKER_HOST="unix:///var/run/user/$(id -u)/podman/podman.sock"
 docker-compose up -d mailserver
 docker-compose ps
 ```


### PR DESCRIPTION
DOCKER_HOST="unix:///var/run/.."" missing "unix:///"

# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->
Improving the documentation

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

