### PR TITLE
Simplify fail2ban output

### DIFF
--- a/target/bin/fail2ban
+++ b/target/bin/fail2ban
@@ -9,7 +9,6 @@ fail2ban-client ping &>/dev/null || _exit_with_error "Fail2ban not running"
 
 unset JAILS
 declare -a JAILS
-IP_REGEXP='((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)'
 
 for LIST in $(fail2ban-client status | grep "Jail list" | cut -f2- | sed 's/,/ /g')
 do
@@ -22,13 +21,11 @@ then
 
   for JAIL in "${JAILS[@]}"
   do
-    BANNED_IPS=$(fail2ban-client status "${JAIL}" \
-      | grep 'Banned IP list' \
-      | grep -oE "${IP_REGEXP}")
+    BANNED_IPS=$(fail2ban-client status "${JAIL}" | grep -oP '(?<=Banned IP list:\s).+')
 
     if [[ -n ${BANNED_IPS} ]]
     then
-      echo "Banned in ${JAIL}: ${BANNED_IPS//$'\n'/, }"
+      echo "Banned in ${JAIL}: ${BANNED_IPS}"
       IPS_BANNED=1
     fi
   done


### PR DESCRIPTION
# Description

This PR simplifies the `fail2ban` script output when it's called without arguments.

There is no need to verify/validate IPv4 addresses with a regex.

This way, it's also compatible with IPv6 addresses, which were previously not caught with the IPv4 regex.


<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #2687

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
