### PR TITLE
refactor: Share a common helper (vhost builder) for sourcing domains

### DIFF
--- a/target/bin/open-dkim
+++ b/target/bin/open-dkim
@@ -108,6 +108,7 @@ function _generate_domains_config
   # unless CLI arg DOMAINS provided an alternative list to use instead:
   if [[ -z ${DOMAINS} ]]
   then
+    _obtain_hostname_and_domainname
     # uses TMP_VHOST:
     _vhost_collect_postfix_domains
   else

--- a/target/bin/open-dkim
+++ b/target/bin/open-dkim
@@ -98,43 +98,27 @@ do
   esac
 done
 
-DATABASE_ACCOUNTS='/tmp/docker-mailserver/postfix-accounts.cf'
-DATABASE_VIRTUAL='/tmp/docker-mailserver/postfix-virtual.cf'
-DATABASE_VHOST='/tmp/vhost'
-TMP_VHOST='/tmp/vhost.dkim.tmp'
-touch "${TMP_VHOST}"
-if [[ -z ${DOMAINS} ]]
-then
-  # getting domains FROM mail accounts
-  if [[ -f ${DATABASE_ACCOUNTS} ]]
+DATABASE_VHOST='/tmp/vhost.dkim'
+# Prepare a file with one domain per line:
+function _generate_domains_config
+{
+  local TMP_VHOST='/tmp/vhost.dkim.tmp'
+
+  # Generate the default vhost (equivalent to /etc/postfix/vhost),
+  # unless CLI arg DOMAINS provided an alternative list to use instead:
+  if [[ -z ${DOMAINS} ]]
   then
-    # shellcheck disable=SC2034
-    while IFS=$'|' read -r LOGIN PASS
-    do
-      DOMAIN=$(echo "${LOGIN}" | cut -d @ -f2)
-      echo "${DOMAIN}" >>"${TMP_VHOST}"
-    done < <(_get_valid_lines_from_file "${DATABASE_ACCOUNTS}")
+    # uses TMP_VHOST:
+    _vhost_collect_postfix_domains
+  else
+    tr ',' '\n' <<< "${DOMAINS}" >"${TMP_VHOST}"
   fi
 
-  # getting domains FROM mail aliases
-  if [[ -f ${DATABASE_VIRTUAL} ]]
-  then
-    # shellcheck disable=SC2034
-    while read -r FROM TO
-    do
-      UNAME=$(echo "${FROM}" | cut -d @ -f1)
-      DOMAIN=$(echo "${FROM}" | cut -d @ -f2)
+  # uses DATABASE_VHOST + TMP_VHOST:
+  _create_vhost
+}
 
-      [[ ${UNAME} != "${DOMAIN}" ]] && echo "${DOMAIN}" >>"${TMP_VHOST}"
-    done < <(_get_valid_lines_from_file "${DATABASE_VIRTUAL}")
-  fi
-else
-  tr ',' '\n' <<< "${DOMAINS}" >"${TMP_VHOST}"
-fi
-
-sort < "${TMP_VHOST}" | uniq >"${DATABASE_VHOST}"
-rm "${TMP_VHOST}"
-
+_generate_domains_config
 if [[ ! -s ${DATABASE_VHOST} ]]
 then
   _log 'warn' 'No entries found, no keys to make'

--- a/target/scripts/helpers/accounts.sh
+++ b/target/scripts/helpers/accounts.sh
@@ -91,8 +91,6 @@ function _create_accounts
       then
         cp "/tmp/docker-mailserver/${LOGIN}.dovecot.sieve" "/var/mail/${DOMAIN}/${USER}/.dovecot.sieve"
       fi
-
-      echo "${DOMAIN}" >>/tmp/vhost.tmp
     done < <(_get_valid_lines_from_file "${DATABASE_ACCOUNTS}")
 
     _create_dovecot_alias_dummy_accounts

--- a/target/scripts/helpers/aliases.sh
+++ b/target/scripts/helpers/aliases.sh
@@ -22,17 +22,6 @@ function _handle_postfix_virtual_config
     fi
 
     cp -f "${DATABASE_VIRTUAL}" /etc/postfix/virtual
-
-    # the `to` is important, don't delete it
-    # shellcheck disable=SC2034
-    while read -r FROM TO
-    do
-      UNAME=$(echo "${FROM}" | cut -d @ -f1)
-      DOMAIN=$(echo "${FROM}" | cut -d @ -f2)
-
-      # if they are equal it means the line looks like: "user1     other@domain.tld"
-      [[ ${UNAME} != "${DOMAIN}" ]] && echo "${DOMAIN}" >>/tmp/vhost.tmp
-    done < <(_get_valid_lines_from_file "${DATABASE_VIRTUAL}")
   else
     _log 'debug' "'${DATABASE_VIRTUAL}' not provided - no mail alias/forward created"
   fi

--- a/target/scripts/helpers/postfix.sh
+++ b/target/scripts/helpers/postfix.sh
@@ -51,7 +51,7 @@ function _vhost_collect_postfix_domains
   if [[ -f ${DATABASE_ACCOUNTS} ]]
   then
     # shellcheck disable=SC2034
-    while IFS=$'|' read -r LOGIN PASS
+    while IFS=$'|' read -r LOGIN _
     do
       DOMAIN=$(echo "${LOGIN}" | cut -d @ -f2)
       echo "${DOMAIN}" >>"${TMP_VHOST}"
@@ -61,9 +61,8 @@ function _vhost_collect_postfix_domains
   # getting domains FROM mail aliases
   if [[ -f ${DATABASE_VIRTUAL} ]]
   then
-    # the `to` is important, don't delete it
     # shellcheck disable=SC2034
-    while read -r FROM TO
+    while read -r FROM _
     do
       UNAME=$(echo "${FROM}" | cut -d @ -f1)
       DOMAIN=$(echo "${FROM}" | cut -d @ -f2)

--- a/target/scripts/helpers/postfix.sh
+++ b/target/scripts/helpers/postfix.sh
@@ -50,7 +50,6 @@ function _vhost_collect_postfix_domains
   # getting domains FROM mail accounts
   if [[ -f ${DATABASE_ACCOUNTS} ]]
   then
-    # shellcheck disable=SC2034
     while IFS=$'|' read -r LOGIN _
     do
       DOMAIN=$(echo "${LOGIN}" | cut -d @ -f2)
@@ -61,7 +60,6 @@ function _vhost_collect_postfix_domains
   # getting domains FROM mail aliases
   if [[ -f ${DATABASE_VIRTUAL} ]]
   then
-    # shellcheck disable=SC2034
     while read -r FROM _
     do
       UNAME=$(echo "${FROM}" | cut -d @ -f1)

--- a/target/scripts/helpers/postfix.sh
+++ b/target/scripts/helpers/postfix.sh
@@ -20,16 +20,25 @@ function _create_postfix_vhost
 {
   # `main.cf` configures `virtual_mailbox_domains = /etc/postfix/vhost`
   # NOTE: Amavis also consumes this file.
-  : >/etc/postfix/vhost
+  local DATABASE_VHOST='/etc/postfix/vhost'
+  local TMP_VHOST='/tmp/vhost.tmp'
+
+  _create_vhost
+}
+
+# Processes TMP_VHOST into final DATABASE_VHOST
+function _create_vhost
+{
+  : >"${DATABASE_VHOST}"
 
   # Account and Alias generation will store values in `/tmp/vhost.tmp`.
   # Filter unique values to the proper config.
   # NOTE: LDAP stores the domain value set by `docker-mailserver`,
   # and correctly removes it from `mydestination` in `main.cf` in `setup-stack.sh`.
-  if [[ -f /tmp/vhost.tmp ]]
+  if [[ -f ${TMP_VHOST} ]]
   then
-    sort < /tmp/vhost.tmp | uniq >> /etc/postfix/vhost
-    rm /tmp/vhost.tmp
+    sort < "${TMP_VHOST}" | uniq >>"${DATABASE_VHOST}"
+    rm "${TMP_VHOST}"
   fi
 }
 

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -360,9 +360,6 @@ function _setup_ldap
 
   configomat.sh "DOVECOT_" "/etc/dovecot/dovecot-ldap.conf.ext"
 
-  # add domainname to vhost
-  echo "${DOMAINNAME}" >>/tmp/vhost.tmp
-
   _log 'trace' 'Enabling Dovecot LDAP authentication'
 
   sed -i -e '/\!include auth-ldap\.conf\.ext/s/^#//' /etc/dovecot/conf.d/10-auth.conf


### PR DESCRIPTION
# Description

`bin/open-dkim` and `helpers/accounts.sh` + `helpers/aliases.sh` have roughly duplicate code for collecting domains to process. This code is now in sync by updating methods in `helpers/postfix.sh`.

<details>
<summary>Commit messages (first to last) for quick reference</summary>

**chore: Split vhost helper method and use filepath vars**
- Helpers `accounts.sh` and `aliases.sh` can move their vhost code into this helper.
- They share duplicate code with `bin/open-dkim` which will also leverage this vhost helper going forward.

**chore: Sync vhost generation logic into helper**
- Chunky commit, but mostly copy/paste of logic into a common method.
- `bin/open-dkim` additionally wrapped relevant logic in a function call and revised inline docs.

**chore: Include LDAP vhost support**
- Revises notes for LDAP vhost support.
- This now ensures LDAP users get vhost rebuilt to match the startup script for when change detection support is enabled.
- `bin/open-dkim` will additionally be able to support the default `DOMAINNAME` var (set via `helpers/dns.sh`) for LDAP users instead of requiring them to provide one explicitly.

**chore(`bin/open-dkim`): Ensure `DOMAINNAME` is properly set**
- This will ensure LDAP users insert the same `DOMAINNAME` value as used during container startup.
- The container itself should panic at startup (during `helpers/dns.sh`) if this isn't configured correctly already, thus it should not introduce any breaking change to users of this utility?

</details>

---

- We use this functionality for populating `/etc/postfix/vhost` used by Postfix `main.cf:virtual_mailbox_domains` setting. `bin/open-dkim` leverages it to acquire domains relevant to Postfix.
- This PR will additionally benefit `check-for-changes.sh` to generate vhost config when `helpers/accounts.sh` or `helpers/aliases.sh` is not affected by the changed file. That support will be covered in https://github.com/docker-mailserver/docker-mailserver/pull/2615

### Relevant history - `bin/open-dkim` arg `DOMAINS`

Additional info regarding `bin/open-dkim` (most of this isn't useful in the context of this PR, but helps understand the background of the alternative support via `DOMAINS` arg):

- It's alternative [`DOMAINS` arg support was added in Jan 2021](https://github.com/docker-mailserver/docker-mailserver/pull/1753) to support the needs of LDAP users ([earlier issue from 2017 for LDAP users](https://github.com/docker-mailserver/docker-mailserver/issues/478#issuecomment-273426172)).
   - The contributor [shares in their original issue](https://github.com/docker-mailserver/docker-mailserver/issues/1735#issuecomment-753459953) a command for their setup to retrieve the domains that they'd supply as `DOMAINS`.
   - The `DOMAINS` arg replaced the need for a separate command that provided similar functionality ([originally for a user with DKIM sourced via SQL](https://github.com/docker-mailserver/docker-mailserver/issues/619), implemented Sep 2017 in https://github.com/docker-mailserver/docker-mailserver/pull/690 ).
     -  #619 notes the intention was to configure DKIM for equivalent domains available in `main.cf:virtual_mailbox_domains` (`/etc/postfix/vhost`), although LDAP setups also add a 2nd table value: `ldap:/etc/postfix/ldap-domains.cf` (_could possible source via `postconf` query? Unless `bin/open-dkim` is not meant to be dependent upon a running/configured Postfix instance_).
   - That PR introduced an unrelated change to the default DKIM keylength size which was bumped up from 2048-bit to 4096-bit ([with little justification](https://github.com/docker-mailserver/docker-mailserver/pull/1753#pullrequestreview-576855284)).
     - AFAIK 4096-bit RSA is excessive for DKIM, it's not for encryption and not damaging to past transactions? You want some strength to avoid forgery, but it's not as valuable as a root CA key.
     - Prior to that, [a March 2018 PR which added support to adjust keylength size](https://github.com/docker-mailserver/docker-mailserver/pull/868) references two issues about services lacking support for key lengths larger than 1024-bit.
       - In 2022, [OpenDKIM docs still document 1024-bit as the default size](http://www.opendkim.org/opendkim-genkey.8.html). 
       - Debian apparently [has defaulted to 2048-bit since 2017](https://github.com/docker-mailserver/docker-mailserver/issues/855#issuecomment-368994889).
       - The NameCheap provider [has since updated support to 2048-bit](https://www.namecheap.com/support/knowledgebase/article.aspx/317/2237/how-do-i-add-txtspfdkimdmarc-records-for-my-domain), unclear if other vendors improved support.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
