### PR TITLE
Check if fail2ban is running

### DIFF
--- a/target/bin/fail2ban
+++ b/target/bin/fail2ban
@@ -5,6 +5,8 @@ source /usr/local/bin/helpers/index.sh
 
 function __usage { echo "Usage: ./setup.sh fail2ban [<ban|unban> <IP>]" ; }
 
+fail2ban-client ping &>/dev/null || _exit_with_error "Fail2ban not running"
+
 unset JAILS
 declare -a JAILS
 IP_REGEXP='((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)'


### PR DESCRIPTION
# Description

In case fail2ban is not enabled, running `./setup.sh fail2ban` shows this error:

```bash
./setup.sh fail2ban
2022-06-06 19:45:53,685 fail2ban                [12]: ERROR   Failed to access socket path: /var/run/fail2ban/fail2ban.sock. Is fail2ban running?
[   INF   ]  No IPs have been banned
```

This PR adds a check and change the output to:

```bash
./setup.sh fail2ban
[  ERROR  ]  Fail2ban not running
[  ERROR  ]  Aborting
```

<!-- Link the issue which will be fixed (if any) here: -->


## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
