### PR TITLE
Add ability to build with Dovecot community repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@
 
 FROM docker.io/debian:11-slim AS stage-base
 
-ARG LOG_LEVEL=trace
 ARG DEBIAN_FRONTEND=noninteractive
+ARG DOVECOT_COMMUNITY_REPO=0
+ARG LOG_LEVEL=trace
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -107,10 +107,10 @@ function _install_fail2ban
 
   _log 'debug' 'Installing Fail2ban'
 
-  gpg --keyserver ${FAIL2BAN_GPG_PUBLIC_KEY_SERVER} --recv-keys ${FAIL2BAN_GPG_PUBLIC_KEY_ID} 2>&1
+  gpg --keyserver "${FAIL2BAN_GPG_PUBLIC_KEY_SERVER}" --recv-keys "${FAIL2BAN_GPG_PUBLIC_KEY_ID}" 2>&1
 
-  curl -Lkso fail2ban.deb ${FAIL2BAN_DEB_URL}
-  curl -Lkso fail2ban.deb.asc ${FAIL2BAN_DEB_ASC_URL}
+  curl -Lkso fail2ban.deb "${FAIL2BAN_DEB_URL}"
+  curl -Lkso fail2ban.deb.asc "${FAIL2BAN_DEB_ASC_URL}"
 
   FINGERPRINT=$(LANG=C gpg --verify fail2ban.deb.asc fail2ban.deb 2>&1 | sed -n 's#Primary key fingerprint: \(.*\)#\1#p')
 

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -105,6 +105,8 @@ function _install_fail2ban
   local FAIL2BAN_GPG_PUBLIC_KEY_ID='0x683BF1BEBD0A882C'
   local FAIL2BAN_GPG_PUBLIC_KEY_SERVER='hkps://keyserver.ubuntu.com'
 
+  _log 'debug' 'Installing Fail2ban'
+
   gpg --keyserver ${FAIL2BAN_GPG_PUBLIC_KEY_SERVER} --recv-keys ${FAIL2BAN_GPG_PUBLIC_KEY_ID} 2>&1
 
   curl -Lkso fail2ban.deb ${FAIL2BAN_DEB_URL}

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -55,7 +55,7 @@ function _install_packages
 
   ANTI_VIRUS_SPAM_PACKAGES=(
     amavisd-new clamav clamav-daemon
-    fail2ban pyzor razor spamassassin
+    pyzor razor spamassassin
   )
 
   CODECS_PACKAGES=(
@@ -97,6 +97,37 @@ function _install_packages
     "${MAIL_PROGRAMS_PACKAGES[@]}"
 }
 
+function _install_fail2ban
+{
+  local FAIL2BAN_DEB_URL='https://github.com/fail2ban/fail2ban/releases/download/0.11.2/fail2ban_0.11.2-1.upstream1_all.deb'
+  local FAIL2BAN_DEB_ASC_URL="${FAIL2BAN_DEB_URL}.asc"
+  local FAIL2BAN_GPG_FINGERPRINT='8738 559E 26F6 71DF 9E2C  6D9E 683B F1BE BD0A 882C'
+  local FAIL2BAN_GPG_PUBLIC_KEY_ID='0x683BF1BEBD0A882C'
+  local FAIL2BAN_GPG_PUBLIC_KEY_SERVER='hkps://keyserver.ubuntu.com'
+
+  gpg --keyserver ${FAIL2BAN_GPG_PUBLIC_KEY_SERVER} --recv-keys ${FAIL2BAN_GPG_PUBLIC_KEY_ID} 2>&1
+
+  curl -Lkso fail2ban.deb ${FAIL2BAN_DEB_URL}
+  curl -Lkso fail2ban.deb.asc ${FAIL2BAN_DEB_ASC_URL}
+
+  FINGERPRINT=$(LANG=C gpg --verify fail2ban.deb.asc fail2ban.deb 2>&1 | sed -n 's#Primary key fingerprint: \(.*\)#\1#p')
+
+  if [[ -z ${FINGERPRINT} ]]
+  then
+    echo 'ERROR: Invalid GPG signature!' >&2
+    exit 1
+  fi
+
+  if [[ ${FINGERPRINT} != "${FAIL2BAN_GPG_FINGERPRINT}" ]]
+  then
+    echo "ERROR: Wrong GPG fingerprint!" >&2
+    exit 1
+  fi
+
+  dpkg -i fail2ban.deb 2>&1
+  rm fail2ban.deb fail2ban.deb.asc
+}
+
 function _post_installation_steps
 {
   _log 'debug' 'Running post-installation steps (cleanup)'
@@ -109,4 +140,5 @@ function _post_installation_steps
 _pre_installation_steps
 _install_postfix
 _install_packages
+_install_fail2ban
 _post_installation_steps


### PR DESCRIPTION
# Description

This PR adds the ability, to use the latest Dovecot packages from the community repository. For this, the build argument `DOVECOT_COMMUNITY_REPO=1` must be used.

The current version for Dovecot in the debian repository is `2.3.13`. In the community repository it is `2.3.19.1`.

There shouldn't be any problems for existing setups switching to the community repository, as the version gap is only minor. However to be safe, we can wait for the next DMS major release, to make the community repository the default.

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
