### PR TITLE
chore(`check-for-changes.sh`): Drop redundant guards

### DIFF
--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -27,12 +27,6 @@ then
   _exit_with_error "Could not change into '/tmp/docker-mailserver/' directory" 0
 fi
 
-# check postfix-accounts.cf exist else break
-if [[ ! -f postfix-accounts.cf ]]
-then
-  _exit_with_error "'/tmp/docker-mailserver/postfix-accounts.cf' is missing" 0
-fi
-
 # verify checksum file exists; must be prepared by start-mailserver.sh
 if [[ ! -f ${CHKSUM_FILE} ]]
 then

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -22,11 +22,6 @@ _log_with_date 'debug' 'Starting changedetector'
 #            to be properly set.
 _obtain_hostname_and_domainname
 
-if ! cd /tmp/docker-mailserver &>/dev/null
-then
-  _exit_with_error "Could not change into '/tmp/docker-mailserver/' directory" 0
-fi
-
 # verify checksum file exists; must be prepared by start-mailserver.sh
 if [[ ! -f ${CHKSUM_FILE} ]]
 then

--- a/target/scripts/helpers/aliases.sh
+++ b/target/scripts/helpers/aliases.sh
@@ -61,13 +61,8 @@ function _handle_postfix_aliases_config
 
   echo "root: ${POSTMASTER_ADDRESS}" >/etc/aliases
 
-  if [[ -f /tmp/docker-mailserver/postfix-aliases.cf ]]
-  then
-    cat /tmp/docker-mailserver/postfix-aliases.cf >>/etc/aliases
-  else
-    _log 'trace' "'/tmp/docker-mailserver/postfix-aliases.cf' is not provided, it will be auto created."
-    : >/tmp/docker-mailserver/postfix-aliases.cf
-  fi
+  local DATABASE_ALIASES='/tmp/docker-mailserver/postfix-aliases.cf'
+  [[ -f ${DATABASE_ALIASES} ]] && cat "${DATABASE_ALIASES}" >>/etc/aliases
 
   postalias /etc/aliases
 }

--- a/target/scripts/helpers/change-detection.sh
+++ b/target/scripts/helpers/change-detection.sh
@@ -4,7 +4,7 @@
 # - check-for-changes.sh
 # - test/test_helper/common.bash:wait_for_changes_to_be_detected_in_container()
 # - test/test_helper.bats
-# - start-mailserver.sh --> setup-stack.sh (to initialize the CHKSUM_FILE state)
+# - start-mailserver.sh --> setup-stack.sh:_setup (to initialize the CHKSUM_FILE state)
 
 # Global checksum file used to track when monitored files have changed in content:
 # shellcheck disable=SC2034
@@ -42,6 +42,7 @@ function _monitored_files_checksums
     )
   fi
 
+  # SSL certs:
   if [[ ${SSL_TYPE:-} == 'manual' ]]
   then
     # When using "manual" as the SSL type,
@@ -63,10 +64,11 @@ function _monitored_files_checksums
     )
   fi
 
+  # If the file actually exists, add to CHANGED_FILES
+  # and generate a content hash entry:
   for FILE in "${STAGING_FILES[@]}"
   do
     [[ -f "${FILE}" ]] && CHANGED_FILES+=("${FILE}")
   done
-
   sha512sum -- "${CHANGED_FILES[@]}"
 }

--- a/target/scripts/helpers/change-detection.sh
+++ b/target/scripts/helpers/change-detection.sh
@@ -16,37 +16,31 @@ function _prepare_for_change_detection
 {
   _log 'debug' 'Setting up configuration checksum file'
 
-  if [[ -d /tmp/docker-mailserver ]]
-  then
-    _log 'trace' "Creating '${CHKSUM_FILE}'"
-    _monitored_files_checksums >"${CHKSUM_FILE}"
-  else
-    # We could just skip the file, but perhaps config can be added later?
-    # If so it must be processed by the check for changes script
-    _log 'trace' "Creating empty '${CHKSUM_FILE}' (no config)"
-    touch "${CHKSUM_FILE}"
-  fi
+  _log 'trace' "Creating '${CHKSUM_FILE}'"
+  _monitored_files_checksums >"${CHKSUM_FILE}"
 }
 
 # Returns a list of changed files, each line is a value pair of:
 # <SHA-512 content hash> <changed file path>
 function _monitored_files_checksums
 {
-  local DMS_DIR=/tmp/docker-mailserver
-  [[ -d ${DMS_DIR} ]] || return 1
-
   # If a wildcard path pattern (or an empty ENV) would yield an invalid path
   # or no results, `shopt -s nullglob` prevents it from being added.
   shopt -s nullglob
   declare -a STAGING_FILES CHANGED_FILES
 
-  STAGING_FILES=(
-    "${DMS_DIR}/postfix-accounts.cf"
-    "${DMS_DIR}/postfix-virtual.cf"
-    "${DMS_DIR}/postfix-aliases.cf"
-    "${DMS_DIR}/dovecot-quotas.cf"
-    "${DMS_DIR}/dovecot-masters.cf"
-  )
+  # Supported user provided configs:
+  local DMS_DIR=/tmp/docker-mailserver
+  if [[ -d ${DMS_DIR} ]]
+  then
+    STAGING_FILES+=(
+      "${DMS_DIR}/postfix-accounts.cf"
+      "${DMS_DIR}/postfix-virtual.cf"
+      "${DMS_DIR}/postfix-aliases.cf"
+      "${DMS_DIR}/dovecot-quotas.cf"
+      "${DMS_DIR}/dovecot-masters.cf"
+    )
+  fi
 
   if [[ ${SSL_TYPE:-} == 'manual' ]]
   then

--- a/target/scripts/helpers/change-detection.sh
+++ b/target/scripts/helpers/change-detection.sh
@@ -36,7 +36,10 @@ function _monitored_files_checksums
     STAGING_FILES+=(
       "${DMS_DIR}/postfix-accounts.cf"
       "${DMS_DIR}/postfix-virtual.cf"
+      "${DMS_DIR}/postfix-regexp.cf"
       "${DMS_DIR}/postfix-aliases.cf"
+      "${DMS_DIR}/postfix-relaymap.cf"
+      "${DMS_DIR}/postfix-sasl-password.cf"
       "${DMS_DIR}/dovecot-quotas.cf"
       "${DMS_DIR}/dovecot-masters.cf"
     )


### PR DESCRIPTION
# Description

Housekeeping PR mostly, added a few extra configs that should be monitored for changes.

I looked into some conditional guards and why they were needed. Turns out they're not, most of it was introduced from early support of Change Detection service and no longer relevant.

Origin of conditional guards:

- `check-for-changes.sh` originally used relative paths to supported config files to monitor. This and checksum file creation relied on changing the working directory to `/tmp/docker-mailserver`. No longer necessary as we use absolute paths.
- This carried over to associated scripts to only run logic if the directory existed (_such as [here in a Aug 2019 commit](https://github.com/docker-mailserver/docker-mailserver/commit/7f3e5a22e18e091e2eeabaa47a18a854788e7db8)_). We support monitoring changes elsewhere now (certs), the guard is legacy and can be dropped.
   - The [full PR that commit belongs to](https://github.com/docker-mailserver/docker-mailserver/pull/1201) is rather large, but useful discussion regarding transition to single checksum file and file locking.
- The `postfix-accounts.cf` guard was introduced as part of the [original `check-for-changes.sh` feature PR in Oct 2017](https://github.com/docker-mailserver/docker-mailserver/pull/738), shortly followed up with a [fix to the guard to `exit` if the config file didn't exist](https://github.com/docker-mailserver/docker-mailserver/pull/748) to prevent log spam.
- `postfix-aliases.cf` was always generated, for what seemed to be a compatibility workaround for `check-for-changes.sh` support. That logic was originally introduced in a [Nov 2018 PR](https://github.com/docker-mailserver/docker-mailserver/pull/1065). That PR did not introduce the original alias support requiring `POSTMASTER_ADDRESS`, but did carry over the dependency for it into `check-for-changes.sh`. As `aliases.sh` has since de-duplicated the alias code and `check-for-changes.sh` is in much better shape, this workaround is no longer necessary.

---

I've additionally added 3 user configs that make sense for change detection to support as well since we already run recreation logic involving them: `postfix-sasl-password.cf`, `postfix-relaymap.cf`, `postfix-regexp.cf`.

All these `/tmp/docker-mailserver` config files are wrapped into the directory check before adding them to `STAGING_FILES`, although with `shopt -s nullglob` and the filtering to `CHANGED_FILES` array, it probably makes no difference and the conditional could be dropped?

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
