### PR TITLE
chore: Extract out `/var/mail` ownership workaround

### DIFF
--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -117,10 +117,9 @@ function _check_for_changes
     # be sure to mimic `setup-stack.sh:_setup_ldap` which appends to `/tmp/vhost.tmp`.
     _create_postfix_vhost
 
-    if find /var/mail -maxdepth 3 -a \( \! -user 5000 -o \! -group 5000 \) | read -r
-    then
-      chown -R 5000:5000 /var/mail
-    fi
+    # Legacy workaround handled here, only seems necessary for _create_accounts:
+    # - `helpers/accounts.sh` logic creates folders/files with wrong ownership.
+    _chown_var_mail_if_necessary
 
     _log_with_date 'debug' 'Restarting services due to detected changes'
 

--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -20,3 +20,19 @@ function _get_dms_env_value
   VALUE=$(grep "^${1}=" /etc/dms-settings | cut -d '=' -f 2)
   printf '%s' "${VALUE:1:-1}"
 }
+
+# TODO: `chown -R 5000:5000 /var/mail` has existed since the projects first commit.
+# It later received a depth guard to apply the fix only when it's relevant for a dir.
+# Assess if this still appropriate, it appears to be problematic for some LDAP users.
+#
+# `helpers/accounts.sh:_create_accounts` (mkdir, cp) appears to be the only writer to
+# /var/mail folders (used during startup and change detection handling).
+function _chown_var_mail_if_necessary
+{
+  # fix permissions, but skip this if 3 levels deep the user id is already set
+  if find /var/mail -maxdepth 3 -a \( \! -user 5000 -o \! -group 5000 \) | read -r
+  then
+    _log 'trace' 'Fixing /var/mail permissions'
+    chown -R 5000:5000 /var/mail || return 1
+  fi
+}

--- a/target/scripts/startup/fixes-stack.sh
+++ b/target/scripts/startup/fixes-stack.sh
@@ -17,14 +17,8 @@ function _fix_var_mail_permissions
 {
   _log 'debug' 'Checking /var/mail permissions'
 
-  # fix permissions, but skip this if 3 levels deep the user id is already set
-  if find /var/mail -maxdepth 3 -a \( \! -user 5000 -o \! -group 5000 \) | read -r
-  then
-    _log 'trace' 'Fixing /var/mail permissions'
-    chown -R 5000:5000 /var/mail || _shutdown 'Failed to fix /var/mail permissions'
-  else
-    _log 'trace' 'Permissions in /var/mail look OK'
-  fi
+  _chown_var_mail_if_necessary || _shutdown 'Failed to fix /var/mail permissions'
+  _log 'trace' 'Permissions in /var/mail look OK'
 }
 
 function _fix_var_amavis_permissions


### PR DESCRIPTION
# Description

Container startup and the Change Detector have their own copy of the `chown -R 5000:5000 /var/mail` logic. I replaced the duplicate code with a call to a shared method in `helpers/utils.sh`.

I've added a `TODO` maintenance comment for the method. I've already looked into that concern and will detail it with a follow-up PR (for a breaking change) where we can discuss if removal is appropriate. For now, at least lets keep the shared logic in sync :+1: 

This PR is part of investigating https://github.com/docker-mailserver/docker-mailserver/pull/2256 so that it can be resolved.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
