### PR TITLE
fix(setup.sh): Do not override an existing `CONTAINER_NAME` value

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -205,7 +205,7 @@ function _main
   INFO=$(${CRI} ps --no-trunc --format "{{.Image}};{{.Names}}" --filter \
     label=org.opencontainers.image.title="docker-mailserver" | tail -1)
 
-  CONTAINER_NAME=${INFO#*;}
+  [[ -z ${CONTAINER_NAME} ]] && CONTAINER_NAME=${INFO#*;}
   [[ -z ${IMAGE_NAME} ]] && IMAGE_NAME=${INFO%;*}
   if [[ -z ${IMAGE_NAME} ]]
   then


### PR DESCRIPTION
# Description

This bug was causing `setup.sh -c` to target the wrong container when an earlier `docker-mailserver` container was already running.

I believe this is to try lookup an implicit default, but an explicit value for `-c` sets `CONTAINER_NAME` prior to this and should be used. It was causing some recent test failures in `test/mail_with_relays.bats`, both on CI and my local VM.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
