### PR TITLE
documentation: DOCKER_HOST missing unix://

### DIFF
--- a/docs/content/config/advanced/podman.md
+++ b/docs/content/config/advanced/podman.md
@@ -38,7 +38,7 @@ systemctl enable --now podman.socket
 This will create a unix socket locate under `/run/podman/podman.sock`, which is the entrypoint of Podman's API. Now, configure docker-mailserver and start it.
 
 ```bash
-export DOCKER_HOST="unix:/run/podman/podman.sock"
+export DOCKER_HOST="unix:///run/podman/podman.sock"
 docker-compose up -d mailserver
 docker-compose ps
 ```


### PR DESCRIPTION
documentation: DOCKER_HOST missing unix://

# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)
- [x] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
