### PR TITLE
tests: Wait at least 30 seconds before checking the health state of the container

### DIFF
--- a/test/tests.bats
+++ b/test/tests.bats
@@ -4,6 +4,7 @@ export IMAGE_NAME
 IMAGE_NAME="${NAME}"
 
 setup_file() {
+  export START_TIME
   local PRIVATE_CONFIG
   PRIVATE_CONFIG=$(duplicate_config_for_container . mail)
   mv "${PRIVATE_CONFIG}/user-patches/user-patches.sh" "${PRIVATE_CONFIG}/user-patches.sh"
@@ -41,7 +42,7 @@ setup_file() {
     --health-cmd "ss --listening --tcp | grep -P 'LISTEN.+:smtp' || exit 1" \
     "${NAME}"
 
-  export START_TIME=$(date +%s)
+  START_TIME=$(date +%s)
   wait_for_finished_setup_in_container mail
 
   # generate accounts after container has been started

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -41,6 +41,7 @@ setup_file() {
     --health-cmd "ss --listening --tcp | grep -P 'LISTEN.+:smtp' || exit 1" \
     "${NAME}"
 
+  export START_TIME=$(date +%s)
   wait_for_finished_setup_in_container mail
 
   # generate accounts after container has been started
@@ -110,6 +111,12 @@ teardown_file() {
 # Be careful with re-locating this test if earlier tests could potentially fail it by
 # triggering the `changedetector` service.
 @test "checking container healthcheck" {
+  local NOW=$(date +%s)
+  # ensure, that at least 30 seconds have passed since container start
+  while (( NOW - START_TIME < 31 )); do
+    sleep 1
+    NOW=$(date +%s)
+  done
   run bash -c "docker inspect mail | jq -r '.[].State.Health.Status'"
   assert_output "healthy"
   assert_success

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -112,7 +112,8 @@ teardown_file() {
 # Be careful with re-locating this test if earlier tests could potentially fail it by
 # triggering the `changedetector` service.
 @test "checking container healthcheck" {
-  local NOW=$(date +%s)
+  local NOW
+  NOW=$(date +%s)
   # ensure, that at least 30 seconds have passed since container start
   while (( NOW - START_TIME < 31 )); do
     sleep 1


### PR DESCRIPTION
# Description

This PR fixes failed health-checks like [this](https://github.com/docker-mailserver/docker-mailserver/actions/runs/3076842772/jobs/4971288987#step:5:227), when the CI is faster than 30 seconds when running the health check (container isn't healthy yet at this point --> first health check is run after 30 seconds):

```
not ok 219 checking container healthcheck in 113ms
# (from function `assert_output' in file test/test_helper/bats-assert/src/assert_output.bash, line 194,
#  in test file test/tests.bats, line 114)
#   `assert_output "healthy"' failed
#
# -- output differs --
# expected : healthy
# actual   : starting
```

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
