### PR TITLE
add `outputs` to `workflow_call` on `generic_build`

### DIFF
--- a/.github/workflows/generic_build.yml
+++ b/.github/workflows/generic_build.yml
@@ -7,6 +7,11 @@ on:
         required: false
         type: string
         default: linux/amd64
+    outputs:
+      build-cache-key:
+        description: The cache key to use when restoring an image later
+        value: ${{ jobs.build-image.outputs.build-cache-key }}
+
 
 permissions:
   contents: read


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
Looking at https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-outputs-from-a-reusable-workflow, we can see that we need to manually set the outputs for a whole generic workflow. This commit fixes an issue where the cache key was not set properly as the input was empty (because the output of the previous job was not actually set).

<!-- Link the issue which will be fixed (if any) here: -->
For reference, see https://github.com/docker-mailserver/docker-mailserver/pull/2772#issuecomment-1248008577

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
