### PR TITLE
Set configomat output to loglevel debug

### DIFF
--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -331,7 +331,7 @@ function _setup_ldap
     [[ ${FILE} =~ ldap-aliases ]] && export LDAP_QUERY_FILTER="${LDAP_QUERY_FILTER_ALIAS}"
     [[ ${FILE} =~ ldap-domains ]] && export LDAP_QUERY_FILTER="${LDAP_QUERY_FILTER_DOMAIN}"
     [[ ${FILE} =~ ldap-senders ]] && export LDAP_QUERY_FILTER="${LDAP_QUERY_FILTER_SENDERS}"
-    configomat.sh "LDAP_" "${FILE}"
+    _log debug "$(configomat.sh "LDAP_" "${FILE}" 2>&1)"
   done
 
   _log 'trace' "Configuring Dovecot LDAP"
@@ -358,7 +358,7 @@ function _setup_ldap
     export "${VAR}=${DOVECOT_LDAP_MAPPING[${VAR}]}"
   done
 
-  configomat.sh "DOVECOT_" "/etc/dovecot/dovecot-ldap.conf.ext"
+  _log debug "$(configomat.sh "DOVECOT_" "/etc/dovecot/dovecot-ldap.conf.ext" 2>&1)"
 
   _log 'trace' 'Enabling Dovecot LDAP authentication'
 


### PR DESCRIPTION
# Description

This PR hides the configomat output, for `LOGLEVEL` != `debug/trace`.

This prevents issues like [this](https://github.com/docker-mailserver/docker-mailserver/issues/2692) in the default configuration.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #2692

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
