### PR TITLE
tests: Ensure excessive FD limits are avoided

### DIFF
--- a/test/mail_fail2ban.bats
+++ b/test/mail_fail2ban.bats
@@ -9,7 +9,10 @@ function setup_file() {
     -e ENABLE_FAIL2BAN=1 \
     -e POSTSCREEN_ACTION=ignore \
     --cap-add=NET_ADMIN \
-    -h mail.my-domain.com -t "${NAME}"
+    --hostname mail.my-domain.com \
+    --tty \
+    --ulimit 'nofile=1024:4096' \
+    "${NAME}"
 
   # Create a container which will send wrong authentications and should get banned
   docker run --name fail-auth-mailer \

--- a/test/mail_fail2ban.bats
+++ b/test/mail_fail2ban.bats
@@ -11,7 +11,7 @@ function setup_file() {
     --cap-add=NET_ADMIN \
     --hostname mail.my-domain.com \
     --tty \
-    --ulimit 'nofile=1024:4096' \
+    --ulimit "nofile=$(ulimit -Sn):$(ulimit -Hn)" \
     "${NAME}"
 
   # Create a container which will send wrong authentications and should get banned

--- a/test/mail_hostname.bats
+++ b/test/mail_hostname.bats
@@ -11,8 +11,10 @@ function setup_file() {
     -e PERMIT_DOCKER=network \
     -e ENABLE_SRS=1 \
     -e OVERRIDE_HOSTNAME=mail.my-domain.com \
-    -h unknown.domain.tld \
-    -t "${NAME}"
+    --hostname unknown.domain.tld \
+    --tty \
+    --ulimit 'nofile=1024:4096' \
+    "${NAME}"
 
   PRIVATE_CONFIG_TWO=$(duplicate_config_for_container . mail_non_subdomain_hostname)
   docker run --rm -d --name mail_non_subdomain_hostname \
@@ -21,7 +23,9 @@ function setup_file() {
     -e PERMIT_DOCKER=network \
     -e ENABLE_SRS=1 \
     --hostname domain.com \
-    -t "${NAME}"
+    --tty \
+    --ulimit 'nofile=1024:4096' \
+    "${NAME}"
 
   PRIVATE_CONFIG_THREE=$(duplicate_config_for_container . mail_srs_domainname)
   docker run --rm -d --name mail_srs_domainname \
@@ -32,7 +36,9 @@ function setup_file() {
     -e SRS_DOMAINNAME='srs.my-domain.com' \
     --domainname 'my-domain.com' \
     --hostname 'mail' \
-    -t "${NAME}"
+    --tty \
+    --ulimit 'nofile=1024:4096' \
+    "${NAME}"
 
   PRIVATE_CONFIG_FOUR=$(duplicate_config_for_container . mail_domainname)
   docker run --rm -d --name mail_domainname \
@@ -42,7 +48,9 @@ function setup_file() {
     -e ENABLE_SRS=1 \
     --domainname 'my-domain.com' \
     --hostname 'mail' \
-    -t "${NAME}"
+    --tty \
+    --ulimit 'nofile=1024:4096' \
+    "${NAME}"
 
   wait_for_smtp_port_in_container mail_override_hostname
   wait_for_smtp_port_in_container mail_non_subdomain_hostname

--- a/test/mail_hostname.bats
+++ b/test/mail_hostname.bats
@@ -13,7 +13,7 @@ function setup_file() {
     -e OVERRIDE_HOSTNAME=mail.my-domain.com \
     --hostname unknown.domain.tld \
     --tty \
-    --ulimit 'nofile=1024:4096' \
+    --ulimit "nofile=$(ulimit -Sn):$(ulimit -Hn)" \
     "${NAME}"
 
   PRIVATE_CONFIG_TWO=$(duplicate_config_for_container . mail_non_subdomain_hostname)
@@ -24,7 +24,7 @@ function setup_file() {
     -e ENABLE_SRS=1 \
     --hostname domain.com \
     --tty \
-    --ulimit 'nofile=1024:4096' \
+    --ulimit "nofile=$(ulimit -Sn):$(ulimit -Hn)" \
     "${NAME}"
 
   PRIVATE_CONFIG_THREE=$(duplicate_config_for_container . mail_srs_domainname)
@@ -37,7 +37,7 @@ function setup_file() {
     --domainname 'my-domain.com' \
     --hostname 'mail' \
     --tty \
-    --ulimit 'nofile=1024:4096' \
+    --ulimit "nofile=$(ulimit -Sn):$(ulimit -Hn)" \
     "${NAME}"
 
   PRIVATE_CONFIG_FOUR=$(duplicate_config_for_container . mail_domainname)
@@ -49,7 +49,7 @@ function setup_file() {
     --domainname 'my-domain.com' \
     --hostname 'mail' \
     --tty \
-    --ulimit 'nofile=1024:4096' \
+    --ulimit "nofile=$(ulimit -Sn):$(ulimit -Hn)" \
     "${NAME}"
 
   wait_for_smtp_port_in_container mail_override_hostname

--- a/test/mail_hostname.bats
+++ b/test/mail_hostname.bats
@@ -63,6 +63,10 @@ function setup_file() {
 }
 
 function teardown_file() {
+  # Running `docker rm -f` too soon after `docker stop` can result in failure during teardown with:
+  # "Error response from daemon: removal of container mail_domainname is already in progress"
+  sleep 1
+
   docker rm -f mail_override_hostname mail_non_subdomain_hostname mail_srs_domainname mail_domainname
 }
 

--- a/test/mail_undef_spam_subject.bats
+++ b/test/mail_undef_spam_subject.bats
@@ -9,10 +9,13 @@ function setup() {
     -v "$(pwd)/test/test-files":/tmp/docker-mailserver-test:ro \
     -e ENABLE_SPAMASSASSIN=1 \
     -e SA_SPAM_SUBJECT="undef" \
-    -h mail.my-domain.com -t "${NAME}"
+    --hostname mail.my-domain.com \
+    --tty \
+    "${NAME}"
 
-  PRIVATE_CONFIG=$(duplicate_config_for_container . mail_undef_spam_subject_2)
-  CONTAINER=$(docker run -d \
+  CONTAINER='mail_undef_spam_subject_2'
+  PRIVATE_CONFIG=$(duplicate_config_for_container . "${CONTAINER}")
+  docker run -d \
     -v "${PRIVATE_CONFIG}":/tmp/docker-mailserver \
     -v "$(pwd)/test/test-files":/tmp/docker-mailserver-test:ro \
     -v "$(pwd)/test/onedir":/var/mail-state \
@@ -30,7 +33,10 @@ function setup() {
     -e SASL_PASSWD="external-domain.com username:password" \
     -e ENABLE_MANAGESIEVE=1 \
     -e PERMIT_DOCKER=host \
-    -h mail.my-domain.com -t "${NAME}")
+    --hostname mail.my-domain.com \
+    --tty \
+    --ulimit 'nofile=1024:4096' \
+    "${NAME}"
 
   wait_for_finished_setup_in_container mail_undef_spam_subject
   wait_for_finished_setup_in_container "${CONTAINER}"

--- a/test/mail_undef_spam_subject.bats
+++ b/test/mail_undef_spam_subject.bats
@@ -35,7 +35,7 @@ function setup() {
     -e PERMIT_DOCKER=host \
     --hostname mail.my-domain.com \
     --tty \
-    --ulimit 'nofile=1024:4096' \
+    --ulimit "nofile=$(ulimit -Sn):$(ulimit -Hn)" \
     "${NAME}"
 
   wait_for_finished_setup_in_container mail_undef_spam_subject

--- a/test/mail_undef_spam_subject.bats
+++ b/test/mail_undef_spam_subject.bats
@@ -33,6 +33,7 @@ function setup() {
     -e SASL_PASSWD="external-domain.com username:password" \
     -e ENABLE_MANAGESIEVE=1 \
     -e PERMIT_DOCKER=host \
+    --name "${CONTAINER}" \
     --hostname mail.my-domain.com \
     --tty \
     --ulimit "nofile=$(ulimit -Sn):$(ulimit -Hn)" \

--- a/test/no_container.bats
+++ b/test/no_container.bats
@@ -1,6 +1,12 @@
-load 'test_helper/bats-support/load'
-load 'test_helper/bats-assert/load'
 load 'test_helper/common'
+
+function setup_file() {
+  # Fail early if the test image is already running:
+  assert_not_equal "$(docker ps | grep -o "${NAME}")" "${NAME}"
+  # Test may fail if an existing DMS container is running,
+  # Which can occur from a prior test failing before reaching `no_container.bats`
+  # and that failure not properly handling teardown.
+}
 
 @test "[No Existing Container] checking setup.sh: setup.sh alias list" {
   mkdir -p ./test/alias/config && echo "test@example.org test@forward.com" > ./test/alias/config/postfix-virtual.cf

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -35,8 +35,9 @@ setup_file() {
     -e SPOOF_PROTECTION=1 \
     -e SSL_TYPE='snakeoil' \
     -e VIRUSMAILS_DELETE_DELAY=7 \
-    -h mail.my-domain.com \
+    --hostname mail.my-domain.com \
     --tty \
+    --ulimit 'nofile=1024:4096' \
     --health-cmd "ss --listening --tcp | grep -P 'LISTEN.+:smtp' || exit 1" \
     "${NAME}"
 

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -37,7 +37,7 @@ setup_file() {
     -e VIRUSMAILS_DELETE_DELAY=7 \
     --hostname mail.my-domain.com \
     --tty \
-    --ulimit 'nofile=1024:4096' \
+    --ulimit "nofile=$(ulimit -Sn):$(ulimit -Hn)" \
     --health-cmd "ss --listening --tcp | grep -P 'LISTEN.+:smtp' || exit 1" \
     "${NAME}"
 

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1,5 +1,3 @@
-load 'test_helper/bats-support/load'
-load 'test_helper/bats-assert/load'
 load 'test_helper/common'
 
 export IMAGE_NAME


### PR DESCRIPTION
# Description

Local tests can fail depending on environment if Docker is configured with an excessive FD limit.

This was affecting tests using `ENABLE_SRS=1` and `ENABLE_FAIL2BAN=1` due to a common step for daemonization taking considerably longer to complete (8 minutes on Fedora 36), causing the tests to fail due to timeout or unreachable service.

I have chosen kernel defaults (1024 soft, 4096 hard), as opposed to systemd (1024, 512K) which should be fine for tests. The limit is for how many files/streams a process can have open at one time. A process can request to raise the soft limit so long as it's below the hard limit.

I avoided documentation as I don't expect this to be a common issue users would face in real deployments. If an issue is raised about high CPU usage or similar odd activity to troubleshoot, it may be due to this, and if so warrant documenting for users. Otherwise I only expect it to affect contributors running tests locally.

### Additional Details

Processes that run as daemons (`postsrsd` and `fail2ban-server`) initialize by closing all FDs (File Descriptors).

This behaviour queries that maximum limit and iterates through the entire range even if only a few FDs are open. In some environments (_Docker, limit configured varies by distro_) this can be a range exceeding 1 billion (_from kernel default of 1024 soft, 4096 hard_), causing an 8 minute delay with heavy CPU activity.

`postsrsd` has since been updated to use `close_range()` syscall, and `fail2ban` will now iterate through `/proc/self/fd` (open FDs) which should resolve the performance hit. Until those updates reach our Docker image, we need to workaround it with `--ulimit` option.

NOTE: The CI does not seem affected, but it can affect local development when running tests causing failures. If `docker.service` on a distro sets `LimitNOFILE=` to approx 1 million or lower, it should not be an issue. On distros such as Fedora 36, it is `LimitNOFILE=infinity` (approx 1 billion) that causes excessive delays.

When `close_range()` syscall is available, at least in Python, this requires kernel 5.9+ and `glibc` >= 2.34, the performance hit is avoided. On Debian 11 and Alpine Linux 3.16, neither container meets the `glibc` requirement (_Debian 11 package is too old, Alpine uses `musl` and has no equivalent support_), whilst Fedora 36 container has `glibc` 2.35 (_[performance improvement demonstrated](https://github.com/docker-mailserver/docker-mailserver/issues/2722#issuecomment-1219104993)_). Thus this PR can likely be reverted once the next Debian release in 2023 occurs.

---

Fixes: #2722

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
