### PR TITLE
scripts: fix error message caused by `grep` on first starts

### DIFF
--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -300,7 +300,7 @@ function _setup_dovecot_local_user
   local SLEEP_PERIOD='10'
   for (( COUNTER = 11 ; COUNTER >= 0 ; COUNTER-- ))
   do
-    if [[ $(grep -cE '.+@.+\|' /tmp/docker-mailserver/postfix-accounts.cf 2>dev/null || printf '%s' '0') -ge 1 ]]
+    if [[ $(grep -cE '.+@.+\|' /tmp/docker-mailserver/postfix-accounts.cf 2>/dev/null || printf '%s' '0') -ge 1 ]]
     then
       return 0
     else

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -300,7 +300,7 @@ function _setup_dovecot_local_user
   local SLEEP_PERIOD='10'
   for (( COUNTER = 11 ; COUNTER >= 0 ; COUNTER-- ))
   do
-    if [[ $(grep -cE '.+@.+\|' /tmp/docker-mailserver/postfix-accounts.cf 2>dev/null || printf '0') -ge 1 ]]
+    if [[ $(grep -cE '.+@.+\|' /tmp/docker-mailserver/postfix-accounts.cf 2>dev/null || printf '%s' '0') -ge 1 ]]
     then
       return 0
     else

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -300,7 +300,7 @@ function _setup_dovecot_local_user
   local SLEEP_PERIOD='10'
   for (( COUNTER = 11 ; COUNTER >= 0 ; COUNTER-- ))
   do
-    if [[ $(grep -cE '.+@.+\|' /tmp/docker-mailserver/postfix-accounts.cf) -ge 1 ]]
+    if [[ $(grep -cE '.+@.+\|' /tmp/docker-mailserver/postfix-accounts.cf 2>dev/null || printf '0') -ge 1 ]]
     then
       return 0
     else


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
On first start, the check for accounts would emit a warning, but also an
error:

`grep: /tmp/docker-mailserver/postfix-accounts.cf: No such file or directory`

since the `postfix-accounts.cf` file is not yet there. This commit fixes
the issue, so only the warning is logged correctly.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
