### PR TITLE
Add basic container healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,6 @@ services:
       - NET_ADMIN
       - SYS_PTRACE
     healthcheck:
-      test: "ss --listening | grep -P 'LISTEN.+:smtp' || exit 1"
+      test: "ss --listening --tcp | grep -P 'LISTEN.+:smtp' || exit 1"
       timeout: 3s
       retries: 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
     stop_grace_period: 1m
     cap_add:
       - NET_ADMIN
-      - SYS_PTRACE
     healthcheck:
       test: "ss --listening --tcp | grep -P 'LISTEN.+:smtp' || exit 1"
       timeout: 3s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,6 @@ services:
       - NET_ADMIN
       - SYS_PTRACE
     healthcheck:
-      test: "ss -l | grep -P 'LISTEN.+:smtp' || exit 1"
+      test: "ss --listening | grep -P 'LISTEN.+:smtp' || exit 1"
       timeout: 3s
       retries: 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,4 +27,7 @@ services:
     cap_add:
       - NET_ADMIN
       - SYS_PTRACE
-
+    healthcheck:
+      test: "ss -l | grep -P 'LISTEN.+:smtp' || exit 1"
+      timeout: 3s
+      retries: 0

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -38,7 +38,7 @@ setup_file() {
     -h mail.my-domain.com \
     --cap-add=SYS_PTRACE \
     --tty \
-    --health-cmd "ss -l | grep -P 'LISTEN.+:smtp' || exit 1" \
+    --health-cmd "ss --listening | grep -P 'LISTEN.+:smtp' || exit 1" \
     "${NAME}"
 
   wait_for_finished_setup_in_container mail

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -38,6 +38,7 @@ setup_file() {
     -h mail.my-domain.com \
     --cap-add=SYS_PTRACE \
     --tty \
+    --health-cmd "ss -l | grep -P 'LISTEN.+:smtp' || exit 1" \
     "${NAME}"
 
   wait_for_finished_setup_in_container mail
@@ -1205,6 +1206,16 @@ EOF
   # check sender is not the default one.
   run docker exec mail grep "From: mailserver-report@mail.my-domain.com" /var/mail/localhost.localdomain/user1/new/ -R
   assert_failure
+}
+
+#
+# healthcheck
+#
+
+@test "checking container healthcheck" {
+  run bash -c "docker inspect mail | jq -r '.[].State.Health.Status'"
+  assert_output "healthy"
+  assert_success
 }
 
 #

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -38,7 +38,7 @@ setup_file() {
     -h mail.my-domain.com \
     --cap-add=SYS_PTRACE \
     --tty \
-    --health-cmd "ss --listening | grep -P 'LISTEN.+:smtp' || exit 1" \
+    --health-cmd "ss --listening --tcp | grep -P 'LISTEN.+:smtp' || exit 1" \
     "${NAME}"
 
   wait_for_finished_setup_in_container mail


### PR DESCRIPTION
# Description

This PR adds a basic healthcheck for DMS. The container is considered healthy, when postfix is running and listening on port tcp/25.


## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
