### PR TITLE
Only calculate checksums, when there are files to monitor.

### DIFF
--- a/target/scripts/helpers/change-detection.sh
+++ b/target/scripts/helpers/change-detection.sh
@@ -73,5 +73,5 @@ function _monitored_files_checksums
   do
     [[ -f "${FILE}" ]] && CHANGED_FILES+=("${FILE}")
   done
-  sha512sum -- "${CHANGED_FILES[@]}"
+  [[ ${#CHANGED_FILES[@]} -ne 0 ]] && sha512sum -- "${CHANGED_FILES[@]}"
 }

--- a/target/scripts/helpers/change-detection.sh
+++ b/target/scripts/helpers/change-detection.sh
@@ -74,7 +74,7 @@ function _monitored_files_checksums
     [[ -f "${FILE}" ]] && CHANGED_FILES+=("${FILE}")
   done
 
-  if [[ ${#CHANGED_FILES[@]} -ne 0 ]]
+  if [[ -n ${CHANGED_FILES:-} ]]
   then
     sha512sum -- "${CHANGED_FILES[@]}"
   fi

--- a/target/scripts/helpers/change-detection.sh
+++ b/target/scripts/helpers/change-detection.sh
@@ -73,5 +73,9 @@ function _monitored_files_checksums
   do
     [[ -f "${FILE}" ]] && CHANGED_FILES+=("${FILE}")
   done
-  [[ ${#CHANGED_FILES[@]} -ne 0 ]] && sha512sum -- "${CHANGED_FILES[@]}"
+
+  if [[ ${#CHANGED_FILES[@]} -ne 0 ]]
+  then
+    sha512sum -- "${CHANGED_FILES[@]}"
+  fi
 }

--- a/test/mail_smtponly.bats
+++ b/test/mail_smtponly.bats
@@ -1,11 +1,7 @@
 load 'test_helper/common'
 
 function setup_file() {
-  local PRIVATE_CONFIG
-  PRIVATE_CONFIG=$(duplicate_config_for_container .)
-
   docker run --rm -d --name mail_smtponly \
-    -v "${PRIVATE_CONFIG}":/tmp/docker-mailserver \
     -v "$(pwd)/test/test-files":/tmp/docker-mailserver-test:ro \
     -e SMTP_ONLY=1 \
     -e PERMIT_DOCKER=network \


### PR DESCRIPTION
# Description

This PR fixes a bug, where checksum calculation was done/tried, when there were no files to monitor.

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #2775

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
