### PR TITLE
ci: Better build caching for CI

### DIFF
--- a/.github/workflows/test_merge_requests.yml
+++ b/.github/workflows/test_merge_requests.yml
@@ -81,7 +81,9 @@ jobs:
       - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@v2.0.0
 
-      # NOTE: ARM platforms removed as exporting the tar image output does not support multi-platform:
+      # NOTE: AMD64 can build within 2 minutes, ARM adds 13 minutes. 330MB each
+      # ARMv7 can build in parallel, adding no extra time (but does add 150MB cache size).
+      # Moving ARM build to a separate job would cut down time to start running tests.
       - name: 'Build images'
         uses: docker/build-push-action@v3.1.1
         with:
@@ -90,16 +92,16 @@ jobs:
             VCS_REF=${{ github.sha }}
             VCS_VER=${{ github.ref }}
           tags: mailserver-testing:ci
-          # Build for AMD64 (runs against test suite) and ARM64 (we only test a successful build):
-          platforms: linux/amd64
+          # Build for AMD64 (runs against test suite) and ARM64 (only to verify building works):
+          platforms: linux/amd64,linux/arm64
           # Paired with steps `actions/cache` and `Replace cache` (replace src with dest):
           # NOTE: `mode=max` is only for `cache-to`, it configures exporting all image layers.
           # https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#cache-from
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-          # Export AMD64 image for upload-artifact step, allowing other jobs to use it:
-          # https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#docker
-          outputs: type=docker,dest=/tmp/dms-docker-img.tar
+          # This job just builds the image and stores to cache, no other exporting required:
+          # https://github.com/docker/build-push-action/issues/546#issuecomment-1122631106
+          outputs: type=cacheonly
 
       # WORKAROUND: The `cache-to: type=local` input for `build-push-action` persists old-unused cache.
       # The workaround is to write the new build cache to a different location that replaces the
@@ -110,15 +112,6 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-     - name: 'Upload DMS Docker Image for job transfer'
-       uses: actions/upload-artifact@v3
-       with:
-         name: dms-build-${{ steps.derive-image-cache-key.outputs.digest }}
-         path: /tmp/dms-docker-img.tar
-          # Artifact limits are unclear for open-source projects,
-          # Each image is roughly 500MB+ (330MB on CI), if necessary reduce retention period:
-          #retention-days: 1
 
   job-run-tests:
     name: 'Run Test Suite'
@@ -131,15 +124,31 @@ jobs:
           # Required to retrieve bats (core + extras):
           submodules: recursive
 
-      - name: 'Retrieve DMS test image'
-        uses: actions/download-artifact@v3
+      # Get the cached build layers from the build job:
+      # This should always be a cache-hit, no new uploads should happen when this job finishes:
+      - name: 'Retrieve image build from build cache'
+        uses: actions/cache@v3
         with:
-          name: dms-build-${{ needs.job-build-image.outputs.image-build-key }}
-          path: /tmp
+          path: /tmp/.buildx-cache
+          key: cache-buildx-${{ needs.job-build-image.outputs.image-build-key }}
+          restore-keys: |
+            cache-buildx-
 
-      - name: 'Import retrieved image'
-        run: |
-          docker load --input /tmp/dms-docker-img.tar
+      # Importing from the cache should create the image within approx 30 seconds:
+      # buildx not needed as no exporting and only single AMD64 platform is loaded:
+      - name: 'Build AMD64 image from cache'
+        uses: docker/build-push-action@v3.1.1
+        with:
+          context: .
+          build-args: |
+            VCS_REF=${{ github.sha }}
+            VCS_VER=${{ github.ref }}
+          tags: mailserver-testing:ci
+          # Export the built image for the Docker host to use:
+          load: true
+          # Rebuilds the AMD64 image from the cache:
+          platforms: linux/amd64
+          cache-from: type=local,src=/tmp/.buildx-cache
 
       - name: 'Run tests'
         env:

--- a/.github/workflows/test_merge_requests.yml
+++ b/.github/workflows/test_merge_requests.yml
@@ -14,60 +14,136 @@ on:
 permissions:
   contents: read
 
+# `actions/cache` does not upload a new cache until completing a job successfully.
+# To better cache image builds, tests are handled in a dependent job afterwards.
+# This way failing tests will not prevent caching of an image. Useful when the build context
+# is not changed by new commits.
 jobs:
-  build-and-test:
+  job-build-image:
     runs-on: ubuntu-20.04
+    outputs:
+      image-build-key: ${{ steps.derive-image-cache-key.outputs.digest }}
     steps:
-      - name: Checkout
+      - name: 'Checkout'
         uses: actions/checkout@v3
         with:
+          # Required for image to include `configomat.sh`:
           submodules: recursive
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.0.0
+      # Can potentially be replaced by: `${{ hashFiles('target/**', 'Dockerfile', 'VERSION') }}`
+      # Must not be affected by file metadata changes and have a consistent sort order:
+      # https://docs.github.com/en/actions/learn-github-actions/expressions#hashfiles
+      # Keying by the relevant build context is more re-usable than a commit SHA.
+      - name: 'Derive Docker image cache key from content'
+        id: derive-image-cache-key
+        shell: bash
+        run: |
+          ADDITIONAL_FILES=(
+            'Dockerfile'
+            'VERSION'
+          )
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.0.0
-        id: buildx
+          # Recursively collect file paths from `target/` and pipe a list of
+          # checksums to be sorted (by hash value) and finally generate a checksum
+          # of that list, using `awk` to only return the hash value (digest):
+          IMAGE_CHECKSUM=$(\
+            find ./target -type f -exec sha256sum "${ADDITIONAL_FILES[@]}" {} + \
+              | sort \
+              | sha256sum \
+              | awk '{ print $1 }' \
+          )
 
-      - name: Cache Docker layers
+          echo "::set-output name=digest::${IMAGE_CHECKSUM}"
+
+      # Attempts to restore the build cache from a prior build run.
+      # If the exact key is not restored, then upon a successful job run
+      # the new cache is uploaded for this key containing the contents at `path`.
+      # Cache storage has a limit of 10GB, and uploads expire after 7 days.
+      # When full, the least accessed cache upload is evicted to free up storage.
+      # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
+      - name: 'Handle Docker build layer cache'
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: cache-buildx-${{ steps.derive-image-cache-key.outputs.digest }}
+          # If no exact cache-hit for key found, lookup caches with a `cache-buildx-` key prefix:
+          # This is safe due to cache layer invalidation via the image build context.
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            cache-buildx-
 
-      - name: Build images locally
+      # Support ARM64 builds on AMD64 host:
+      - name: 'Set up QEMU'
+        uses: docker/setup-qemu-action@v2.0.0
+        with:
+          platforms: arm64
+
+      # Enables `buildx` support within `build-push-action`, improving cache and platform support:
+      - name: 'Set up Docker Buildx'
+        uses: docker/setup-buildx-action@v2.0.0
+
+      # NOTE: ARM platforms removed as exporting the tar image output does not support multi-platform:
+      - name: 'Build images'
         uses: docker/build-push-action@v3.1.1
         with:
-          builder: ${{ steps.buildx.outputs.name }}
           context: .
-          file: ./Dockerfile
           build-args: |
             VCS_REF=${{ github.sha }}
             VCS_VER=${{ github.ref }}
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
           tags: mailserver-testing:ci
-          cache-to: type=local,dest=/tmp/.buildx-cache
-
-      - name: Build image for test suit
-        uses: docker/build-push-action@v3.1.1
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: .
-          file: ./Dockerfile
-          build-args: |
-            VCS_REF=${{ github.sha }}
-            VCS_VER=${{ github.ref }}
+          # Build for AMD64 (runs against test suite) and ARM64 (we only test a successful build):
           platforms: linux/amd64
-          load: true
-          tags: mailserver-testing:ci
+          # Paired with steps `actions/cache` and `Replace cache` (replace src with dest):
+          # NOTE: `mode=max` is only for `cache-to`, it configures exporting all image layers.
+          # https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#cache-from
           cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          # Export AMD64 image for upload-artifact step, allowing other jobs to use it:
+          # https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#docker
+          outputs: type=docker,dest=/tmp/dms-docker-img.tar
 
-      - name: Run test suite
-        run: >
-          NAME=mailserver-testing:ci
-          bash -c 'make generate-accounts tests'
+      # WORKAROUND: The `cache-to: type=local` input for `build-push-action` persists old-unused cache.
+      # The workaround is to write the new build cache to a different location that replaces the
+      # original restored cache after build, reducing frequency of eviction due to cache storage limit (10GB).
+      # https://github.com/docker/build-push-action/blob/965c6a410d446a30e95d35052c67d6eded60dad6/docs/advanced/cache.md?plain=1#L193-L199
+      # NOTE: This does not affect `cache-hit == 'true'` (which skips upload on direct cache key hit)
+      - name: 'Replace cache'
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+     - name: 'Upload DMS Docker Image for job transfer'
+       uses: actions/upload-artifact@v3
+       with:
+         name: dms-build-${{ steps.derive-image-cache-key.outputs.digest }}
+         path: /tmp/dms-docker-img.tar
+          # Artifact limits are unclear for open-source projects,
+          # Each image is roughly 500MB+ (330MB on CI), if necessary reduce retention period:
+          #retention-days: 1
+
+  job-run-tests:
+    name: 'Run Test Suite'
+    needs: job-build-image
+    runs-on: ubuntu-20.04
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+        with:
+          # Required to retrieve bats (core + extras):
+          submodules: recursive
+
+      - name: 'Retrieve DMS test image'
+        uses: actions/download-artifact@v3
+        with:
+          name: dms-build-${{ needs.job-build-image.outputs.image-build-key }}
+          path: /tmp
+
+      - name: 'Import retrieved image'
+        run: |
+          docker load --input /tmp/dms-docker-img.tar
+
+      - name: 'Run tests'
         env:
           CI: true
+        run: |
+          NAME=mailserver-testing:ci
+          make generate-accounts tests


### PR DESCRIPTION
# Description

Fixing flaws to make the tests workflow and Dockerfile more cache friendly.

## Change Overview

In Sep 2019, a PR introduced the VCS `ARG` directives with [acknowledgement that it invalidates the build cache](https://github.com/docker-mailserver/docker-mailserver/pull/1256#issuecomment-529406724).

Every time the commit SHA changes, due to this placement all layers afterwards are invalidated and must be rebuilt, even though only `LABEL` directive values were being updated (_even without those, `RUN` will implicitly be invalidated due to `ARG` changing as it is cached as part of the build ENV_).

I've shifted all directives related to image config that aren't necessary until the end to a 2nd stage. The additional `FROM` introducing a 2nd stage is not necessary, but provides a basis for later refactoring the Dockerfile to split out ClamAV and Fail2Ban layers into their own stages to further improve build caching.

The original intent of this PR was to address the caching with a more stable cache key (_instead of the commit SHA_), such that if the build context (_files involved in the image build process_) has not changed since the last build, that we can re-use the build cache for that.

---

**Presently the existing cache key would:**
- Only be valid when running tests for the same commit again, but that is rarely helpful if tests failed as it prevents uploading the cache (_cache upload happens at end of workflow job if successful only_).
- Would needlessly upload cache (_new key per push if job successful, even if the image didn't really change_) if a PR only contributes tests wasting cache storage (_10GB storage limit, less frequently used cache is evicted first_)

**The new cache key:**
- Is valid when `Dockerfile`, `VERSION` and `target/**` has not changed between commits.
- Uploads cache even when tests fail (_due to cache eviction policy and open-source plan this is fine provided cache upload is not excessive_), but only when there was no direct cache `key` hit (_`restore-key` fallback to an older build cache, reducing build time and upon job success uploading for the new derived cache key_).

**Complimentary changes:**
- The `type=local` cache mode needs a [workaround](https://github.com/docker/build-push-action/blob/965c6a410d446a30e95d35052c67d6eded60dad6/docs/advanced/cache.md?plain=1#L193-L199) to avoid accidentally accumulating cache wastefully which adds to upload/download time and more evictions (_330-810MB + 7-20 sec depending on supported platforms, vs **2-3GB I've seen presently cached** with download times of approx 1 minute_).
  - A new `type=gha` cache mode has since been made available (still deemed experimental) earlier this year that uses the `actions/cache` API (_reverse engineered IIRC, not officially supported_), I've chosen to avoid that for now and have not had time to try and compare it.
- Fixing the `Dockerfile` issue with `ARG` usage is an important one, as while the derived cache key can be effective at caching, when the commit SHA changed, the cache was completely ignored due to the builder invalidating cache... which caused a problem as that cache hit would not upload the new build cache (_build args passed in aren't part of the derived cache key_). Although the built image will still be slightly different due to these `ARG`, we are only sharing the build layer cache between jobs, so there is minimal work to recreate the image from cache and append the `ARG` changes (_avoiding wasteful cache upload for `ARG` changes_).
- Workflow is better documented. Removed unnecessary inputs like default `Dockerfile` and buildx `builder` instance.

**Impact of platforms on cache storage + build time:**
- I also checked the build cache for each platform, approx 330MB per platform, but the two ARM platforms seem to be capable of sharing a bit as when they're both included with AMD64, the total size is 810MB (_655MB with AMD64 and ARM64 only_).
- The ARM builds turned out to **introduce 13 mins to build time** and work in parallel (_no worthwhile speed improvement with only ARM64_), thus deprecating ARMv7 won't provide CI improvements (_except reducing cache storage_).
- AMD64 alone seems warranted as it can be **built within 2 minutes without cache** (_30 seconds with cache_). It might make sense to run ARM64 as a separate job in parallel (_or if available a native ARM64 runner_), or as a dependent job after the more important ARM64 build and test.

---

## Additional details

In the first commit, I also experimented with `upload-artifact` and `download-artifact` to transfer across jobs but this was much worse than just using `actions/cache`.

Future improvements could leverage buildx `COPY --link` feature that is available since March 2022. `type=gha` for the image cache might be interesting too if it caches on step success instead of job success, allowing for tests to be in the same job. Similar workflows could also potentially be more DRY with Github Actions support for re-usable workflows.

For now though, this PR should help, especially if a follow-up moves out the ARM64 build.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
