### PR TITLE
docs(fix): Update to fix regression causing broken links

### DIFF
--- a/.github/workflows/scripts/docs/build-docs.sh
+++ b/.github/workflows/scripts/docs/build-docs.sh
@@ -10,7 +10,7 @@ docker run \
   --user "$(id -u):$(id -g)" \
   --volume "${PWD}:/docs" \
   --name "build-docs" \
-  squidfunk/mkdocs-material:8.3.5 build --strict
+  squidfunk/mkdocs-material:8.3.9 build --strict
 
 # Remove unnecessary build artifacts: https://github.com/squidfunk/mkdocs-material/issues/2519
 # site/ is the build output folder.


### PR DESCRIPTION
# Description

Bug was [reported and fixed upstream roughly a month ago](https://github.com/squidfunk/mkdocs-material/issues/4028#issuecomment-1157448208). It had gone unnoticed with our `v11.1` docs release (_I'll need to rebuild that and update the `gh-pages` branch_).

Fixes #2680 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update (after merging)
