### PR TITLE
chore: `addmailuser` - Remove delaying completion until `/var/mail` is ready

### DIFF
--- a/target/bin/addmailuser
+++ b/target/bin/addmailuser
@@ -13,9 +13,9 @@ function _main
 
   _manage_accounts_create "${MAIL_ACCOUNT}" "${PASSWD}"
 
-  # Change Detection will be triggered from `postfix-accounts.cf` update,
-  # block until event processed (actual account creation handled there):
-  _wait_until_account_maildir_exists "${MAIL_ACCOUNT}"
+  # NOTE: An account has only been added to `postfix-accounts.cf`.
+  # The `changedetector` service will be triggered from this update
+  # where the actual account is created in Dovecot. Expect a delay.
 }
 
 function __usage
@@ -46,39 +46,6 @@ ${ORANGE}EXIT STATUS${RESET}
     or arguments contain errors, the script will exit early with exit status 1.
 
 "
-}
-
-# TODO: Remove this method or at least it's usage in `addmailuser`. If tests are failing, correct the tests.
-#
-# This method was added to delay command completion until a change detection event had processed the newly added user,
-# confirmed once maildir was created. It was a workaround to accomodate the test suite apparently, but otherwise
-# prevents batch adding users (each one would have to go through their own change detection event).
-#
-# Originally introduced in PR 1980 (afterwards two futher PRs deleted, and then reverted that deletion):
-# https://github.com/docker-mailserver/docker-mailserver/pull/1980
-# Not much details/discussion in the PR, these are the specific commits:
-# - Initial commit: https://github.com/docker-mailserver/docker-mailserver/pull/1980/commits/2ed402a12cedd412abcf577e8079137ea05204fe#diff-92d2047e4a9a7965f6ef2f029dd781e09265b0ce171b5322a76e35b66ab4cbf4R67
-# - Follow-up commit: https://github.com/docker-mailserver/docker-mailserver/pull/1980/commits/27542867b20c617b63bbec6fdcba421b65a44fbb#diff-92d2047e4a9a7965f6ef2f029dd781e09265b0ce171b5322a76e35b66ab4cbf4R67
-#
-# Original reasoning for this method (sounds like a network storage I/O issue):
-# Tests fail if the creation of /var/mail/${DOMAIN}/${USER} doesn't happen fast enough after addmailuser executes (check-for-changes.sh race-condition)
-# Prevent infinite loop in tests like "checking accounts: user3 should have been added to /tmp/docker-mailserver/postfix-accounts.cf even when that file does not exist"
-function _wait_until_account_maildir_exists
-{
-  local MAIL_ACCOUNT=${1}
-
-  if [[ -f ${CHKSUM_FILE} ]]
-  then
-    local USER="${MAIL_ACCOUNT%@*}"
-    local DOMAIN="${MAIL_ACCOUNT#*@}"
-
-    local MAIL_ACCOUNT_STORAGE_DIR="/var/mail/${DOMAIN}/${USER}"
-    while [[ ! -d ${MAIL_ACCOUNT_STORAGE_DIR} ]]
-    do
-      _log 'info' "Waiting for dovecot to create '${MAIL_ACCOUNT_STORAGE_DIR}'"
-      sleep 1
-    done
-  fi
 }
 
 _main "${@}"

--- a/test/setup-cli.bats
+++ b/test/setup-cli.bats
@@ -38,7 +38,7 @@ function teardown_file() {
   value=$(grep setup_email_add@example.com "${TEST_TMP_CONFIG}/postfix-accounts.cf" | awk -F '|' '{print $1}')
   assert_equal "${value}" 'setup_email_add@example.com'
 
-  wait_for_changes_to_be_detected_in_container "${TEST_NAME}"
+  wait_until_change_detection_event_completes "${TEST_NAME}"
 
   wait_for_service "${TEST_NAME}" postfix
   wait_for_service "${TEST_NAME}" dovecot

--- a/test/setup-cli.bats
+++ b/test/setup-cli.bats
@@ -38,7 +38,7 @@ function teardown_file() {
   value=$(grep setup_email_add@example.com "${TEST_TMP_CONFIG}/postfix-accounts.cf" | awk -F '|' '{print $1}')
   assert_equal "${value}" 'setup_email_add@example.com'
 
-  wait_until_change_detection_event_completes "${TEST_NAME}"
+  wait_until_account_maildir_exists "${TEST_NAME}" setup_email_add@example.com
 
   wait_for_service "${TEST_NAME}" postfix
   wait_for_service "${TEST_NAME}" dovecot

--- a/test/setup-cli.bats
+++ b/test/setup-cli.bats
@@ -9,8 +9,15 @@ load 'test_helper/common'
 function setup_file() {
   # Initializes common default vars to prepare a DMS container with:
   init_with_defaults
-  # Creates and starts the container:
-  common_container_setup
+
+  # Creates and starts the container with additional ENV needed:
+  # `LOG_LEVEL=debug` required for using `wait_until_change_detection_event_completes()`
+  # shellcheck disable=SC2034
+  local CONTAINER_ARGS_ENV_CUSTOM=(
+    --env LOG_LEVEL='debug'
+  )
+
+  common_container_setup 'CONTAINER_ARGS_ENV_CUSTOM'
 }
 
 function teardown_file() {
@@ -48,7 +55,7 @@ function teardown_file() {
   wait_until_account_maildir_exists "${TEST_NAME}" "${MAIL_ACCOUNT}"
   # Dovecot is stopped briefly at the end of processing a change event (should change to reload in future),
   # to more accurately use `wait_for_service` ensure you wait until `changedetector` is done.
-  wait_until_change_detection_event_completes
+  wait_until_change_detection_event_completes "${TEST_NAME}"
   wait_for_service "${TEST_NAME}" dovecot
 
   # Verify account authentication is successful:

--- a/test/test_helper/common.bash
+++ b/test/test_helper/common.bash
@@ -173,14 +173,6 @@ function wait_for_changes_to_be_detected_in_container() {
   repeat_in_container_until_success_or_timeout "${TIMEOUT}" "${CONTAINER_NAME}" bash -c 'source /usr/local/bin/helpers/index.sh; _obtain_hostname_and_domainname; cmp --silent -- <(_monitored_files_checksums) "${CHKSUM_FILE}" >/dev/null'
 }
 
-function wait_for_empty_mail_queue_in_container() {
-  local CONTAINER_NAME="${1}"
-  local TIMEOUT=${TEST_TIMEOUT_IN_SECONDS}
-
-  # shellcheck disable=SC2016
-  repeat_in_container_until_success_or_timeout "${TIMEOUT}" "${CONTAINER_NAME}" bash -c '[[ $(mailq) == *"Mail queue is empty"* ]]'
-}
-
 function wait_until_change_detection_event_completes() {
   local CONTAINER_NAME="${1}"
 
@@ -238,6 +230,14 @@ function add_mail_account_then_wait_until_ready() {
   assert_success
 
   wait_until_account_maildir_exists "${CONTAINER_NAME}" "${MAIL_ACCOUNT}"
+}
+
+function wait_for_empty_mail_queue_in_container() {
+  local CONTAINER_NAME="${1}"
+  local TIMEOUT=${TEST_TIMEOUT_IN_SECONDS}
+
+  # shellcheck disable=SC2016
+  repeat_in_container_until_success_or_timeout "${TIMEOUT}" "${CONTAINER_NAME}" bash -c '[[ $(mailq) == *"Mail queue is empty"* ]]'
 }
 
 # Common defaults appropriate for most tests, override vars in each test when necessary.

--- a/test/test_helper/common.bash
+++ b/test/test_helper/common.bash
@@ -173,11 +173,17 @@ function wait_for_changes_to_be_detected_in_container() {
   repeat_in_container_until_success_or_timeout "${TIMEOUT}" "${CONTAINER_NAME}" bash -c 'source /usr/local/bin/helpers/index.sh; _obtain_hostname_and_domainname; cmp --silent -- <(_monitored_files_checksums) "${CHKSUM_FILE}" >/dev/null'
 }
 
+# Relies on ENV `LOG_LEVEL=debug` or higher
 function wait_until_change_detection_event_completes() {
   local CONTAINER_NAME="${1}"
+  # Ensure failure from lack of providing a container is apparent:
+  assert_not_equal "${CONTAINER_NAME}" ""
+  # Ensure required LOG_LEVEL ENV is applied:
+  run docker exec "${CONTAINER_NAME}" grep -E '^LOG_LEVEL=(debug|trace)$' /etc/dms-settings
+  assert_success
 
   local CHANGE_EVENT_START='Change detected'
-  local CHANGE_EVENT_END='Completed handling of detected change'
+  local CHANGE_EVENT_END='Completed handling of detected change' # debug log
 
   function __change_event_status() {
     docker exec "${CONTAINER_NAME}" \

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -102,6 +102,16 @@ teardown_file() {
 }
 
 #
+# healthcheck
+#
+
+@test "checking container healthcheck" {
+  run bash -c "docker inspect mail | jq -r '.[].State.Health.Status'"
+  assert_output "healthy"
+  assert_success
+}
+
+#
 # processes
 #
 
@@ -958,16 +968,6 @@ EOF
   # check sender is not the default one.
   run docker exec mail grep "From: mailserver-report@mail.my-domain.com" /var/mail/localhost.localdomain/user1/new/ -R
   assert_failure
-}
-
-#
-# healthcheck
-#
-
-@test "checking container healthcheck" {
-  run bash -c "docker inspect mail | jq -r '.[].State.Health.Status'"
-  assert_output "healthy"
-  assert_success
 }
 
 #

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -10,6 +10,7 @@ setup_file() {
   PRIVATE_CONFIG=$(duplicate_config_for_container . mail)
   mv "${PRIVATE_CONFIG}/user-patches/user-patches.sh" "${PRIVATE_CONFIG}/user-patches.sh"
 
+  # `LOG_LEVEL=debug` required for using `wait_until_change_detection_event_completes()`
   docker run --rm -d --name mail \
     -v "${PRIVATE_CONFIG}":/tmp/docker-mailserver \
     -v "$(pwd)/test/test-files":/tmp/docker-mailserver-test:ro \
@@ -22,6 +23,7 @@ setup_file() {
     -e ENABLE_SPAMASSASSIN=1 \
     -e ENABLE_SRS=1 \
     -e ENABLE_UPDATE_CHECK=0 \
+    -e LOG_LEVEL='debug' \
     -e PERMIT_DOCKER=container \
     -e PERMIT_DOCKER=host \
     -e PFLOGSUMM_TRIGGER=logrotate \

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -641,7 +641,7 @@ EOF
 }
 
 @test "checking user updating password for user in /tmp/docker-mailserver/postfix-accounts.cf" {
-  docker exec mail /bin/sh -c "addmailuser user4@domain.tld mypassword"
+  add_mail_account_then_wait_until_ready mail 'user4@domain.tld'
 
   initialpass=$(docker exec mail /bin/sh -c "grep '^user4@domain\.tld' -i /tmp/docker-mailserver/postfix-accounts.cf")
   sleep 2
@@ -691,8 +691,7 @@ EOF
 
 
 @test "checking quota: setquota user must be existing" {
-  run docker exec mail /bin/sh -c "addmailuser quota_user@domain.tld mypassword"
-  assert_success
+  add_mail_account_then_wait_until_ready mail 'quota_user@domain.tld'
 
   run docker exec mail /bin/sh -c "setquota quota_user 50M"
   assert_failure
@@ -707,8 +706,7 @@ EOF
 }
 
 @test "checking quota: setquota <quota> must be well formatted" {
-  run docker exec mail /bin/sh -c "addmailuser quota_user@domain.tld mypassword"
-  assert_success
+  add_mail_account_then_wait_until_ready mail 'quota_user@domain.tld'
 
   run docker exec mail /bin/sh -c "setquota quota_user@domain.tld 26GIGOTS"
   assert_failure
@@ -737,8 +735,7 @@ EOF
 }
 
 @test "checking quota: delquota user must be existing" {
-  run docker exec mail /bin/sh -c "addmailuser quota_user@domain.tld mypassword"
-  assert_success
+  add_mail_account_then_wait_until_ready mail 'quota_user@domain.tld'
 
   run docker exec mail /bin/sh -c "delquota uota_user@domain.tld"
   assert_failure
@@ -759,8 +756,7 @@ EOF
 }
 
 @test "checking quota: delquota allow when no quota for existing user" {
-  run docker exec mail /bin/sh -c "addmailuser quota_user@domain.tld mypassword"
-  assert_success
+  add_mail_account_then_wait_until_ready mail 'quota_user@domain.tld'
 
   run docker exec mail /bin/sh -c "grep -i 'quota_user@domain.tld' /tmp/docker-mailserver/dovecot-quotas.cf"
   assert_failure
@@ -814,8 +810,7 @@ EOF
 }
 
 @test "checking quota: quota directive is removed when mailbox is removed" {
-  run docker exec mail /bin/sh -c "addmailuser quserremoved@domain.tld mypassword"
-  assert_success
+  add_mail_account_then_wait_until_ready mail 'quserremoved@domain.tld'
 
   run docker exec mail /bin/sh -c "setquota quserremoved@domain.tld 12M"
   assert_success
@@ -853,7 +848,8 @@ EOF
   skip 'disabled as it fails randomly: https://github.com/docker-mailserver/docker-mailserver/pull/2511'
 
   # create user
-  run docker exec mail /bin/sh -c "addmailuser quotauser@otherdomain.tld mypassword && setquota quotauser@otherdomain.tld 10k"
+  add_mail_account_then_wait_until_ready mail 'quotauser@otherdomain.tld'
+  run docker exec mail /bin/sh -c 'setquota quotauser@otherdomain.tld 10k'
   assert_success
 
   # wait until quota has been updated

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -105,6 +105,11 @@ teardown_file() {
 # healthcheck
 #
 
+# NOTE: Healthcheck defaults an interval of 30 seconds
+# If Postfix is temporarily down (eg: restart triggered by `check-for-changes.sh`),
+# it may result in a false-positive `unhealthy` state.
+# Be careful with re-locating this test if earlier tests could potentially fail it by
+# triggering the `changedetector` service.
 @test "checking container healthcheck" {
   run bash -c "docker inspect mail | jq -r '.[].State.Health.Status'"
   assert_output "healthy"

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -627,6 +627,8 @@ EOF
 }
 
 @test "checking accounts: user3 should have been removed from /tmp/docker-mailserver/postfix-accounts.cf but not auser3" {
+  wait_until_account_maildir_exists mail 'user3@domain.tld'
+
   docker exec mail /bin/sh -c "delmailuser -y user3@domain.tld"
 
   run docker exec mail /bin/sh -c "grep '^user3@domain\.tld' -i /tmp/docker-mailserver/postfix-accounts.cf"
@@ -703,6 +705,7 @@ EOF
   run docker exec mail /bin/sh -c "delmailuser -y quota_user@domain.tld"
   assert_success
 }
+
 @test "checking quota: setquota <quota> must be well formatted" {
   run docker exec mail /bin/sh -c "addmailuser quota_user@domain.tld mypassword"
   assert_success
@@ -733,7 +736,6 @@ EOF
   assert_success
 }
 
-
 @test "checking quota: delquota user must be existing" {
   run docker exec mail /bin/sh -c "addmailuser quota_user@domain.tld mypassword"
   assert_success
@@ -755,6 +757,7 @@ EOF
   run docker exec mail /bin/sh -c "delmailuser -y quota_user@domain.tld"
   assert_success
 }
+
 @test "checking quota: delquota allow when no quota for existing user" {
   run docker exec mail /bin/sh -c "addmailuser quota_user@domain.tld mypassword"
   assert_success


### PR DESCRIPTION
# Description

## Quick Summary

Resolves a `TODO` task with `addmailuser`.

## Overview

The main change is adding three new methods in `common.bash`, which replace the completion delay in `addmailuser` / `setup email add` command.

Other than that:

- I swapped `sh -c 'addmailuser ...'` to `setup email add ...`.
- Improved three tests in `setup-cli.bats` for `setup email add|update|del` (_logic remains effectively the same still_).
- Rewrote the `TODO` comment for `setup-cli.bats` test on `setup email del` to better clarify the concern, but the test itself was no longer affected due to changes prior to this PR, so I enabled the commented out assertion.
- Removed unnecessary waits. The two `skip` tests in `test/tests.bats` could be enabled again after this PR.

Commit messages provide additional details if helpful.

## Details

Presently when adding a user to `postfix-accounts.cf` with a running container, the `addmailuser` (_aka `setup email add`_) command will delay completion until the account has a directory in `/var/mail` (_which is created by the `changedetector` service during creation of the Dovecot user_).

AFAIK the delay was added primarily for our test suite and serves no other purpose. This PR migrates that delay logic into `common.bash` test helper methods, resolving the `TODO`.

### Future work

A future improvement might instead skip the `changedetector` service and add the Dovecot account directly.

Presently that is not an option as [that functionality](https://github.com/docker-mailserver/docker-mailserver/blob/0d5f550bdf22ab21bb7a852861221ae0b82264e1/target/scripts/helpers/accounts.sh#L12-L43) is wrapped in a loop and assumes a clean slate.

The upcoming Dovecot `mailcrypt` plugin feature does require `addmailuser` delaying until `/var/mail` account folder is available however. This PR will not help users of that feature until Dovecot accounts can be created directly without relying on `changedetector`.

---

### TODO addressed by this PR

Removed comment inline-docs `TODO` for reference (_and having Github link the PR to those issues if traceability is needed in future_)

> `TODO:` Remove this method or at least it's usage in `addmailuser`. If tests are failing, correct the tests.
> 
> This method was added to delay command completion until a change detection event had processed the newly added user,
> confirmed once maildir was created.
> It was a workaround to accommodate the test suite apparently, but otherwise
> prevents batch adding users (_each one would have to go through their own change detection event_).
> 
> Originally introduced in [PR 1980](https://github.com/docker-mailserver/docker-mailserver/pull/1980) (_afterwards two futher PRs deleted, and then reverted that deletion_):
> Not much details/discussion were in the PR, these are the specific commits:
> - [Initial commit](https://github.com/docker-mailserver/docker-mailserver/pull/1980/commits/2ed402a12cedd412abcf577e8079137ea05204fe#diff-92d2047e4a9a7965f6ef2f029dd781e09265b0ce171b5322a76e35b66ab4cbf4R67)
> - [Follow-up commit](https://github.com/docker-mailserver/docker-mailserver/pull/1980/commits/27542867b20c617b63bbec6fdcba421b65a44fbb#diff-92d2047e4a9a7965f6ef2f029dd781e09265b0ce171b5322a76e35b66ab4cbf4R67)
> 
> Original reasoning for this method (_sounds like a network storage I/O issue_):
> Tests fail if the creation of `/var/mail/${DOMAIN}/${USER}` doesn't happen fast enough after `addmailuser` executes (_`check-for-changes.sh` race-condition_)
> Prevent infinite loop in tests like: _"checking accounts: user3 should have been added to /tmp/docker-mailserver/postfix-accounts.cf even when that file does not exist"_

---

Fixes: https://github.com/docker-mailserver/docker-mailserver/issues/2096#issuecomment-885205611

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
