### PR TITLE
ci: adjust build arguments

### DIFF
--- a/.github/workflows/generic_build.yml
+++ b/.github/workflows/generic_build.yml
@@ -83,9 +83,6 @@ jobs:
         uses: docker/build-push-action@v3.1.1
         with:
           context: .
-          build-args: |
-            VCS_REF=${{ github.sha }}
-            VCS_VER=${{ github.ref }}
           # Build at least the AMD64 image (which runs against the test suite).
           platforms: ${{ inputs.platforms }}
           # Paired with steps `actions/cache` and `Replace cache` (replace src with dest):

--- a/.github/workflows/generic_publish.yml
+++ b/.github/workflows/generic_publish.yml
@@ -66,13 +66,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 'Acquire the image version'
+        id: get-version
+        shell: bash
+        run: echo "::set-output name=version::$(<VERSION)"
+
       - name: 'Build and publish images'
         uses: docker/build-push-action@v3.1
         with:
           context: .
           build-args: |
-            VCS_REF=${{ github.sha }}
-            VCS_VER=${{ github.ref }}
+            VCS_REVISION=${{ github.sha }}
+            VCS_VERSION=${{ steps.get-version.outputs.version }}
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
           tags: ${{ steps.prep.outputs.tags }}

--- a/.github/workflows/generic_test.yml
+++ b/.github/workflows/generic_test.yml
@@ -37,9 +37,6 @@ jobs:
         uses: docker/build-push-action@v3.1.1
         with:
           context: .
-          build-args: |
-            VCS_REF=${{ github.sha }}
-            VCS_VER=${{ github.ref }}
           tags: mailserver-testing:ci
           # Export the built image to the Docker host for use with BATS:
           load: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -281,8 +281,8 @@ COPY target/scripts/helpers /usr/local/bin/helpers
 #
 
 FROM stage-base AS stage-final
-ARG VCS_REF
-ARG VCS_VER
+ARG VCS_REVISION=unknown
+ARG VCS_VERSION=edge
 
 WORKDIR /
 EXPOSE 25 587 143 465 993 110 995 4190
@@ -312,5 +312,5 @@ LABEL org.opencontainers.image.documentation="https://github.com/docker-mailserv
 LABEL org.opencontainers.image.source="https://github.com/docker-mailserver/docker-mailserver"
 # ARG invalidates cache when it is used by a layer (implicitly affects RUN)
 # Thus to maximize cache, keep these lines last:
-LABEL org.opencontainers.image.revision=${VCS_REF}
-LABEL org.opencontainers.image.version=${VCS_VER}
+LABEL org.opencontainers.image.revision=${VCS_REVISION}
+LABEL org.opencontainers.image.version=${VCS_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 SHELL = /bin/bash
 
-NAME   ?= mailserver-testing:ci
-VCS_REF = $(shell git rev-parse --short HEAD)
-VCS_VER = $(shell git describe --tags --contains --always)
+NAME        ?= mailserver-testing:ci
+VCS_REVISION = $(shell git rev-parse --short HEAD)
+VCS_VERSION  = $(shell cat VERSION)
 
 # -----------------------------------------------
 # --- Generic Build Targets ---------------------
@@ -11,7 +11,7 @@ VCS_VER = $(shell git describe --tags --contains --always)
 all: lint build backup generate-accounts tests clean
 
 build:
-	docker build -t $(NAME) . --build-arg VCS_VER=$(VCS_VER) --build-arg VCS_REF=$(VCS_REF)
+	docker build -t $(NAME) . --build-arg VCS_VERSION=$(VCS_VERSION) --build-arg VCS_REVISION=$(VCS_REVISION)
 
 backup:
 # if backup directory exist, clean hasn't been called, therefore


### PR DESCRIPTION
# Description

The build arguments `VCS_REF` and `VCS_VER` were renamed and given proper values according to their names.

1. `VCS_REVISION` holds the current SHA sum of the (git) HEAD pointer
2. `VCS_VERSION` now holds the contents of the `VERSION` file, i.e. a semver version tag (one can now inspect the image and find a proper version tag in the `org.opencontainers.image.version` label)

The build arguments were given defaults in order to allow the `generic_build` and `generic_test` workflows to omit them (as they are not need there anyways). When publishing images, this is fina as the cache will rebuild almost all of the image except the last few layers which are `LABEL`s anyways.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes