### PR TITLE
Fail2ban can use legacy iptables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN \
   dovecot-ldap dovecot-lmtpd dovecot-managesieved dovecot-pop3d \
   dovecot-sieve dovecot-solr dumb-init \
   # E - O
-  ed fetchmail file gamin gnupg gzip iproute2 \
+  ed fetchmail file gamin gnupg gzip iproute2 iptables \
   locales logwatch lhasa libdate-manip-perl libldap-common liblz4-tool \
   libmail-spf-perl libnet-dns-perl libsasl2-modules lrzip lzop \
   netcat-openbsd nftables nomarch opendkim opendkim-tools opendmarc \
@@ -78,6 +78,9 @@ RUN \
     echo "ERROR: Wrong GPG fingerprint!" >&2; exit 1; fi && \
   dpkg -i fail2ban.deb 2>&1 && \
   rm fail2ban.deb fail2ban.deb.asc && \
+  # allow legacy iptables to be configured via FAIL2BAN_LEGACY_IPTABLES
+  update-alternatives --set iptables /usr/sbin/iptables-legacy && \
+  update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy && \
   # cleanup
   apt-get -qq autoremove && \
   apt-get -qq autoclean && \

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -112,6 +112,14 @@ Otherwise, `nftables` won't be able to ban IPs.
 - reject => reject packet (send ICMP unreachable)
 FAIL2BAN_BLOCKTYPE=drop
 
+##### FAIL2BAN_LEGACY_IPTABLES
+
+Enable legacy iptables firewall. Useful when docker is running on some type of appliance (e.g. QNAP NAS)
+
+- **0**   => use nftables
+- 1 => use iptables-legacy
+FAIL2BAN_LEGACY_IPTABLES=0
+
 ##### SMTP_ONLY
 
 - **empty** => all daemons start

--- a/mailserver.env
+++ b/mailserver.env
@@ -126,6 +126,11 @@ ENABLE_FAIL2BAN=0
 # reject => reject packet (send ICMP unreachable)
 FAIL2BAN_BLOCKTYPE=drop
 
+# Fail2Ban use legacy iptables
+# **0**   => use nftables
+# 1 => use iptables-legacy
+FAIL2BAN_LEGACY_IPTABLES=0
+
 # 1 => Enables Managesieve on port 4190
 # empty => disables Managesieve
 ENABLE_MANAGESIEVE=

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -1070,6 +1070,11 @@ function _setup_fail2ban
     echo -e '[Init]\nblocktype = drop' >/etc/fail2ban/action.d/nftables-common.local
   fi
 
+  if [[ ${FAIL2BAN_LEGACY_IPTABLES} -eq 1 ]]
+  then
+    sed -i 's/banaction = nftables-allports/banaction = iptables-allports/' /etc/fail2ban/jail.local
+  fi
+
   echo '[Definition]' >/etc/fail2ban/filter.d/custom.conf
 }
 


### PR DESCRIPTION
On some appliance (e.g., QNAP NAS') nftables on docker is not
available.
This commit adds FAIL2BAN_LEGACY_IPTABLES environment variable to allow configuring fail2ban to use iptables-legacy.

Fixes #2661

# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [N] If necessary I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
