### PR TITLE
Remove unnecessary postconf switch '-e' and use single quotes where possible

### DIFF
--- a/target/scripts/helpers/relay.sh
+++ b/target/scripts/helpers/relay.sh
@@ -189,10 +189,10 @@ function _populate_relayhost_map
 
 function _relayhost_configure_postfix
 {
-  postconf -e \
-    "smtp_sasl_auth_enable = yes" \
-    "smtp_sasl_security_options = noanonymous" \
-    "smtp_tls_security_level = encrypt"
+  postconf  \
+    'smtp_sasl_auth_enable = yes' \
+    'smtp_sasl_security_options = noanonymous' \
+    'smtp_tls_security_level = encrypt'
 }
 
 function _setup_relayhost
@@ -202,7 +202,7 @@ function _setup_relayhost
   if [[ -n ${DEFAULT_RELAY_HOST} ]]
   then
     _log 'trace' "Setting default relay host ${DEFAULT_RELAY_HOST} to /etc/postfix/main.cf"
-    postconf -e "relayhost = ${DEFAULT_RELAY_HOST}"
+    postconf "relayhost = ${DEFAULT_RELAY_HOST}"
   fi
 
   if [[ -n ${RELAY_HOST} ]]

--- a/target/scripts/helpers/relay.sh
+++ b/target/scripts/helpers/relay.sh
@@ -189,7 +189,7 @@ function _populate_relayhost_map
 
 function _relayhost_configure_postfix
 {
-  postconf  \
+  postconf \
     'smtp_sasl_auth_enable = yes' \
     'smtp_sasl_security_options = noanonymous' \
     'smtp_tls_security_level = encrypt'

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -96,8 +96,8 @@ function _setup_dmarc_hostname
 function _setup_postfix_hostname
 {
   _log 'debug' 'Applying hostname and domainname to Postfix'
-  postconf -e "myhostname = ${HOSTNAME}"
-  postconf -e "mydomain = ${DOMAINNAME}"
+  postconf "myhostname = ${HOSTNAME}"
+  postconf "mydomain = ${DOMAINNAME}"
 }
 
 function _setup_dovecot_hostname
@@ -359,21 +359,21 @@ function _setup_ldap
 
   if [[ -f /etc/postfix/ldap-users.cf ]]
   then
-    postconf -e 'virtual_mailbox_maps = ldap:/etc/postfix/ldap-users.cf'
+    postconf 'virtual_mailbox_maps = ldap:/etc/postfix/ldap-users.cf'
   else
     _log 'warn' "'/etc/postfix/ldap-users.cf' not found"
   fi
 
   if [[ -f /etc/postfix/ldap-domains.cf ]]
   then
-    postconf -e 'virtual_mailbox_domains = /etc/postfix/vhost, ldap:/etc/postfix/ldap-domains.cf'
+    postconf 'virtual_mailbox_domains = /etc/postfix/vhost, ldap:/etc/postfix/ldap-domains.cf'
   else
     _log 'warn' "'/etc/postfix/ldap-domains.cf' not found"
   fi
 
   if [[ -f /etc/postfix/ldap-aliases.cf ]] && [[ -f /etc/postfix/ldap-groups.cf ]]
   then
-    postconf -e 'virtual_alias_maps = ldap:/etc/postfix/ldap-aliases.cf, ldap:/etc/postfix/ldap-groups.cf'
+    postconf 'virtual_alias_maps = ldap:/etc/postfix/ldap-aliases.cf, ldap:/etc/postfix/ldap-groups.cf'
   else
     _log 'warn' "'/etc/postfix/ldap-aliases.cf' and / or '/etc/postfix/ldap-groups.cf' not found"
   fi
@@ -431,13 +431,13 @@ function _setup_postfix_postscreen
 function _setup_postfix_sizelimits
 {
   _log 'trace' "Configuring Postfix message size limit to '${POSTFIX_MESSAGE_SIZE_LIMIT}'"
-  postconf -e "message_size_limit = ${POSTFIX_MESSAGE_SIZE_LIMIT}"
+  postconf "message_size_limit = ${POSTFIX_MESSAGE_SIZE_LIMIT}"
 
   _log 'trace' "Configuring Postfix mailbox size limit to '${POSTFIX_MAILBOX_SIZE_LIMIT}'"
-  postconf -e "mailbox_size_limit = ${POSTFIX_MAILBOX_SIZE_LIMIT}"
+  postconf "mailbox_size_limit = ${POSTFIX_MAILBOX_SIZE_LIMIT}"
 
   _log 'trace' "Configuring Postfix virtual mailbox size limit to '${POSTFIX_MAILBOX_SIZE_LIMIT}'"
-  postconf -e "virtual_mailbox_limit = ${POSTFIX_MAILBOX_SIZE_LIMIT}"
+  postconf "virtual_mailbox_limit = ${POSTFIX_MAILBOX_SIZE_LIMIT}"
 }
 
 function _setup_clamav_sizelimit
@@ -449,7 +449,7 @@ function _setup_clamav_sizelimit
 function _setup_postfix_smtputf8
 {
   _log 'trace' "Disabling Postfix's smtputf8 support"
-  postconf -e "smtputf8_enable = no"
+  postconf 'smtputf8_enable = no'
 }
 
 function _setup_spoof_protection
@@ -463,16 +463,16 @@ function _setup_spoof_protection
   then
     if [[ -z ${LDAP_QUERY_FILTER_SENDERS} ]]
     then
-      postconf -e 'smtpd_sender_login_maps = ldap:/etc/postfix/ldap-users.cf ldap:/etc/postfix/ldap-aliases.cf ldap:/etc/postfix/ldap-groups.cf'
+      postconf 'smtpd_sender_login_maps = ldap:/etc/postfix/ldap-users.cf ldap:/etc/postfix/ldap-aliases.cf ldap:/etc/postfix/ldap-groups.cf'
     else
-      postconf -e 'smtpd_sender_login_maps = ldap:/etc/postfix/ldap-senders.cf'
+      postconf 'smtpd_sender_login_maps = ldap:/etc/postfix/ldap-senders.cf'
     fi
   else
     if [[ -f /etc/postfix/regexp ]]
     then
-      postconf -e 'smtpd_sender_login_maps = unionmap:{ texthash:/etc/postfix/virtual, hash:/etc/aliases, pcre:/etc/postfix/maps/sender_login_maps.pcre, pcre:/etc/postfix/regexp }'
+      postconf 'smtpd_sender_login_maps = unionmap:{ texthash:/etc/postfix/virtual, hash:/etc/aliases, pcre:/etc/postfix/maps/sender_login_maps.pcre, pcre:/etc/postfix/regexp }'
     else
-      postconf -e 'smtpd_sender_login_maps = texthash:/etc/postfix/virtual, hash:/etc/aliases, pcre:/etc/postfix/maps/sender_login_maps.pcre'
+      postconf 'smtpd_sender_login_maps = texthash:/etc/postfix/virtual, hash:/etc/aliases, pcre:/etc/postfix/maps/sender_login_maps.pcre'
     fi
   fi
 }
@@ -567,10 +567,10 @@ function _setup_SRS
 {
   _log 'debug' 'Setting up SRS'
 
-  postconf -e 'sender_canonical_maps = tcp:localhost:10001'
-  postconf -e "sender_canonical_classes = ${SRS_SENDER_CLASSES}"
-  postconf -e 'recipient_canonical_maps = tcp:localhost:10002'
-  postconf -e 'recipient_canonical_classes = envelope_recipient,header_recipient'
+  postconf 'sender_canonical_maps = tcp:localhost:10001'
+  postconf "sender_canonical_classes = ${SRS_SENDER_CLASSES}"
+  postconf 'recipient_canonical_maps = tcp:localhost:10002'
+  postconf 'recipient_canonical_classes = envelope_recipient,header_recipient'
 }
 
 function _setup_dkim
@@ -612,7 +612,7 @@ function _setup_postfix_vhost
 function _setup_postfix_inet_protocols
 {
   _log 'trace' 'Setting up POSTFIX_INET_PROTOCOLS option'
-  postconf -e "inet_protocols = ${POSTFIX_INET_PROTOCOLS}"
+  postconf "inet_protocols = ${POSTFIX_INET_PROTOCOLS}"
 }
 
 function _setup_dovecot_inet_protocols
@@ -663,7 +663,7 @@ function _setup_docker_permit
   case "${PERMIT_DOCKER}" in
     ( 'none' )
       _log 'trace' "Clearing Postfix's 'mynetworks'"
-      postconf -e "mynetworks ="
+      postconf "mynetworks ="
       ;;
 
     ( 'connected-networks' )
@@ -671,7 +671,7 @@ function _setup_docker_permit
       do
         NETWORK=$(_sanitize_ipv4_to_subnet_cidr "${NETWORK}")
         _log 'trace' "Adding Docker network '${NETWORK}' to Postfix's 'mynetworks'"
-        postconf -e "$(postconf | grep '^mynetworks =') ${NETWORK}"
+        postconf "$(postconf | grep '^mynetworks =') ${NETWORK}"
         echo "${NETWORK}" >> /etc/opendmarc/ignore.hosts
         echo "${NETWORK}" >> /etc/opendkim/TrustedHosts
       done
@@ -679,21 +679,21 @@ function _setup_docker_permit
 
     ( 'container' )
       _log 'trace' "Adding container IP address to Postfix's 'mynetworks'"
-      postconf -e "$(postconf | grep '^mynetworks =') ${CONTAINER_IP}/32"
+      postconf "$(postconf | grep '^mynetworks =') ${CONTAINER_IP}/32"
       echo "${CONTAINER_IP}/32" >> /etc/opendmarc/ignore.hosts
       echo "${CONTAINER_IP}/32" >> /etc/opendkim/TrustedHosts
       ;;
 
     ( 'host' )
       _log 'trace' "Adding '${CONTAINER_NETWORK}/16' to Postfix's 'mynetworks'"
-      postconf -e "$(postconf | grep '^mynetworks =') ${CONTAINER_NETWORK}/16"
+      postconf "$(postconf | grep '^mynetworks =') ${CONTAINER_NETWORK}/16"
       echo "${CONTAINER_NETWORK}/16" >> /etc/opendmarc/ignore.hosts
       echo "${CONTAINER_NETWORK}/16" >> /etc/opendkim/TrustedHosts
       ;;
 
     ( 'network' )
       _log 'trace' "Adding Docker network to Postfix's 'mynetworks'"
-      postconf -e "$(postconf | grep '^mynetworks =') 172.16.0.0/12"
+      postconf "$(postconf | grep '^mynetworks =') 172.16.0.0/12"
       echo 172.16.0.0/12 >> /etc/opendmarc/ignore.hosts
       echo 172.16.0.0/12 >> /etc/opendkim/TrustedHosts
       ;;
@@ -701,7 +701,7 @@ function _setup_docker_permit
     ( * )
       _log 'warn' "Invalid value for PERMIT_DOCKER: '${PERMIT_DOCKER}'"
       _log 'warn' "Clearing Postfix's 'mynetworks'"
-      postconf -e "mynetworks ="
+      postconf "mynetworks ="
       ;;
 
   esac
@@ -718,7 +718,7 @@ function _setup_postfix_virtual_transport
     return 1
   fi
 
-  postconf -e "virtual_transport = ${POSTFIX_DAGENT}"
+  postconf "virtual_transport = ${POSTFIX_DAGENT}"
 }
 
 function _setup_postfix_override_configuration
@@ -1077,8 +1077,8 @@ function _setup_dnsbl_disable
     /etc/postfix/main.cf
 
   _log 'debug' 'Disabling postscreen DNS block lists'
-  postconf -e "postscreen_dnsbl_action = ignore"
-  postconf -e "postscreen_dnsbl_sites = "
+  postconf 'postscreen_dnsbl_action = ignore'
+  postconf 'postscreen_dnsbl_sites = '
 }
 
 function _setup_fetchmail

--- a/test/mail_smtponly.bats
+++ b/test/mail_smtponly.bats
@@ -47,7 +47,7 @@ function teardown_file() {
 #
 
 @test "checking smtp_only: mail send should work" {
-  run docker exec mail_smtponly /bin/sh -c "postconf -e smtp_host_lookup=no"
+  run docker exec mail_smtponly /bin/sh -c "postconf smtp_host_lookup=no"
   assert_success
   run docker exec mail_smtponly /bin/sh -c "/etc/init.d/postfix reload"
   assert_success

--- a/test/permit_docker.bats
+++ b/test/permit_docker.bats
@@ -62,7 +62,7 @@ teardown_file() {
   assert_output --partial "${IPNET1}"
   assert_output --partial "${IPNET2}"
 
-  run docker exec mail_smtponly_second_network /bin/sh -c "postconf -e smtp_host_lookup=no"
+  run docker exec mail_smtponly_second_network /bin/sh -c "postconf smtp_host_lookup=no"
   assert_success
 
   run docker exec mail_smtponly_second_network /bin/sh -c "/etc/init.d/postfix reload"
@@ -76,7 +76,7 @@ teardown_file() {
 }
 
 @test "checking PERMIT_DOCKER: none" {
-  run docker exec mail_smtponly_force_authentication /bin/sh -c "postconf -e smtp_host_lookup=no"
+  run docker exec mail_smtponly_force_authentication /bin/sh -c "postconf smtp_host_lookup=no"
   assert_success
 
   run docker exec mail_smtponly_force_authentication /bin/sh -c "/etc/init.d/postfix reload"


### PR DESCRIPTION
# Description

This PR streamlines the `postconf` usage to not use the `-e` option, as it's the default since Postfix version >=2.8

From the man page: `The -e option is no longer needed with Postfix version 2.8 and later.`

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
