### PR TITLE
refactor: Revise `check-for-changes.sh`

### DIFF
--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -125,6 +125,22 @@ function _check_for_changes
   mv "${CHKSUM_FILE}.new" "${CHKSUM_FILE}"
 }
 
+function _get_changed_files
+{
+
+}
+
+
+function _postfix_dovecot_changes
+{
+
+}
+
+function _ssl_changes
+{
+
+}
+
 while true
 do
   _check_for_changes

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -58,23 +58,7 @@ function _check_for_changes
     # We should fix that and write to temporary files, stop, swap and start
 
     _ssl_changes
-
-    # regenerate postfix accounts
-    [[ ${SMTP_ONLY} -ne 1 ]] && _create_accounts
-
-    _rebuild_relayhost
-
-    # regenerate postix aliases
-    _create_aliases
-
-    # regenerate /etc/postfix/vhost
-    # NOTE: If later adding support for LDAP with change detection and this method is called,
-    # be sure to mimic `setup-stack.sh:_setup_ldap` which appends to `/tmp/vhost.tmp`.
-    _create_postfix_vhost
-
-    # Legacy workaround handled here, only seems necessary for _create_accounts:
-    # - `helpers/accounts.sh` logic creates folders/files with wrong ownership.
-    _chown_var_mail_if_necessary
+    _postfix_dovecot_changes
 
     _log_with_date 'debug' 'Restarting services due to detected changes'
 
@@ -110,7 +94,22 @@ function _get_changed_files
 
 function _postfix_dovecot_changes
 {
+  # regenerate postfix accounts
+  [[ ${SMTP_ONLY} -ne 1 ]] && _create_accounts
 
+  _rebuild_relayhost
+
+  # regenerate postix aliases
+  _create_aliases
+
+  # regenerate /etc/postfix/vhost
+  # NOTE: If later adding support for LDAP with change detection and this method is called,
+  # be sure to mimic `setup-stack.sh:_setup_ldap` which appends to `/tmp/vhost.tmp`.
+  _create_postfix_vhost
+
+  # Legacy workaround handled here, only seems necessary for _create_accounts:
+  # - `helpers/accounts.sh` logic creates folders/files with wrong ownership.
+  _chown_var_mail_if_necessary
 }
 
 function _ssl_changes

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -51,8 +51,9 @@ function _check_for_changes
   then
     _log_with_date 'info' 'Change detected'
     _create_lock # Shared config safety lock
+
     local CHANGED
-    CHANGED=$(grep -Fxvf "${CHKSUM_FILE}" "${CHKSUM_FILE}.new" | sed 's/^[^ ]\+  //')
+    CHANGED=$(_get_changed_files "${CHKSUM_FILE}" "${CHKSUM_FILE}.new")
 
     # TODO Perform updates below conditionally too
     # Also note that changes are performed in place and are not atomic
@@ -127,7 +128,18 @@ function _check_for_changes
 
 function _get_changed_files
 {
+  local CHKSUM_CURRENT=${1}
+  local CHKSUM_NEW=${2}
 
+  # Diff the two files for lines that don't match or differ from lines in CHKSUM_FILE
+  # grep -Fxvf
+  #   -f use CHKSUM_FILE lines as input patterns to match for
+  #   -F The patterns to match are treated as strings only, not treated as regex syntax
+  #   -x (match whole lines only)
+  #   -v invert the matching so only non-matches are output
+  # Extract file paths by truncating the matched content hash and white-space from lines:
+  # sed -r 's/^\S+[[:space:]]+//'
+  grep -Fxvf "${CHKSUM_CURRENT}" "${CHKSUM_NEW}" | sed -r 's/^\S+[[:space:]]+//'
 }
 
 

--- a/target/scripts/helpers/aliases.sh
+++ b/target/scripts/helpers/aliases.sh
@@ -9,7 +9,6 @@
 function _handle_postfix_virtual_config
 {
   : >/etc/postfix/virtual
-  : >/etc/postfix/regexp
 
   local DATABASE_VIRTUAL=/tmp/docker-mailserver/postfix-virtual.cf
 
@@ -29,6 +28,8 @@ function _handle_postfix_virtual_config
 
 function _handle_postfix_regexp_config
 {
+  : >/etc/postfix/regexp
+
   if [[ -f /tmp/docker-mailserver/postfix-regexp.cf ]]
   then
     _log 'trace' "Adding regexp alias file postfix-regexp.cf"


### PR DESCRIPTION
# Description

This PR is mostly housekeeping for `check-for-changes.sh`, in preparation for further refactoring.

Changes have been staged via individual commits with messages for further context. It may be easier to follow the changes via commit diffs, than as a whole.

### Change Overview:

- Inline docs for `check-for-changes.sh` have been shuffled around and revised a bit.
- Change processing extracted from the main change detection loop method to their own methods:
   - `_get_changed_files()` - I extracted the `grep`+`sed` line to it's own method.
      - This was due to the verbosity of inline docs I added. I value being able to under to know quickly at a glance what I'm looking at without having to go refresh on the syntax :sweat_smile: - However if other maintainers feel this is a bad idea it can be reverted, no worries!
   - `_postfix_dovecot_changes()` - The bulk of change processing was moved to this method. I've added conditionals to only run relevant logic.
   - `_ssl_changes()` - Just shifted, no logic changed. `REGEX_NEVER_MATCH` and `ACME_CERT_DIR` vars scope set to `local`.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
