### PR TITLE
ci: improve GitHub Action CI with re-usable workflows

### DIFF
--- a/.github/workflows/default_on_push.yml
+++ b/.github/workflows/default_on_push.yml
@@ -1,4 +1,4 @@
-name: Build, Test & Deploy
+name: 'Build, Test & Deploy'
 
 on:
   workflow_dispatch:
@@ -20,18 +20,18 @@ permissions:
 
 jobs:
   build-image:
-    name: Build AMD64 Image
+    name: 'Build AMD64 Image'
     uses: ./.github/workflows/generic_build.yml
 
   run-tests:
-    name: Test AMD64 Image
+    name: 'Test AMD64 Image'
     needs: build-image
     uses: ./.github/workflows/generic_test.yml
     with:
       cache-key: ${{ needs.build-image.outputs.build-cache-key }}
 
   publish-images:
-    name: Publish AMD64 and ARM64 Image
+    name: 'Publish AMD64 and ARM64 Image'
     needs: [build-image, run-tests]
     uses: ./.github/workflows/generic_publish.yml
     with:

--- a/.github/workflows/default_on_push.yml
+++ b/.github/workflows/default_on_push.yml
@@ -22,36 +22,22 @@ jobs:
   build-and-test-image:
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Prepare tags
+        id: prep
+        uses: docker/metadata-action@v4.0.1
         with:
-          submodules: recursive
+          images: |
+            ${{ secrets.DOCKER_REPOSITORY }}
+            ${{ secrets.GHCR_REPOSITORY }}
+          tags: |
+            type=raw,value=edge
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.0.0
-        id: buildx
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
+      - name: Build image
+        uses: ./github/workflows/generic_build.yml
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Build image locally
-        uses: docker/build-push-action@v3.1.1
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: .
-          file: ./Dockerfile
-          build-args: |
-            VCS_REF=${{ github.sha }}
-            VCS_VER=${{ github.ref }}
           platforms: linux/amd64
-          load: true
-          tags: mailserver-testing:ci
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          publish: false
+          cache-layers-to: true
 
       - name: Run test suite
         run: >
@@ -64,12 +50,6 @@ jobs:
     needs: build-and-test-image
     runs-on: ubuntu-20.04
     steps:
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
       - name: Prepare tags
         id: prep
         uses: docker/metadata-action@v4.0.1
@@ -85,44 +65,9 @@ jobs:
           flavor: |
             latest=auto
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.0.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.0.0
-        id: buildx
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
+      - name: Build image
+        uses: ./github/workflows/generic_build.yml
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2.0.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2.0.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build images locally
-        uses: docker/build-push-action@v3.1.1
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: .
-          file: ./Dockerfile
-          build-args: |
-            VCS_REF=${{ github.sha }}
-            VCS_VER=${{ github.ref }}
           platforms: linux/amd64,linux/arm/v7,linux/arm64
-          push: true
-          tags: ${{ steps.prep.outputs.tags }}
-          cache-from: type=local,src=/tmp/.buildx-cache
+          publish: true
+          cache-layers-from: true

--- a/.github/workflows/default_on_push.yml
+++ b/.github/workflows/default_on_push.yml
@@ -5,14 +5,14 @@ on:
   push:
     branches:
       - master
-    # paths:
-    #   - target/**
-    #   - .dockerignore
-    #   - .gitmodules
-    #   - Dockerfile
-    #   - setup.sh
-    # tags:
-    #   - '*.*.*'
+    paths:
+      - target/**
+      - .dockerignore
+      - .gitmodules
+      - Dockerfile
+      - setup.sh
+    tags:
+      - '*.*.*'
 
 permissions:
   contents: read

--- a/.github/workflows/default_on_push.yml
+++ b/.github/workflows/default_on_push.yml
@@ -21,18 +21,19 @@ permissions:
 jobs:
   build-image:
     name: 'Build AMD64 Image'
-    uses: ./.github/workflows/generic_build.yml
+    uses: docker-mailserver/docker-mailserver/.github/workflows/generic_build.yml@master
 
   run-tests:
     name: 'Test AMD64 Image'
     needs: build-image
-    uses: ./.github/workflows/generic_test.yml
+    uses: docker-mailserver/docker-mailserver/.github/workflows/generic_test.yml@master
     with:
       cache-key: ${{ needs.build-image.outputs.build-cache-key }}
 
   publish-images:
     name: 'Publish AMD64 and ARM64 Image'
     needs: [build-image, run-tests]
-    uses: ./.github/workflows/generic_publish.yml
+    uses: docker-mailserver/docker-mailserver/.github/workflows/generic_publish.yml@master
     with:
       cache-key: ${{ needs.build-image.outputs.build-cache-key }}
+    secrets: inherit

--- a/.github/workflows/default_on_push.yml
+++ b/.github/workflows/default_on_push.yml
@@ -5,14 +5,14 @@ on:
   push:
     branches:
       - master
-    paths:
-      - target/**
-      - .dockerignore
-      - .gitmodules
-      - Dockerfile
-      - setup.sh
-    tags:
-      - '*.*.*'
+    # paths:
+    #   - target/**
+    #   - .dockerignore
+    #   - .gitmodules
+    #   - Dockerfile
+    #   - setup.sh
+    # tags:
+    #   - '*.*.*'
 
 permissions:
   contents: read
@@ -20,19 +20,19 @@ permissions:
 
 jobs:
   build-image:
-    name: Build the container images
-    uses: ./github/workflows/generic_build.yml
+    name: Build AMD64 Image
+    uses: ./.github/workflows/generic_build.yml
 
   run-tests:
-    name: Build the container images
+    name: Test AMD64 Image
     needs: build-image
-    uses: ./github/workflows/generic_test.yml
+    uses: ./.github/workflows/generic_test.yml
     with:
       cache-key: ${{ needs.build-image.outputs.build-cache-key }}
 
   publish-images:
-    name: Publish the container images
+    name: Publish AMD64 and ARM64 Image
     needs: [build-image, run-tests]
-    uses: ./github/workflows/generic_publish.yml
+    uses: ./.github/workflows/generic_publish.yml
     with:
       cache-key: ${{ needs.build-image.outputs.build-cache-key }}

--- a/.github/workflows/default_on_push.yml
+++ b/.github/workflows/default_on_push.yml
@@ -1,4 +1,4 @@
-name: "Build, Test & Deploy"
+name: Build, Test & Deploy
 
 on:
   workflow_dispatch:
@@ -6,11 +6,11 @@ on:
     branches:
       - master
     paths:
-      - 'target/**'
-      - '.dockerignore'
-      - '.gitmodules'
-      - 'Dockerfile'
-      - 'setup.sh'
+      - target/**
+      - .dockerignore
+      - .gitmodules
+      - Dockerfile
+      - setup.sh
     tags:
       - '*.*.*'
 
@@ -19,55 +19,20 @@ permissions:
   packages: write
 
 jobs:
-  build-and-test-image:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Prepare tags
-        id: prep
-        uses: docker/metadata-action@v4.0.1
-        with:
-          images: |
-            ${{ secrets.DOCKER_REPOSITORY }}
-            ${{ secrets.GHCR_REPOSITORY }}
-          tags: |
-            type=raw,value=edge
+  build-image:
+    name: Build the container images
+    uses: ./github/workflows/generic_build.yml
 
-      - name: Build image
-        uses: ./github/workflows/generic_build.yml
-        with:
-          platforms: linux/amd64
-          publish: false
-          cache-layers-to: true
+  run-tests:
+    name: Build the container images
+    needs: build-image
+    uses: ./github/workflows/generic_test.yml
+    with:
+      cache-key: ${{ needs.build-image.outputs.build-cache-key }}
 
-      - name: Run test suite
-        run: >
-          NAME=mailserver-testing:ci
-          bash -c 'make generate-accounts tests'
-        env:
-          CI: true
-
-  build-multiarch-and-publish:
-    needs: build-and-test-image
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Prepare tags
-        id: prep
-        uses: docker/metadata-action@v4.0.1
-        with:
-          images: |
-            ${{ secrets.DOCKER_REPOSITORY }}
-            ${{ secrets.GHCR_REPOSITORY }}
-          tags: |
-            type=edge,branch=master
-            type=semver,pattern={{major}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}.{{minor}}.{{patch}}
-          flavor: |
-            latest=auto
-
-      - name: Build image
-        uses: ./github/workflows/generic_build.yml
-        with:
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
-          publish: true
-          cache-layers-from: true
+  publish-images:
+    name: Publish the container images
+    needs: [build-image, run-tests]
+    uses: ./github/workflows/generic_publish.yml
+    with:
+      cache-key: ${{ needs.build-image.outputs.build-cache-key }}

--- a/.github/workflows/generic_build.yml
+++ b/.github/workflows/generic_build.yml
@@ -70,10 +70,9 @@ jobs:
             cache-buildx-
 
       - name: 'Set up QEMU'
-        if: inputs.extra-platforms != ''
         uses: docker/setup-qemu-action@v2.0.0
         with:
-          platforms: arm64
+          platforms: arm64,arm
 
       - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@v2.0.0

--- a/.github/workflows/generic_build.yml
+++ b/.github/workflows/generic_build.yml
@@ -3,104 +3,113 @@ name: Build the DMS container image
 on:
   workflow_call:
     inputs:
-      platforms:
-        required: true
+      extra-platforms:
+        required: false
         type: string
-      publish:
-        required: true
-        type: boolean
-      cache-layers-to:
-        required: false
-        type: boolean
-        default: false
-      cache-layers-from:
-        required: false
-        type: boolean
-        default: false
+        default: ''
 
 permissions:
   contents: read
-  packages: write
+
+# `actions/cache` does not upload a new cache until
+# completing a job successfully.
+#   To better cache image builds, tests are handled in
+# a dependent job afterwards.
+#   This way failing tests will not prevent caching of
+# an image. Useful when the build context is not
+# changed by new commits.
 
 jobs:
-  generic-build:
-    name: Build (and Publish) an Image
+  build-image:
+    name: Build an Image
     runs-on: ubuntu-20.04
+    outputs:
+      build-cache-key: ${{ steps.derive-image-cache-key.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           submodules: recursive
 
+      # Can potentially be replaced by: `${{ hashFiles('target/**', 'Dockerfile', 'VERSION') }}`
+      # Must not be affected by file metadata changes and have a consistent sort order:
+      # https://docs.github.com/en/actions/learn-github-actions/expressions#hashfiles
+      # Keying by the relevant build context is more re-usable than a commit SHA.
+      - name: Derive Docker image cache key from content
+        id: derive-image-cache-key
+        shell: bash
+        run: |
+          ADDITIONAL_FILES=(
+            'Dockerfile'
+            'VERSION'
+          )
+
+          # Recursively collect file paths from `target/` and pipe a list of
+          # checksums to be sorted (by hash value) and finally generate a checksum
+          # of that list, using `awk` to only return the hash value (digest):
+          IMAGE_CHECKSUM=$(\
+            find ./target -type f -exec sha256sum "${ADDITIONAL_FILES[@]}" {} + \
+              | sort \
+              | sha256sum \
+              | awk '{ print $1 }' \
+          )
+
+          echo "::set-output name=digest::${IMAGE_CHECKSUM}"
+
+      # Attempts to restore the build cache from a prior build run.
+      # If the exact key is not restored, then upon a successful job run
+      # the new cache is uploaded for this key containing the contents at `path`.
+      # Cache storage has a limit of 10GB, and uploads expire after 7 days.
+      # When full, the least accessed cache upload is evicted to free up storage.
+      # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
+      - name: Handle Docker build layer cache
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: cache-buildx-${{ steps.derive-image-cache-key.outputs.digest }}
+          # If no exact cache-hit for key found, lookup caches with a `cache-buildx-` key prefix:
+          # This is safe due to cache layer invalidation via the image build context.
+          restore-keys: |
+            cache-buildx-
+
       - name: Set up QEMU
+        if: input.extra-platforms != ''
         uses: docker/setup-qemu-action@v2.0.0
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.0.0
         id: buildx
 
-      - name: Cache Docker layers
-        if: input.cache-layers-to == true
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Login to DockerHub
-        if: input.publish == true
-        uses: docker/login-action@v2.0.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Login to GitHub Container Registry
-        if: input.publish == true
-        uses: docker/login-action@v2.0.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build image(s) locally without cache
-        if: input.cache-layers-to == false
+      # NOTE: AMD64 can build within 2 minutes, ARM adds 13 minutes. 330MB each
+      # ARMv7 can build in parallel, adding no extra time (but does add 150MB cache size).
+      # Moving ARM build to a separate job would cut down time to start running tests.
+      - name: Build images
         uses: docker/build-push-action@v3.1.1
         with:
-          builder: ${{ steps.buildx.outputs.name }}
           context: .
           build-args: |
             VCS_REF=${{ github.sha }}
             VCS_VER=${{ github.ref }}
-          platforms: ${{ inputs.platforms }}
-          push: ${{ inputs.publish }}
-          tags: ${{ steps.prep.outputs.tags }}
-
-      - name: Build image(s) locally and cache it
-        if: input.cache-layers-to == true
-        uses: docker/build-push-action@v3.1.1
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: .
-          build-args: |
-            VCS_REF=${{ github.sha }}
-            VCS_VER=${{ github.ref }}
-          platforms: ${{ inputs.platforms }}
-          load: true
           tags: mailserver-testing:ci
-          push: ${{ inputs.publish }}
-          cache-to: type=local,dest=/tmp/.buildx-cache
-
-      - name: Build image(s) locally from cache
-        if: input.cache-layers-from == true
-        uses: docker/build-push-action@v3.1.1
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: .
-          build-args: |
-            VCS_REF=${{ github.sha }}
-            VCS_VER=${{ github.ref }}
-          platforms: ${{ inputs.platforms }}
-          push: ${{ inputs.publish }}
-          tags: ${{ steps.prep.outputs.tags }}
+          # Build for AMD64 runs against test suite:
+          platforms: linux/amd64${{ input.extra-platforms }}
+          # Paired with steps `actions/cache` and `Replace cache` (replace src with dest):
+          # NOTE: `mode=max` is only for `cache-to`, it configures exporting all image layers.
+          # https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#cache-from
           cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          # This job just builds the image and stores to cache, no other exporting required:
+          # https://github.com/docker/build-push-action/issues/546#issuecomment-1122631106
+          outputs: type=cacheonly
+
+      # WORKAROUND: The `cache-to: type=local` input for `build-push-action` persists old-unused cache.
+      # The workaround is to write the new build cache to a different location that replaces the
+      # original restored cache after build, reducing frequency of eviction due to cache storage limit (10GB).
+      # https://github.com/docker/build-push-action/blob/965c6a410d446a30e95d35052c67d6eded60dad6/docs/advanced/cache.md?plain=1#L193-L199
+      # NOTE: This does not affect `cache-hit == 'true'` (which skips upload on direct cache key hit)
+      - name: Replace cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/generic_build.yml
+++ b/.github/workflows/generic_build.yml
@@ -23,7 +23,8 @@ permissions:
   packages: write
 
 jobs:
-  publish:
+  generic-build:
+    name: Build (and Publish) an Image
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -62,7 +63,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build image locally without cache
+      - name: Build image(s) locally without cache
         if: input.cache-layers-to == false
         uses: docker/build-push-action@v3.1.1
         with:
@@ -75,7 +76,7 @@ jobs:
           push: ${{ inputs.publish }}
           tags: ${{ steps.prep.outputs.tags }}
 
-      - name: Build image locally with cache
+      - name: Build image(s) locally and cache it
         if: input.cache-layers-to == true
         uses: docker/build-push-action@v3.1.1
         with:
@@ -90,7 +91,7 @@ jobs:
           push: ${{ inputs.publish }}
           cache-to: type=local,dest=/tmp/.buildx-cache
 
-      - name: Build images locally
+      - name: Build image(s) locally from cache
         if: input.cache-layers-from == true
         uses: docker/build-push-action@v3.1.1
         with:

--- a/.github/workflows/generic_build.yml
+++ b/.github/workflows/generic_build.yml
@@ -86,7 +86,6 @@ jobs:
           build-args: |
             VCS_REF=${{ github.sha }}
             VCS_VER=${{ github.ref }}
-          tags: mailserver-testing:ci
           # Build at least the AMD64 image (which runs against the test suite).
           platforms: ${{ inputs.platforms }}
           # Paired with steps `actions/cache` and `Replace cache` (replace src with dest):

--- a/.github/workflows/generic_build.yml
+++ b/.github/workflows/generic_build.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   build-image:
-    name: Build an Image
+    name: Build
     runs-on: ubuntu-20.04
     outputs:
       build-cache-key: ${{ steps.derive-image-cache-key.outputs.digest }}
@@ -73,7 +73,7 @@ jobs:
             cache-buildx-
 
       - name: Set up QEMU
-        if: input.extra-platforms != ''
+        if: inputs.extra-platforms != ''
         uses: docker/setup-qemu-action@v2.0.0
         with:
           platforms: arm64
@@ -94,7 +94,7 @@ jobs:
             VCS_VER=${{ github.ref }}
           tags: mailserver-testing:ci
           # Build for AMD64 runs against test suite:
-          platforms: linux/amd64${{ input.extra-platforms }}
+          platforms: linux/amd64${{ inputs.extra-platforms }}
           # Paired with steps `actions/cache` and `Replace cache` (replace src with dest):
           # NOTE: `mode=max` is only for `cache-to`, it configures exporting all image layers.
           # https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#cache-from

--- a/.github/workflows/generic_build.yml
+++ b/.github/workflows/generic_build.yml
@@ -11,13 +11,10 @@ on:
 permissions:
   contents: read
 
-# `actions/cache` does not upload a new cache until
-# completing a job successfully.
-#   To better cache image builds, tests are handled in
-# a dependent job afterwards.
-#   This way failing tests will not prevent caching of
-# an image. Useful when the build context is not
-# changed by new commits.
+# `actions/cache` does not upload a new cache until completing a job successfully.
+# To better cache image builds, tests are handled in a dependent job afterwards.
+# This way failing tests will not prevent caching of an image. Useful when the build context
+# is not changed by new commits.
 
 jobs:
   build-image:
@@ -80,7 +77,6 @@ jobs:
 
       - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@v2.0.0
-        id: buildx
 
       # NOTE: AMD64 can build within 2 minutes, ARM adds 13 minutes. 330MB each
       # ARMv7 can build in parallel, adding no extra time (but does add 150MB cache size).

--- a/.github/workflows/generic_build.yml
+++ b/.github/workflows/generic_build.yml
@@ -3,10 +3,10 @@ name: 'Build the DMS Container Image'
 on:
   workflow_call:
     inputs:
-      extra-platforms:
+      platforms:
         required: false
         type: string
-        default: ''
+        default: linux/amd64
 
 permissions:
   contents: read
@@ -88,11 +88,7 @@ jobs:
             VCS_VER=${{ github.ref }}
           tags: mailserver-testing:ci
           # Build at least the AMD64 image (which runs against the test suite).
-          # With the `extra-platforms` input, we may build all platforms we need.
-          # ATTENTION: Due to the current way `inputs.extra-platforms` is placed,
-          # one will need to start the string that contains extra platforms with
-          # a comma (`,`)!
-          platforms: linux/amd64${{ inputs.extra-platforms }}
+          platforms: ${{ inputs.platforms }}
           # Paired with steps `actions/cache` and `Replace cache` (replace src with dest):
           # NOTE: `mode=max` is only for `cache-to`, it configures exporting all image layers.
           # https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#cache-from

--- a/.github/workflows/generic_build.yml
+++ b/.github/workflows/generic_build.yml
@@ -1,4 +1,4 @@
-name: Build the DMS container image
+name: Build the DMS Container Image
 
 on:
   workflow_call:

--- a/.github/workflows/generic_build.yml
+++ b/.github/workflows/generic_build.yml
@@ -93,7 +93,11 @@ jobs:
             VCS_REF=${{ github.sha }}
             VCS_VER=${{ github.ref }}
           tags: mailserver-testing:ci
-          # Build for AMD64 runs against test suite:
+          # Build at least the AMD64 image (which runs against the test suite).
+          # With the `extra-platforms` input, we may build all platforms we need.
+          # ATTENTION: Due to the current way `inputs.extra-platforms` is placed,
+          # one will need to start the string that contains extra platforms with
+          # a comma (`,`)!
           platforms: linux/amd64${{ inputs.extra-platforms }}
           # Paired with steps `actions/cache` and `Replace cache` (replace src with dest):
           # NOTE: `mode=max` is only for `cache-to`, it configures exporting all image layers.

--- a/.github/workflows/generic_build.yml
+++ b/.github/workflows/generic_build.yml
@@ -1,0 +1,105 @@
+name: Build the DMS container image
+
+on:
+  workflow_call:
+    inputs:
+      platforms:
+        required: true
+        type: string
+      publish:
+        required: true
+        type: boolean
+      cache-layers-to:
+        required: false
+        type: boolean
+        default: false
+      cache-layers-from:
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.0.0
+        id: buildx
+
+      - name: Cache Docker layers
+        if: input.cache-layers-to == true
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to DockerHub
+        if: input.publish == true
+        uses: docker/login-action@v2.0.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to GitHub Container Registry
+        if: input.publish == true
+        uses: docker/login-action@v2.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image locally without cache
+        if: input.cache-layers-to == false
+        uses: docker/build-push-action@v3.1.1
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          build-args: |
+            VCS_REF=${{ github.sha }}
+            VCS_VER=${{ github.ref }}
+          platforms: ${{ inputs.platforms }}
+          push: ${{ inputs.publish }}
+          tags: ${{ steps.prep.outputs.tags }}
+
+      - name: Build image locally with cache
+        if: input.cache-layers-to == true
+        uses: docker/build-push-action@v3.1.1
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          build-args: |
+            VCS_REF=${{ github.sha }}
+            VCS_VER=${{ github.ref }}
+          platforms: ${{ inputs.platforms }}
+          load: true
+          tags: mailserver-testing:ci
+          push: ${{ inputs.publish }}
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Build images locally
+        if: input.cache-layers-from == true
+        uses: docker/build-push-action@v3.1.1
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          build-args: |
+            VCS_REF=${{ github.sha }}
+            VCS_VER=${{ github.ref }}
+          platforms: ${{ inputs.platforms }}
+          push: ${{ inputs.publish }}
+          tags: ${{ steps.prep.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/generic_build.yml
+++ b/.github/workflows/generic_build.yml
@@ -1,4 +1,4 @@
-name: Build the DMS Container Image
+name: 'Build the DMS Container Image'
 
 on:
   workflow_call:
@@ -21,12 +21,12 @@ permissions:
 
 jobs:
   build-image:
-    name: Build
+    name: 'Build'
     runs-on: ubuntu-20.04
     outputs:
       build-cache-key: ${{ steps.derive-image-cache-key.outputs.digest }}
     steps:
-      - name: Checkout
+      - name: 'Checkout'
         uses: actions/checkout@v3
         with:
           submodules: recursive
@@ -35,7 +35,7 @@ jobs:
       # Must not be affected by file metadata changes and have a consistent sort order:
       # https://docs.github.com/en/actions/learn-github-actions/expressions#hashfiles
       # Keying by the relevant build context is more re-usable than a commit SHA.
-      - name: Derive Docker image cache key from content
+      - name: 'Derive Docker image cache key from content'
         id: derive-image-cache-key
         shell: bash
         run: |
@@ -62,7 +62,7 @@ jobs:
       # Cache storage has a limit of 10GB, and uploads expire after 7 days.
       # When full, the least accessed cache upload is evicted to free up storage.
       # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
-      - name: Handle Docker build layer cache
+      - name: 'Handle Docker build layer cache'
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
@@ -72,20 +72,19 @@ jobs:
           restore-keys: |
             cache-buildx-
 
-      - name: Set up QEMU
+      - name: 'Set up QEMU'
         if: inputs.extra-platforms != ''
         uses: docker/setup-qemu-action@v2.0.0
         with:
           platforms: arm64
 
-      - name: Set up Docker Buildx
+      - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@v2.0.0
         id: buildx
 
       # NOTE: AMD64 can build within 2 minutes, ARM adds 13 minutes. 330MB each
       # ARMv7 can build in parallel, adding no extra time (but does add 150MB cache size).
-      # Moving ARM build to a separate job would cut down time to start running tests.
-      - name: Build images
+      - name: 'Build images'
         uses: docker/build-push-action@v3.1.1
         with:
           context: .
@@ -113,7 +112,7 @@ jobs:
       # original restored cache after build, reducing frequency of eviction due to cache storage limit (10GB).
       # https://github.com/docker/build-push-action/blob/965c6a410d446a30e95d35052c67d6eded60dad6/docs/advanced/cache.md?plain=1#L193-L199
       # NOTE: This does not affect `cache-hit == 'true'` (which skips upload on direct cache key hit)
-      - name: Replace cache
+      - name: 'Replace cache'
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/generic_publish.yml
+++ b/.github/workflows/generic_publish.yml
@@ -37,14 +37,12 @@ jobs:
       - name: 'Set up QEMU'
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: arm64
+          platforms: arm64, arm
 
       - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@v2
-        id: buildx
 
-      # Get the cached build layers from a build job
-      # that built an AMD64 image:
+      # Get the cached build layers from an earlier build job that built an AMD64 image:
       - name: 'Retrieve image build from build cache'
         uses: actions/cache@v3
         with:

--- a/.github/workflows/generic_publish.yml
+++ b/.github/workflows/generic_publish.yml
@@ -69,7 +69,6 @@ jobs:
       - name: Build and publish images
         uses: docker/build-push-action@v3.1
         with:
-          builder: ${{ steps.buildx.outputs.name }}
           context: .
           build-args: |
             VCS_REF=${{ github.sha }}

--- a/.github/workflows/generic_publish.yml
+++ b/.github/workflows/generic_publish.yml
@@ -37,12 +37,14 @@ jobs:
       - name: 'Set up QEMU'
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: arm64, arm
+          platforms: arm64,arm
 
       - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@v2
 
-      # Get the cached build layers from an earlier build job that built an AMD64 image:
+      # Try get the cached build layers from a prior `generic_build.yml` job.
+      # NOTE: Until adopting `type=gha` scoped cache exporter (in `docker/build-push-action`),
+      # only AMD64 image is expected to be cached, ARM images will build from scratch.
       - name: 'Retrieve image build from build cache'
         uses: actions/cache@v3
         with:

--- a/.github/workflows/generic_publish.yml
+++ b/.github/workflows/generic_publish.yml
@@ -1,0 +1,80 @@
+name: Publish the DMS Container Image
+
+on:
+  workflow_call:
+    inputs:
+      cache-key:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-images:
+    name: Publish Images
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Prepare tags
+        id: prep
+        uses: docker/metadata-action@v4.0
+        with:
+          images: |
+            ${{ secrets.DOCKER_REPOSITORY }}
+            ${{ secrets.GHCR_REPOSITORY }}
+          tags: |
+            type=edge,branch=master
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        id: buildx
+
+      # Get the cached build layers from a build job
+      # that built an AMD64 image:
+      - name: Retrieve image build from build cache
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: cache-buildx-${{ input.cache-key }}
+          restore-keys: |
+            cache-buildx-
+
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@v2
+      #   with:
+      #     username: ${{ secrets.DOCKER_USERNAME }}
+      #     password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish images
+        uses: docker/build-push-action@v3.1
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          build-args: |
+            VCS_REF=${{ github.sha }}
+            VCS_VER=${{ github.ref }}
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/generic_publish.yml
+++ b/.github/workflows/generic_publish.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   publish-images:
-    name: Publish Images
+    name: Publish
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
-          key: cache-buildx-${{ input.cache-key }}
+          key: cache-buildx-${{ inputs.cache-key }}
           restore-keys: |
             cache-buildx-
 

--- a/.github/workflows/generic_publish.yml
+++ b/.github/workflows/generic_publish.yml
@@ -53,11 +53,11 @@ jobs:
           restore-keys: |
             cache-buildx-
 
-      # - name: Login to DockerHub
-      #   uses: docker/login-action@v2
-      #   with:
-      #     username: ${{ secrets.DOCKER_USERNAME }}
-      #     password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/generic_publish.yml
+++ b/.github/workflows/generic_publish.yml
@@ -1,4 +1,4 @@
-name: Publish the DMS Container Image
+name: 'Publish the DMS Container Image'
 
 on:
   workflow_call:
@@ -13,15 +13,15 @@ permissions:
 
 jobs:
   publish-images:
-    name: Publish
+    name: 'Publish'
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout
+      - name: 'Checkout'
         uses: actions/checkout@v3
         with:
           submodules: recursive
 
-      - name: Prepare tags
+      - name: 'Prepare tags'
         id: prep
         uses: docker/metadata-action@v4.0
         with:
@@ -34,18 +34,18 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
 
-      - name: Set up QEMU
+      - name: 'Set up QEMU'
         uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64
 
-      - name: Set up Docker Buildx
+      - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@v2
         id: buildx
 
       # Get the cached build layers from a build job
       # that built an AMD64 image:
-      - name: Retrieve image build from build cache
+      - name: 'Retrieve image build from build cache'
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
@@ -53,20 +53,20 @@ jobs:
           restore-keys: |
             cache-buildx-
 
-      - name: Login to DockerHub
+      - name: 'Login to DockerHub'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Login to GitHub Container Registry
+      - name: 'Login to GitHub Container Registry'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and publish images
+      - name: 'Build and publish images'
         uses: docker/build-push-action@v3.1
         with:
           context: .

--- a/.github/workflows/generic_test.yml
+++ b/.github/workflows/generic_test.yml
@@ -21,21 +21,16 @@ jobs:
           # Required to retrieve bats (core + extras):
           submodules: recursive
 
-      # Get the cached build layers from a build job:
-      # This should always be a cache-hit, no new uploads
-      # should happen when this job finishes:
+      # Get the cached build layers from the build job:
+      # This should always be a cache-hit, no new uploads should happen when this job finishes:
       - name: 'Retrieve image built from build cache'
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: cache-buildx-${{ inputs.cache-key }}
-          restore-keys: |
-            cache-buildx-
 
-      # Importing from the cache should create the image
-      # within approx 30 seconds:
-      # buildx not needed as no exporting and only single
-      # AMD64 platform is loaded:
+      # Importing from the cache should create the image within approx 30 seconds:
+      # buildx not needed as no exporting and only single AMD64 platform is loaded:
       - name: 'Build AMD64 image from cache'
         uses: docker/build-push-action@v3.1.1
         with:

--- a/.github/workflows/generic_test.yml
+++ b/.github/workflows/generic_test.yml
@@ -50,9 +50,8 @@ jobs:
           platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
 
-      - name: Run tests
-        run: >
-          NAME=mailserver-testing:ci
-          make generate-accounts tests
+      - name: 'Run tests'
+        run: make generate-accounts tests
         env:
           CI: true
+          NAME: mailserver-testing:ci

--- a/.github/workflows/generic_test.yml
+++ b/.github/workflows/generic_test.yml
@@ -1,0 +1,58 @@
+name: Test the DMS Container Image
+
+on:
+  workflow_call:
+    inputs:
+      cache-key:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  run-tests:
+    name: Run Test Suite
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # Required to retrieve bats (core + extras):
+          submodules: recursive
+
+      # Get the cached build layers from a build job:
+      # This should always be a cache-hit, no new uploads
+      # should happen when this job finishes:
+      - name: Retrieve image build from build cache
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: cache-buildx-${{ input.cache-key }}
+          restore-keys: |
+            cache-buildx-
+
+      # Importing from the cache should create the image
+      # within approx 30 seconds:
+      # buildx not needed as no exporting and only single
+      # AMD64 platform is loaded:
+      - name: Build AMD64 image from cache
+        uses: docker/build-push-action@v3.1.1
+        with:
+          context: .
+          build-args: |
+            VCS_REF=${{ github.sha }}
+            VCS_VER=${{ github.ref }}
+          tags: mailserver-testing:ci
+          # Export the built image for the Docker host to use:
+          load: true
+          # Rebuilds the AMD64 image from the cache:
+          platforms: linux/amd64
+          cache-from: type=local,src=/tmp/.buildx-cache
+
+      - name: Run tests
+        run: >
+          NAME=mailserver-testing:ci
+          make generate-accounts tests
+        env:
+          CI: true

--- a/.github/workflows/generic_test.yml
+++ b/.github/workflows/generic_test.yml
@@ -22,7 +22,8 @@ jobs:
           submodules: recursive
 
       # Get the cached build layers from the build job:
-      # This should always be a cache-hit, no new uploads should happen when this job finishes:
+      # This should always be a cache-hit, thus `restore-keys` fallback is not used.
+      # No new cache uploads should ever happen for this job.
       - name: 'Retrieve image built from build cache'
         uses: actions/cache@v3
         with:
@@ -30,7 +31,8 @@ jobs:
           key: cache-buildx-${{ inputs.cache-key }}
 
       # Importing from the cache should create the image within approx 30 seconds:
-      # buildx not needed as no exporting and only single AMD64 platform is loaded:
+      # Earlier `buildx` + `qemu` steps are not needed as no cache is exported,
+      # and only a single platform (AMD64) is loaded:
       - name: 'Build AMD64 image from cache'
         uses: docker/build-push-action@v3.1.1
         with:
@@ -39,7 +41,7 @@ jobs:
             VCS_REF=${{ github.sha }}
             VCS_VER=${{ github.ref }}
           tags: mailserver-testing:ci
-          # Export the built image for the Docker host to use:
+          # Export the built image to the Docker host for use with BATS:
           load: true
           # Rebuilds the AMD64 image from the cache:
           platforms: linux/amd64

--- a/.github/workflows/generic_test.yml
+++ b/.github/workflows/generic_test.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   run-tests:
-    name: Run Test Suite
+    name: Test
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -28,7 +28,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
-          key: cache-buildx-${{ input.cache-key }}
+          key: cache-buildx-${{ inputs.cache-key }}
           restore-keys: |
             cache-buildx-
 

--- a/.github/workflows/generic_test.yml
+++ b/.github/workflows/generic_test.yml
@@ -24,7 +24,7 @@ jobs:
       # Get the cached build layers from a build job:
       # This should always be a cache-hit, no new uploads
       # should happen when this job finishes:
-      - name: Retrieve image build from build cache
+      - name: Retrieve image built from build cache
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache

--- a/.github/workflows/generic_test.yml
+++ b/.github/workflows/generic_test.yml
@@ -1,4 +1,4 @@
-name: Test the DMS Container Image
+name: 'Test the DMS Container Image'
 
 on:
   workflow_call:
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   run-tests:
-    name: Test
+    name: 'Test'
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -24,7 +24,7 @@ jobs:
       # Get the cached build layers from a build job:
       # This should always be a cache-hit, no new uploads
       # should happen when this job finishes:
-      - name: Retrieve image built from build cache
+      - name: 'Retrieve image built from build cache'
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
@@ -36,7 +36,7 @@ jobs:
       # within approx 30 seconds:
       # buildx not needed as no exporting and only single
       # AMD64 platform is loaded:
-      - name: Build AMD64 image from cache
+      - name: 'Build AMD64 image from cache'
         uses: docker/build-push-action@v3.1.1
         with:
           context: .

--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -9,8 +9,15 @@ permissions:
   packages: write
 
 jobs:
-  publish:
+  build-images:
+    name: Build the container images
     uses: ./github/workflows/generic_build.yml
     with:
-      platforms: linux/amd64,linux/arm/v7,linux/arm64
-      publish: true
+      extra-platforms: ',linux/arm/v7,linux/arm64'
+
+  publish-images:
+    name: Publish the container images
+    needs: build-images
+    uses: ./github/workflows/generic_publish.yml
+    with:
+      cache-key: ${{ needs.build-images.outputs.build-cache-key }}

--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -10,13 +10,13 @@ permissions:
 
 jobs:
   build-images:
-    name: Build Images
+    name: 'Build Images'
     uses: ./.github/workflows/generic_build.yml
     with:
       extra-platforms: ',linux/arm/v7,linux/arm64'
 
   publish-images:
-    name: Publish Images
+    name: 'Publish Images'
     needs: build-images
     uses: ./.github/workflows/generic_publish.yml
     with:

--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -11,13 +11,14 @@ permissions:
 jobs:
   build-images:
     name: 'Build Images'
-    uses: ./.github/workflows/generic_build.yml
+    uses: docker-mailserver/docker-mailserver/.github/workflows/generic_build.yml@master
     with:
       platforms: linux/amd64,linux/arm/v7,linux/arm64
 
   publish-images:
     name: 'Publish Images'
     needs: build-images
-    uses: ./.github/workflows/generic_publish.yml
+    uses: docker-mailserver/docker-mailserver/.github/workflows/generic_publish.yml@master
     with:
       cache-key: ${{ needs.build-images.outputs.build-cache-key }}
+    secrets: inherit

--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -1,4 +1,4 @@
-name: Build Edge on Schedule
+name: 'Deploy :edge on Schedule'
 
 on:
   schedule:
@@ -10,14 +10,14 @@ permissions:
 
 jobs:
   build-images:
-    name: Build the container images
-    uses: ./github/workflows/generic_build.yml
+    name: Build Images
+    uses: ./.github/workflows/generic_build.yml
     with:
       extra-platforms: ',linux/arm/v7,linux/arm64'
 
   publish-images:
-    name: Publish the container images
+    name: Publish Images
     needs: build-images
-    uses: ./github/workflows/generic_publish.yml
+    uses: ./.github/workflows/generic_publish.yml
     with:
       cache-key: ${{ needs.build-images.outputs.build-cache-key }}

--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -1,60 +1,16 @@
-name: "Build Edge on Schedule"
+name: Build Edge on Schedule
 
 on:
   schedule:
-    - cron: "0 0 * * 5"
+    - cron: 0 0 * * 5
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      - name: Prepare tags
-        id: prep
-        uses: docker/metadata-action@v4.0.1
-        with:
-          images: |
-            ${{ secrets.DOCKER_REPOSITORY }}
-            ${{ secrets.GHCR_REPOSITORY }}
-          tags: |
-            type=raw,value=edge
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.0.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.0.0
-        id: buildx
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2.0.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2.0.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build image locally
-        uses: docker/build-push-action@v3.1.1
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: .
-          file: ./Dockerfile
-          build-args: |
-            VCS_REF=${{ github.sha }}
-            VCS_VER=${{ github.ref }}
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
-          push: true
-          tags: ${{ steps.prep.outputs.tags }}
+    uses: ./github/workflows/generic_build.yml
+    with:
+      platforms: linux/amd64,linux/arm/v7,linux/arm64
+      publish: true

--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -13,7 +13,7 @@ jobs:
     name: 'Build Images'
     uses: ./.github/workflows/generic_build.yml
     with:
-      extra-platforms: ',linux/arm/v7,linux/arm64'
+      platforms: linux/amd64,linux/arm/v7,linux/arm64
 
   publish-images:
     name: 'Publish Images'

--- a/.github/workflows/test_merge_requests.yml
+++ b/.github/workflows/test_merge_requests.yml
@@ -20,6 +20,7 @@ permissions:
 # is not changed by new commits.
 jobs:
   job-build-image:
+    name: Build Test Image
     runs-on: ubuntu-20.04
     outputs:
       image-build-key: ${{ steps.derive-image-cache-key.outputs.digest }}
@@ -158,7 +159,7 @@ jobs:
           CI: true
 
   job-build-arm:
-    name: Build ARM image
+    name: Build ARM Image
     needs: job-build-image
     uses: ./github/workflows/generic_build.yml
     with:

--- a/.github/workflows/test_merge_requests.yml
+++ b/.github/workflows/test_merge_requests.yml
@@ -14,155 +14,21 @@ on:
 permissions:
   contents: read
 
-# `actions/cache` does not upload a new cache until completing a job successfully.
-# To better cache image builds, tests are handled in a dependent job afterwards.
-# This way failing tests will not prevent caching of an image. Useful when the build context
-# is not changed by new commits.
 jobs:
-  job-build-image:
-    name: Build Test Image
-    runs-on: ubuntu-20.04
-    outputs:
-      image-build-key: ${{ steps.derive-image-cache-key.outputs.digest }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          # Required for image to include `configomat.sh`:
-          submodules: recursive
+  build-AMD64-image:
+    name: Build the container images
+    uses: ./github/workflows/generic_build.yml
 
-      # Can potentially be replaced by: `${{ hashFiles('target/**', 'Dockerfile', 'VERSION') }}`
-      # Must not be affected by file metadata changes and have a consistent sort order:
-      # https://docs.github.com/en/actions/learn-github-actions/expressions#hashfiles
-      # Keying by the relevant build context is more re-usable than a commit SHA.
-      - name: Derive Docker image cache key from content
-        id: derive-image-cache-key
-        shell: bash
-        run: |
-          ADDITIONAL_FILES=(
-            'Dockerfile'
-            'VERSION'
-          )
-
-          # Recursively collect file paths from `target/` and pipe a list of
-          # checksums to be sorted (by hash value) and finally generate a checksum
-          # of that list, using `awk` to only return the hash value (digest):
-          IMAGE_CHECKSUM=$(\
-            find ./target -type f -exec sha256sum "${ADDITIONAL_FILES[@]}" {} + \
-              | sort \
-              | sha256sum \
-              | awk '{ print $1 }' \
-          )
-
-          echo "::set-output name=digest::${IMAGE_CHECKSUM}"
-
-      # Attempts to restore the build cache from a prior build run.
-      # If the exact key is not restored, then upon a successful job run
-      # the new cache is uploaded for this key containing the contents at `path`.
-      # Cache storage has a limit of 10GB, and uploads expire after 7 days.
-      # When full, the least accessed cache upload is evicted to free up storage.
-      # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
-      - name: Handle Docker build layer cache
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: cache-buildx-${{ steps.derive-image-cache-key.outputs.digest }}
-          # If no exact cache-hit for key found, lookup caches with a `cache-buildx-` key prefix:
-          # This is safe due to cache layer invalidation via the image build context.
-          restore-keys: |
-            cache-buildx-
-
-      # Support ARM64 builds on AMD64 host:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.0.0
-        with:
-          platforms: arm64
-
-      # Enables `buildx` support within `build-push-action`, improving cache and platform support:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.0.0
-
-      # NOTE: AMD64 can build within 2 minutes, ARM adds 13 minutes. 330MB each
-      # ARMv7 can build in parallel, adding no extra time (but does add 150MB cache size).
-      # Moving ARM build to a separate job would cut down time to start running tests.
-      - name: Build images
-        uses: docker/build-push-action@v3.1.1
-        with:
-          context: .
-          build-args: |
-            VCS_REF=${{ github.sha }}
-            VCS_VER=${{ github.ref }}
-          tags: mailserver-testing:ci
-          # Build for AMD64 (runs against test suite) and ARM64 (only to verify building works):
-          platforms: linux/amd64
-          # Paired with steps `actions/cache` and `Replace cache` (replace src with dest):
-          # NOTE: `mode=max` is only for `cache-to`, it configures exporting all image layers.
-          # https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#cache-from
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-          # This job just builds the image and stores to cache, no other exporting required:
-          # https://github.com/docker/build-push-action/issues/546#issuecomment-1122631106
-          outputs: type=cacheonly
-
-      # WORKAROUND: The `cache-to: type=local` input for `build-push-action` persists old-unused cache.
-      # The workaround is to write the new build cache to a different location that replaces the
-      # original restored cache after build, reducing frequency of eviction due to cache storage limit (10GB).
-      # https://github.com/docker/build-push-action/blob/965c6a410d446a30e95d35052c67d6eded60dad6/docs/advanced/cache.md?plain=1#L193-L199
-      # NOTE: This does not affect `cache-hit == 'true'` (which skips upload on direct cache key hit)
-      - name: Replace cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-  job-run-tests:
-    name: Run Test Suite
-    needs: job-build-image
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          # Required to retrieve bats (core + extras):
-          submodules: recursive
-
-      # Get the cached build layers from the build job:
-      # This should always be a cache-hit, no new uploads should happen when this job finishes:
-      - name: Retrieve image build from build cache
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: cache-buildx-${{ needs.job-build-image.outputs.image-build-key }}
-          restore-keys: |
-            cache-buildx-
-
-      # Importing from the cache should create the image within approx 30 seconds:
-      # buildx not needed as no exporting and only single AMD64 platform is loaded:
-      - name: Build AMD64 image from cache
-        uses: docker/build-push-action@v3.1.1
-        with:
-          context: .
-          build-args: |
-            VCS_REF=${{ github.sha }}
-            VCS_VER=${{ github.ref }}
-          tags: mailserver-testing:ci
-          # Export the built image for the Docker host to use:
-          load: true
-          # Rebuilds the AMD64 image from the cache:
-          platforms: linux/amd64
-          cache-from: type=local,src=/tmp/.buildx-cache
-
-      - name: Run tests
-        run: >
-          NAME=mailserver-testing:ci
-          make generate-accounts tests
-        env:
-          CI: true
+  run-tests:
+    name: Build the container images
+    needs: build-AMD64-image
+    uses: ./github/workflows/generic_test.yml
+    with:
+      cache-key: ${{ needs.build-AMD64-image.outputs.build-cache-key }}
 
   job-build-arm:
-    name: Build ARM Image
-    needs: job-build-image
+    name: Build ARM64 Image
+    needs: build-AMD64-image
     uses: ./github/workflows/generic_build.yml
     with:
-      platforms: linux/arm/v7,linux/arm64
-      publish: false
-      cache-layers-to: false
+      extra-platforms: ',linux/arm64'

--- a/.github/workflows/test_merge_requests.yml
+++ b/.github/workflows/test_merge_requests.yml
@@ -28,6 +28,9 @@ jobs:
 
   job-build-arm:
     name: 'Build ARM64 Image'
+    # Dependency ensures the cache-key is only created for AMD64 builds.
+    # ARM64 will not be able to use this cache, building from scratch each time.
+    # Expect about 13 minutes build time until adopting `type=gha` with scopes for cache.
     needs: build-image-amd64
     uses: ./.github/workflows/generic_build.yml
     with:

--- a/.github/workflows/test_merge_requests.yml
+++ b/.github/workflows/test_merge_requests.yml
@@ -16,19 +16,18 @@ permissions:
 
 jobs:
   build-AMD64-image:
-    name: Build the container images
-    uses: ./github/workflows/generic_build.yml
+    name: Build AMD64 Image
+    uses: ./.github/workflows/generic_build.yml
 
   run-tests:
-    name: Build the container images
+    name: Test AMD64 Image
     needs: build-AMD64-image
-    uses: ./github/workflows/generic_test.yml
+    uses: ./.github/workflows/generic_test.yml
     with:
       cache-key: ${{ needs.build-AMD64-image.outputs.build-cache-key }}
 
   job-build-arm:
     name: Build ARM64 Image
-    needs: build-AMD64-image
-    uses: ./github/workflows/generic_build.yml
+    uses: ./.github/workflows/generic_build.yml
     with:
       extra-platforms: ',linux/arm64'

--- a/.github/workflows/test_merge_requests.yml
+++ b/.github/workflows/test_merge_requests.yml
@@ -15,19 +15,20 @@ permissions:
   contents: read
 
 jobs:
-  build-AMD64-image:
+  build-image-amd64:
     name: 'Build AMD64 Image'
     uses: ./.github/workflows/generic_build.yml
 
   run-tests:
     name: 'Test AMD64 Image'
-    needs: build-AMD64-image
+    needs: build-image-amd64
     uses: ./.github/workflows/generic_test.yml
     with:
-      cache-key: ${{ needs.build-AMD64-image.outputs.build-cache-key }}
+      cache-key: ${{ needs.build-image-amd64.outputs.build-cache-key }}
 
   job-build-arm:
     name: 'Build ARM64 Image'
+    needs: build-image-amd64
     uses: ./.github/workflows/generic_build.yml
     with:
       extra-platforms: ',linux/arm64'

--- a/.github/workflows/test_merge_requests.yml
+++ b/.github/workflows/test_merge_requests.yml
@@ -1,4 +1,4 @@
-name: Test Merge Requests
+name: 'Test Merge Requests'
 
 on:
   workflow_dispatch:
@@ -16,18 +16,18 @@ permissions:
 
 jobs:
   build-AMD64-image:
-    name: Build AMD64 Image
+    name: 'Build AMD64 Image'
     uses: ./.github/workflows/generic_build.yml
 
   run-tests:
-    name: Test AMD64 Image
+    name: 'Test AMD64 Image'
     needs: build-AMD64-image
     uses: ./.github/workflows/generic_test.yml
     with:
       cache-key: ${{ needs.build-AMD64-image.outputs.build-cache-key }}
 
   job-build-arm:
-    name: Build ARM64 Image
+    name: 'Build ARM64 Image'
     uses: ./.github/workflows/generic_build.yml
     with:
       extra-platforms: ',linux/arm64'

--- a/.github/workflows/test_merge_requests.yml
+++ b/.github/workflows/test_merge_requests.yml
@@ -17,12 +17,12 @@ permissions:
 jobs:
   build-image-amd64:
     name: 'Build AMD64 Image'
-    uses: ./.github/workflows/generic_build.yml
+    uses: docker-mailserver/docker-mailserver/.github/workflows/generic_build.yml@master
 
   run-tests:
     name: 'Test AMD64 Image'
     needs: build-image-amd64
-    uses: ./.github/workflows/generic_test.yml
+    uses: docker-mailserver/docker-mailserver/.github/workflows/generic_test.yml@master
     with:
       cache-key: ${{ needs.build-image-amd64.outputs.build-cache-key }}
 
@@ -32,6 +32,6 @@ jobs:
     # ARM64 will not be able to use this cache, building from scratch each time.
     # Expect about 13 minutes build time until adopting `type=gha` with scopes for cache.
     needs: build-image-amd64
-    uses: ./.github/workflows/generic_build.yml
+    uses: docker-mailserver/docker-mailserver/.github/workflows/generic_build.yml@master
     with:
       platforms: linux/arm/v7,linux/arm64

--- a/.github/workflows/test_merge_requests.yml
+++ b/.github/workflows/test_merge_requests.yml
@@ -34,4 +34,4 @@ jobs:
     needs: build-image-amd64
     uses: ./.github/workflows/generic_build.yml
     with:
-      extra-platforms: ',linux/arm64'
+      platforms: linux/arm/v7,linux/arm64

--- a/.github/workflows/test_merge_requests.yml
+++ b/.github/workflows/test_merge_requests.yml
@@ -1,15 +1,15 @@
-name: "Test Merge Requests"
+name: Test Merge Requests
 
 on:
   workflow_dispatch:
   pull_request:
     paths:
-      - 'target/**'
-      - 'test/**'
-      - '.dockerignore'
-      - '.gitmodules'
-      - 'Dockerfile'
-      - 'setup.sh'
+      - target/**
+      - test/**
+      - .dockerignore
+      - .gitmodules
+      - Dockerfile
+      - setup.sh
 
 permissions:
   contents: read
@@ -24,7 +24,7 @@ jobs:
     outputs:
       image-build-key: ${{ steps.derive-image-cache-key.outputs.digest }}
     steps:
-      - name: 'Checkout'
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           # Required for image to include `configomat.sh`:
@@ -34,7 +34,7 @@ jobs:
       # Must not be affected by file metadata changes and have a consistent sort order:
       # https://docs.github.com/en/actions/learn-github-actions/expressions#hashfiles
       # Keying by the relevant build context is more re-usable than a commit SHA.
-      - name: 'Derive Docker image cache key from content'
+      - name: Derive Docker image cache key from content
         id: derive-image-cache-key
         shell: bash
         run: |
@@ -61,7 +61,7 @@ jobs:
       # Cache storage has a limit of 10GB, and uploads expire after 7 days.
       # When full, the least accessed cache upload is evicted to free up storage.
       # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
-      - name: 'Handle Docker build layer cache'
+      - name: Handle Docker build layer cache
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
@@ -72,19 +72,19 @@ jobs:
             cache-buildx-
 
       # Support ARM64 builds on AMD64 host:
-      - name: 'Set up QEMU'
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.0.0
         with:
           platforms: arm64
 
       # Enables `buildx` support within `build-push-action`, improving cache and platform support:
-      - name: 'Set up Docker Buildx'
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.0.0
 
       # NOTE: AMD64 can build within 2 minutes, ARM adds 13 minutes. 330MB each
       # ARMv7 can build in parallel, adding no extra time (but does add 150MB cache size).
       # Moving ARM build to a separate job would cut down time to start running tests.
-      - name: 'Build images'
+      - name: Build images
         uses: docker/build-push-action@v3.1.1
         with:
           context: .
@@ -93,7 +93,7 @@ jobs:
             VCS_VER=${{ github.ref }}
           tags: mailserver-testing:ci
           # Build for AMD64 (runs against test suite) and ARM64 (only to verify building works):
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           # Paired with steps `actions/cache` and `Replace cache` (replace src with dest):
           # NOTE: `mode=max` is only for `cache-to`, it configures exporting all image layers.
           # https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#cache-from
@@ -108,17 +108,17 @@ jobs:
       # original restored cache after build, reducing frequency of eviction due to cache storage limit (10GB).
       # https://github.com/docker/build-push-action/blob/965c6a410d446a30e95d35052c67d6eded60dad6/docs/advanced/cache.md?plain=1#L193-L199
       # NOTE: This does not affect `cache-hit == 'true'` (which skips upload on direct cache key hit)
-      - name: 'Replace cache'
+      - name: Replace cache
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   job-run-tests:
-    name: 'Run Test Suite'
+    name: Run Test Suite
     needs: job-build-image
     runs-on: ubuntu-20.04
     steps:
-      - name: 'Checkout'
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           # Required to retrieve bats (core + extras):
@@ -126,7 +126,7 @@ jobs:
 
       # Get the cached build layers from the build job:
       # This should always be a cache-hit, no new uploads should happen when this job finishes:
-      - name: 'Retrieve image build from build cache'
+      - name: Retrieve image build from build cache
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
@@ -136,7 +136,7 @@ jobs:
 
       # Importing from the cache should create the image within approx 30 seconds:
       # buildx not needed as no exporting and only single AMD64 platform is loaded:
-      - name: 'Build AMD64 image from cache'
+      - name: Build AMD64 image from cache
         uses: docker/build-push-action@v3.1.1
         with:
           context: .
@@ -150,9 +150,18 @@ jobs:
           platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
 
-      - name: 'Run tests'
-        env:
-          CI: true
-        run: |
+      - name: Run tests
+        run: >
           NAME=mailserver-testing:ci
           make generate-accounts tests
+        env:
+          CI: true
+
+  job-build-arm:
+    name: Build ARM image
+    needs: job-build-image
+    uses: ./github/workflows/generic_build.yml
+    with:
+      platforms: linux/arm/v7,linux/arm64
+      publish: false
+      cache-layers-to: false


### PR DESCRIPTION
# Description

Mew re-usable workflows are introduced to handle building, testing and publishing the container
image in a uniform and easy way. Now, the `scheduled_builds`, `default_on_push`
and a part of the `test_merge_requests` workflow can use the same code
for building, testing and publishing the container images. This is DRY.

Follow-up for: #2742

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
