### PR TITLE
scripts: set nofile for fail2ban process

### DIFF
--- a/target/scripts/wrapper/fail2ban-wrapper.sh
+++ b/target/scripts/wrapper/fail2ban-wrapper.sh
@@ -20,6 +20,11 @@ trap "/usr/bin/fail2ban-client stop" SIGINT
 trap "/usr/bin/fail2ban-client stop" SIGTERM
 trap "/usr/bin/fail2ban-client reload" SIGHUP
 
+# fail2ban calls close_range(0, $OPEN_MAX, ..) which causes it to hang on startup
+# in some containers.
+# fixed in 535a982dcc of fail2ban - delete once debian has the fix:
+ulimit -n 1024
+
 /usr/bin/fail2ban-client start
 sleep 5
 


### PR DESCRIPTION
# Description

Fail2ban closes all fds on startup using `OPEN_MAX` (nofile) to determine the range.
In some Docker environments, nofile is set ridiculously high.
Then, fail2ban-server is busy closing files on startup and effectively hangs.

The problem is addressed upstream. Introduce a workaround until the fix trickles down.

Fixes #2781

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
