### PR TITLE
chore: Remove redundant capability `SYS_PTRACE`

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,6 @@ services:
       - ONE_DIR=1
     cap_add:
       - NET_ADMIN
-      - SYS_PTRACE
     restart: always
 ```
 
@@ -316,6 +315,5 @@ services:
       - POSTFIX_MESSAGE_SIZE_LIMIT=100000000
     cap_add:
       - NET_ADMIN
-      - SYS_PTRACE
     restart: always
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,5 +26,3 @@ services:
     stop_grace_period: 1m
     cap_add:
       - NET_ADMIN
-      - SYS_PTRACE
-

--- a/docs/content/config/advanced/full-text-search.md
+++ b/docs/content/config/advanced/full-text-search.md
@@ -83,7 +83,6 @@ While indexing is memory intensive, you can configure the plugin to limit the am
           stop_grace_period: 1m
           cap_add:
             - NET_ADMIN
-            - SYS_PTRACE
     ```
 
 3. Recreate containers:

--- a/docs/content/config/advanced/kubernetes.md
+++ b/docs/content/config/advanced/kubernetes.md
@@ -199,7 +199,6 @@ spec:
                 - NET_BIND_SERVICE
                 # miscellaneous  capabilities
                 - SYS_CHROOT
-                - SYS_PTRACE
                 - KILL
               drop: [ALL]
             seccompProfile:

--- a/docs/content/examples/tutorials/basic-installation.md
+++ b/docs/content/examples/tutorials/basic-installation.md
@@ -61,7 +61,6 @@ In this setup `docker-mailserver` is not intended to receive email externally, s
               - SPOOF_PROTECTION=0
             cap_add:
               - NET_ADMIN # For Fail2Ban to work
-              - SYS_PTRACE
         ```
 
     - The docs have a detailed page on [Environment Variables][docs-environment] for reference.

--- a/test/default_relay_host.bats
+++ b/test/default_relay_host.bats
@@ -8,7 +8,6 @@ function setup() {
     -v "${PRIVATE_CONFIG}":/tmp/docker-mailserver \
     -v "$(pwd)/test/test-files":/tmp/docker-mailserver-test:ro \
     -e DEFAULT_RELAY_HOST=default.relay.host.invalid:25 \
-    --cap-add=SYS_PTRACE \
     -e PERMIT_DOCKER=host \
     -h mail.my-domain.com -t "${NAME}"
 

--- a/test/mail_privacy.bats
+++ b/test/mail_privacy.bats
@@ -8,7 +8,6 @@ function setup_file() {
     -v "${PRIVATE_CONFIG}":/tmp/docker-mailserver \
     -v "$(pwd)/test/test-files":/tmp/docker-mailserver-test:ro \
     -e ENABLE_MANAGESIEVE=1 \
-    --cap-add=SYS_PTRACE \
     -e PERMIT_DOCKER=host \
     -h mail.my-domain.com \
     -e SSL_TYPE='snakeoil' \

--- a/test/mail_special_use_folders.bats
+++ b/test/mail_special_use_folders.bats
@@ -10,7 +10,6 @@ setup_file() {
     -e SASL_PASSWD="external-domain.com username:password" \
     -e ENABLE_CLAMAV=0 \
     -e ENABLE_SPAMASSASSIN=0 \
-    --cap-add=SYS_PTRACE \
     -e PERMIT_DOCKER=host \
     -h mail.my-domain.com -t "${NAME}"
 

--- a/test/mail_undef_spam_subject.bats
+++ b/test/mail_undef_spam_subject.bats
@@ -29,7 +29,6 @@ function setup() {
     -e ENABLE_SRS=1 \
     -e SASL_PASSWD="external-domain.com username:password" \
     -e ENABLE_MANAGESIEVE=1 \
-    --cap-add=SYS_PTRACE \
     -e PERMIT_DOCKER=host \
     -h mail.my-domain.com -t "${NAME}")
 

--- a/test/mail_with_mdbox.bats
+++ b/test/mail_with_mdbox.bats
@@ -11,7 +11,6 @@ setup_file() {
     -e ENABLE_CLAMAV=0 \
     -e ENABLE_SPAMASSASSIN=0 \
     -e DOVECOT_MAILBOX_FORMAT=mdbox \
-    --cap-add=SYS_PTRACE \
     -e PERMIT_DOCKER=host \
     -h mail.my-domain.com -t "${NAME}"
 

--- a/test/mail_with_relays.bats
+++ b/test/mail_with_relays.bats
@@ -13,7 +13,6 @@ function setup_file() {
     -e RELAY_PORT=2525 \
     -e RELAY_USER=smtp_user \
     -e RELAY_PASSWORD=smtp_password \
-    --cap-add=SYS_PTRACE \
     -e PERMIT_DOCKER=host \
     -h mail.my-domain.com -t "${NAME}"
 

--- a/test/mail_with_sdbox.bats
+++ b/test/mail_with_sdbox.bats
@@ -11,7 +11,6 @@ setup_file() {
     -e ENABLE_CLAMAV=0 \
     -e ENABLE_SPAMASSASSIN=0 \
     -e DOVECOT_MAILBOX_FORMAT=sdbox \
-    --cap-add=SYS_PTRACE \
     -e PERMIT_DOCKER=host \
     -h mail.my-domain.com -t "${NAME}"
 

--- a/test/open_dkim.bats
+++ b/test/open_dkim.bats
@@ -14,7 +14,6 @@ function setup_file
 
   docker run -d \
     --name "${CONTAINER_NAME}" \
-    --cap-add=SYS_PTRACE \
     -v "${PRIVATE_CONFIG}":/tmp/docker-mailserver \
     -v "${PWD}/test/test-files":/tmp/docker-mailserver-test:ro \
     -e DEFAULT_RELAY_HOST=default.relay.host.invalid:25 \

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -36,7 +36,6 @@ setup_file() {
     -e SSL_TYPE='snakeoil' \
     -e VIRUSMAILS_DELETE_DELAY=7 \
     -h mail.my-domain.com \
-    --cap-add=SYS_PTRACE \
     --tty \
     "${NAME}"
 


### PR DESCRIPTION
# Description

This capability was added as part of the [original `check-for-changes.sh` feature PR in Oct 2017](https://github.com/docker-mailserver/docker-mailserver/pull/738):
- The original explanation for needing this was detailed in an [associated issue comment](https://github.com/docker-mailserver/docker-mailserver/issues/552#issuecomment-335243949), but it is unclear if they were referring to the earlier `postfix reload` commit, or the `supervisorctl restart postfix` line that replaced it.
- A review comment expressed a concern with using `postfix reload` that may possibly lead to a process (_which one?_) losing a PID (_for Postfix?_).

---

In June 2018, the [`SYS_PTRACE` requirement was clarified](https://github.com/docker-mailserver/docker-mailserver/issues/1057#issuecomment-503985435):

> _Without `SYS_PTRACE` one of the unit tests fails with several of these in syslog:_
> 
> `Jun 20 08:51:22 mail postfix/postfix-script[2964]: fatal: the Postfix mail system is already running`
> 
> _I think the postfix script is trying to connect to the master process with the saved pid and fails without `SYS_PTRACE`._
> _I haven't seen this on my server so far, but perhaps the tests are doing something that doesn't happen very often._

and:

> _This can happen when the system is running as well. The postfix management script needs `SYS_PTRACE`._

That is still a bit vague. None of the current unit tests seem to fail anymore. I assume the referenced "postfix management script" is [`wrappers/postfix-wrapper.sh`](https://github.com/docker-mailserver/docker-mailserver/blob/0010786d181a3a6c70856d4c34e46b60ad015b7e/target/scripts/wrapper/postfix-wrapper.sh)?

`postfix-wrapper.sh` was [introduced in Aug 2017](https://github.com/docker-mailserver/docker-mailserver/pull/676) (_as part of adding `supervisord` into the image_), so a little bit earlier than the change detection service. The wrapper purpose is described:

> _Some processes are not single processes like `postfix` and `fail2ban` and they have a wrapper._
> _The wrapper takes care of proper shutdown and checking if the process is running or not. Supervisored will restart the wrapping script if the process is gone._

---

I'm not sure what has changed since. Perhaps @casperklein or @georglauterbach know of a reason to keep `SYS_PTRACE` around?

I'd also like to understand the intent to require restarting Postfix and Dovecot, as opposed to `postfix reload` /`dovecot reload`. This was used prior to adopting `supervisord` (_and the wrapper scripts that it seemed to require?_). All I have to go by is the concern that maintainer expressed with a PID possibly being lost.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] New and existing unit tests pass locally with my changes
