### PR TITLE
fix: Amavis should reload config for `/etc/postfix/vhost` updates

### DIFF
--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -60,7 +60,7 @@ function _check_for_changes
     # via their 'reload' commands; some may require restarting?:
     _log_with_date 'debug' 'Restarting services due to detected changes'
 
-    _reload_amavis
+    [[ ${ENABLE_AMAVIS} -eq 1 ]] && _reload_amavis
     supervisorctl restart postfix
     [[ ${SMTP_ONLY} -ne 1 ]] && supervisorctl restart dovecot
 


### PR DESCRIPTION
# Description

When `/etc/postfix/vhost` is updated from change detection, Amavis did not refresh that source, and thus would not be aware of any new domains, ignoring them for spam/virus checking.

A test could probably be added, my time is focused on prepping PRs with the time I have available right now.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
