### PR TITLE
chore(housekeeping): Normalize how config files filter out unwanted lines

### DIFF
--- a/target/bin/listalias
+++ b/target/bin/listalias
@@ -8,5 +8,5 @@ DATABASE='/tmp/docker-mailserver/postfix-virtual.cf'
 [[ -f ${DATABASE} ]] || _exit_with_error "No 'postfix-virtual.cf' file"
 [[ -s ${DATABASE} ]] || _exit_with_error "Empty 'postfix-virtual.cf' - no aliases have been added"
 
-grep -v "^\s*$\|^\s*\#" "${DATABASE}"
+_get_valid_lines_from_file "${DATABASE}"
 exit 0

--- a/target/bin/listdovecotmasteruser
+++ b/target/bin/listdovecotmasteruser
@@ -16,6 +16,6 @@ while read -r LINE
 do
   USER=$(echo "${LINE}" | cut -d'|' -f1)
   echo "* ${USER}"
-done < "${DATABASE}"
+done < <(_get_valid_lines_from_file "${DATABASE}")
 
 exit 0

--- a/target/bin/listmailuser
+++ b/target/bin/listmailuser
@@ -47,7 +47,7 @@ do
   else
     echo
   fi
-done < <(_filter_to_valid_lines "${DATABASE}")
+done < <(_get_valid_lines_from_file "${DATABASE}")
 
 
 exit 0

--- a/target/bin/open-dkim
+++ b/target/bin/open-dkim
@@ -98,23 +98,26 @@ do
   esac
 done
 
-touch /tmp/vhost.dkim.tmp
-
+DATABASE_ACCOUNTS='/tmp/docker-mailserver/postfix-accounts.cf'
+DATABASE_VIRTUAL='/tmp/docker-mailserver/postfix-virtual.cf'
+DATABASE_VHOST='/tmp/vhost'
+TMP_VHOST='/tmp/vhost.dkim.tmp'
+touch "${TMP_VHOST}"
 if [[ -z ${DOMAINS} ]]
 then
   # getting domains FROM mail accounts
-  if [[ -f /tmp/docker-mailserver/postfix-accounts.cf ]]
+  if [[ -f ${DATABASE_ACCOUNTS} ]]
   then
     # shellcheck disable=SC2034
     while IFS=$'|' read -r LOGIN PASS
     do
       DOMAIN=$(echo "${LOGIN}" | cut -d @ -f2)
-      echo "${DOMAIN}" >>/tmp/vhost.dkim.tmp
-    done < <(grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-accounts.cf || true)
+      echo "${DOMAIN}" >>"${TMP_VHOST}"
+    done < <(grep -v "^\s*$\|^\s*\#" "${DATABASE_ACCOUNTS}" || true)
   fi
 
   # getting domains FROM mail aliases
-  if [[ -f /tmp/docker-mailserver/postfix-virtual.cf ]]
+  if [[ -f ${DATABASE_VIRTUAL} ]]
   then
     # shellcheck disable=SC2034
     while read -r FROM TO
@@ -122,17 +125,17 @@ then
       UNAME=$(echo "${FROM}" | cut -d @ -f1)
       DOMAIN=$(echo "${FROM}" | cut -d @ -f2)
 
-      [[ ${UNAME} != "${DOMAIN}" ]] && echo "${DOMAIN}" >>/tmp/vhost.dkim.tmp
-    done < <(grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-virtual.cf || true)
+      [[ ${UNAME} != "${DOMAIN}" ]] && echo "${DOMAIN}" >>"${TMP_VHOST}"
+    done < <(grep -v "^\s*$\|^\s*\#" "${DATABASE_VIRTUAL}" || true)
   fi
 else
-  tr ',' '\n' <<< "${DOMAINS}" >/tmp/vhost.dkim.tmp
+  tr ',' '\n' <<< "${DOMAINS}" >"${TMP_VHOST}"
 fi
 
-sort < /tmp/vhost.dkim.tmp | uniq >/tmp/vhost
-rm /tmp/vhost.dkim.tmp
+sort < "${TMP_VHOST}" | uniq >"${DATABASE_VHOST}"
+rm "${TMP_VHOST}"
 
-if [[ ! -s /tmp/vhost ]]
+if [[ ! -s ${DATABASE_VHOST} ]]
 then
   _log 'warn' 'No entries found, no keys to make'
   exit 0
@@ -179,7 +182,7 @@ do
       echo "${SIGNINGTABLEENTRY}" >>/tmp/docker-mailserver/opendkim/SigningTable
     fi
   fi
-done < <(grep -vE '^(\s*$|#)' /tmp/vhost)
+done < <(grep -vE '^(\s*$|#)' "${DATABASE_VHOST}")
 
 # create TrustedHosts if missing
 if [[ -d /tmp/docker-mailserver/opendkim ]] && [[ ! -f /tmp/docker-mailserver/opendkim/TrustedHosts ]]

--- a/target/bin/open-dkim
+++ b/target/bin/open-dkim
@@ -113,7 +113,7 @@ then
     do
       DOMAIN=$(echo "${LOGIN}" | cut -d @ -f2)
       echo "${DOMAIN}" >>"${TMP_VHOST}"
-    done < <(grep -v "^\s*$\|^\s*\#" "${DATABASE_ACCOUNTS}" || true)
+    done < <(_get_valid_lines_from_file "${DATABASE_ACCOUNTS}")
   fi
 
   # getting domains FROM mail aliases
@@ -126,7 +126,7 @@ then
       DOMAIN=$(echo "${FROM}" | cut -d @ -f2)
 
       [[ ${UNAME} != "${DOMAIN}" ]] && echo "${DOMAIN}" >>"${TMP_VHOST}"
-    done < <(grep -v "^\s*$\|^\s*\#" "${DATABASE_VIRTUAL}" || true)
+    done < <(_get_valid_lines_from_file "${DATABASE_VIRTUAL}")
   fi
 else
   tr ',' '\n' <<< "${DOMAINS}" >"${TMP_VHOST}"
@@ -182,7 +182,7 @@ do
       echo "${SIGNINGTABLEENTRY}" >>/tmp/docker-mailserver/opendkim/SigningTable
     fi
   fi
-done < <(grep -vE '^(\s*$|#)' "${DATABASE_VHOST}")
+done < <(_get_valid_lines_from_file "${DATABASE_VHOST}")
 
 # create TrustedHosts if missing
 if [[ -d /tmp/docker-mailserver/opendkim ]] && [[ ! -f /tmp/docker-mailserver/opendkim/TrustedHosts ]]

--- a/target/scripts/helpers/accounts.sh
+++ b/target/scripts/helpers/accounts.sh
@@ -108,7 +108,9 @@ function _create_accounts
 # for more details on this method
 function _create_dovecot_alias_dummy_accounts
 {
-  if [[ -f /tmp/docker-mailserver/postfix-virtual.cf ]] && [[ ${ENABLE_QUOTAS} -eq 1 ]]
+  local DATABASE_VIRTUAL='/tmp/docker-mailserver/postfix-virtual.cf'
+
+  if [[ -f ${DATABASE_VIRTUAL} ]] && [[ ${ENABLE_QUOTAS} -eq 1 ]]
   then
     # adding aliases to Dovecot's userdb
     # ${REAL_FQUN} is a user's fully-qualified username
@@ -166,7 +168,7 @@ function _create_dovecot_alias_dummy_accounts
       else
         echo "${DOVECOT_USERDB_LINE}" >>"${DOVECOT_USERDB_FILE}"
       fi
-    done < /tmp/docker-mailserver/postfix-virtual.cf
+    done < "${DATABASE_VIRTUAL}"
   fi
 }
 

--- a/target/scripts/helpers/accounts.sh
+++ b/target/scripts/helpers/accounts.sh
@@ -178,16 +178,17 @@ function _create_masters
 {
   : >"${DOVECOT_MASTERDB_FILE}"
 
-  if [[ -f /tmp/docker-mailserver/dovecot-masters.cf ]]
+  local DATABASE_DOVECOT_MASTERS='/tmp/docker-mailserver/dovecot-masters.cf'
+  if [[ -f ${DATABASE_DOVECOT_MASTERS} ]]
   then
     _log 'trace' "Checking file line endings"
-    sed -i 's|\r||g' /tmp/docker-mailserver/dovecot-masters.cf
+    sed -i 's|\r||g' "${DATABASE_DOVECOT_MASTERS}"
 
     _log 'trace' "Regenerating dovecot masters list"
 
-    # checking that /tmp/docker-mailserver/dovecot-masters.cf ends with a newline
+    # checking that ${DATABASE_DOVECOT_MASTERS} ends with a newline
     # shellcheck disable=SC1003
-    sed -i -e '$a\' /tmp/docker-mailserver/dovecot-masters.cf
+    sed -i -e '$a\' "${DATABASE_DOVECOT_MASTERS}"
 
     chown dovecot:dovecot "${DOVECOT_MASTERDB_FILE}"
     chmod 640 "${DOVECOT_MASTERDB_FILE}"
@@ -213,6 +214,6 @@ function _create_masters
         echo "${DOVECOT_MASTERDB_LINE}" >>"${DOVECOT_MASTERDB_FILE}"
       fi
 
-    done < <(grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/dovecot-masters.cf)
+    done < <(grep -v "^\s*$\|^\s*\#" "${DATABASE_DOVECOT_MASTERS}")
   fi
 }

--- a/target/scripts/helpers/accounts.sh
+++ b/target/scripts/helpers/accounts.sh
@@ -93,7 +93,7 @@ function _create_accounts
       fi
 
       echo "${DOMAIN}" >>/tmp/vhost.tmp
-    done < <(grep -v "^\s*$\|^\s*\#" "${DATABASE_ACCOUNTS}")
+    done < <(_get_valid_lines_from_file "${DATABASE_ACCOUNTS}")
 
     _create_dovecot_alias_dummy_accounts
   fi
@@ -117,9 +117,6 @@ function _create_dovecot_alias_dummy_accounts
     local ALIAS REAL_FQUN DOVECOT_USERDB_LINE
     while read -r ALIAS REAL_FQUN
     do
-      # ignore comments
-      [[ ${ALIAS} == \#* ]] && continue
-
       # alias is assumed to not be a proper e-mail
       # these aliases do not need to be added to Dovecot's userdb
       [[ ! ${ALIAS} == *@* ]] && continue
@@ -168,7 +165,7 @@ function _create_dovecot_alias_dummy_accounts
       else
         echo "${DOVECOT_USERDB_LINE}" >>"${DOVECOT_USERDB_FILE}"
       fi
-    done < "${DATABASE_VIRTUAL}"
+    done < <(_get_valid_lines_from_file "${DATABASE_VIRTUAL}")
   fi
 }
 
@@ -213,7 +210,6 @@ function _create_masters
       else
         echo "${DOVECOT_MASTERDB_LINE}" >>"${DOVECOT_MASTERDB_FILE}"
       fi
-
-    done < <(grep -v "^\s*$\|^\s*\#" "${DATABASE_DOVECOT_MASTERS}")
+    done < <(_get_valid_lines_from_file "${DATABASE_DOVECOT_MASTERS}")
   fi
 }

--- a/target/scripts/helpers/aliases.sh
+++ b/target/scripts/helpers/aliases.sh
@@ -11,15 +11,17 @@ function _handle_postfix_virtual_config
   : >/etc/postfix/virtual
   : >/etc/postfix/regexp
 
-  if [[ -f /tmp/docker-mailserver/postfix-virtual.cf ]]
+  local DATABASE_VIRTUAL=/tmp/docker-mailserver/postfix-virtual.cf
+
+  if [[ -f ${DATABASE_VIRTUAL} ]]
   then
     # fixing old virtual user file
-    if grep -q ",$" /tmp/docker-mailserver/postfix-virtual.cf
+    if grep -q ",$" "${DATABASE_VIRTUAL}"
     then
-      sed -i -e "s|, |,|g" -e "s|,$||g" /tmp/docker-mailserver/postfix-virtual.cf
+      sed -i -e "s|, |,|g" -e "s|,$||g" "${DATABASE_VIRTUAL}"
     fi
 
-    cp -f /tmp/docker-mailserver/postfix-virtual.cf /etc/postfix/virtual
+    cp -f "${DATABASE_VIRTUAL}" /etc/postfix/virtual
 
     # the `to` is important, don't delete it
     # shellcheck disable=SC2034
@@ -30,9 +32,9 @@ function _handle_postfix_virtual_config
 
       # if they are equal it means the line looks like: "user1     other@domain.tld"
       [[ ${UNAME} != "${DOMAIN}" ]] && echo "${DOMAIN}" >>/tmp/vhost.tmp
-    done < <(grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-virtual.cf || true)
+    done < <(grep -v "^\s*$\|^\s*\#" "${DATABASE_VIRTUAL}" || true)
   else
-    _log 'debug' "'/tmp/docker-mailserver/postfix-virtual.cf' not provided - no mail alias/forward created"
+    _log 'debug' "'${DATABASE_VIRTUAL}' not provided - no mail alias/forward created"
   fi
 }
 

--- a/target/scripts/helpers/aliases.sh
+++ b/target/scripts/helpers/aliases.sh
@@ -32,7 +32,7 @@ function _handle_postfix_virtual_config
 
       # if they are equal it means the line looks like: "user1     other@domain.tld"
       [[ ${UNAME} != "${DOMAIN}" ]] && echo "${DOMAIN}" >>/tmp/vhost.tmp
-    done < <(grep -v "^\s*$\|^\s*\#" "${DATABASE_VIRTUAL}" || true)
+    done < <(_get_valid_lines_from_file "${DATABASE_VIRTUAL}")
   else
     _log 'debug' "'${DATABASE_VIRTUAL}' not provided - no mail alias/forward created"
   fi

--- a/target/scripts/helpers/relay.sh
+++ b/target/scripts/helpers/relay.sh
@@ -96,13 +96,7 @@ function _relayhost_sasl
   if [[ -f ${DATABASE_SASL_PASSWD} ]]
   then
     # Add domain-specific auth from config file:
-    while read -r LINE
-    do
-      if ! _is_comment "${LINE}"
-      then
-        echo "${LINE}" >> /etc/postfix/sasl_passwd
-      fi
-    done < "${DATABASE_SASL_PASSWD}"
+    _get_valid_lines_from_file "${DATABASE_SASL_PASSWD}" >> /etc/postfix/sasl_passwd
 
     # Only relevant when providing this user config (unless users append elsewhere too)
     postconf 'smtp_sender_dependent_authentication = yes'

--- a/target/scripts/helpers/relay.sh
+++ b/target/scripts/helpers/relay.sh
@@ -92,7 +92,8 @@ function _relayhost_sasl
     echo "${SASL_PASSWD}" >> /etc/postfix/sasl_passwd
   fi
 
-  if [[ -f /tmp/docker-mailserver/postfix-sasl-password.cf ]]
+  local DATABASE_SASL_PASSWD='/tmp/docker-mailserver/postfix-sasl-password.cf'
+  if [[ -f ${DATABASE_SASL_PASSWD} ]]
   then
     # Add domain-specific auth from config file:
     while read -r LINE
@@ -101,7 +102,7 @@ function _relayhost_sasl
       then
         echo "${LINE}" >> /etc/postfix/sasl_passwd
       fi
-    done < /tmp/docker-mailserver/postfix-sasl-password.cf
+    done < "${DATABASE_SASL_PASSWD}"
 
     # Only relevant when providing this user config (unless users append elsewhere too)
     postconf 'smtp_sender_dependent_authentication = yes'

--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -7,13 +7,13 @@ function _escape
 
 # Returns input after filtering out lines that are:
 # empty, white-space, comments (`#` as the first non-whitespace character)
-function _filter_to_valid_lines
+function _get_valid_lines_from_file
 {
   grep --extended-regexp --invert-match "^\s*$|^\s*#" "${1}" || true
 }
 
 # TODO: Only used by `relay.sh`, will be removed in future.
-# Similar to _filter_to_valid_lines, but only returns a status code
+# Similar to _get_valid_lines_from_file, but only returns a status code
 # to indicate invalid line(s):
 function _is_comment
 {

--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -12,14 +12,6 @@ function _get_valid_lines_from_file
   grep --extended-regexp --invert-match "^\s*$|^\s*#" "${1}" || true
 }
 
-# TODO: Only used by `relay.sh`, will be removed in future.
-# Similar to _get_valid_lines_from_file, but only returns a status code
-# to indicate invalid line(s):
-function _is_comment
-{
-  grep -q -E "^\s*$|^\s*#" <<< "${1}"
-}
-
 # Provide the name of an environment variable to this function
 # and it will return its value stored in /etc/dms-settings
 function _get_dms_env_value

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -1167,8 +1167,7 @@ function _setup_fetchmail_parallel
         # Just the server settings that need to be added to the specific rc.d file
         echo "${LINE}" >>"${FETCHMAILRCD}/fetchmail-${COUNTER}.rc"
       fi
-    # delete commented lines before parsing
-    done < <(sed '/^[[:space:]]*#/d' "${FETCHMAILRC}")
+    done < <(_get_valid_lines_from_file "${FETCHMAILRC}")
 
     rm "${DEFAULT_FILE}"
   }


### PR DESCRIPTION
# Description

We have used various ways to filter out unwanted lines (empty, white-space only, comments) from configs when reading them to iterate through. In some cases, we had not filtered for all kinds of unwanted lines, or did not filter at all (even though we probably should have). 

This PR has normalized that approach to call a helper method instead (added in  https://github.com/docker-mailserver/docker-mailserver/pull/2617), with a common approach to call the filter method applied:
- The changes are mostly converting config file paths into local vars to reference instead. These are staged out into commits for easy review if needed (no commit messages).
- Then normalizes the config file pre-processing step to use the recently added method `_get_valid_lines_from_file()` (renamed in this PR from earlier `_filter_to_valid_lines()` due to feedback in [#2617](https://github.com/docker-mailserver/docker-mailserver/pull/2617) ).
- `helpers/relay.sh` had a loop that only seems to strip out the unwanted lines for the target config. This doesn't seem necessary and could probably just be a `cp` instead? I collapsed that loop to call the filtering method and just write the output of that instead.
- `helpers/utils.sh:_is_comment()` has been removed, as only `relay.sh` was using it and it no longer seems to serve any purpose.

### Relevant history

Looks like initial filtering to avoid issues was [introduced via this PR](https://github.com/docker-mailserver/docker-mailserver/pull/1494) in May 2020.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
