### PR TITLE
docs: add note about Docker version when building

### DIFF
--- a/docs/content/examples/tutorials/docker-build.md
+++ b/docs/content/examples/tutorials/docker-build.md
@@ -25,6 +25,22 @@ Retrieving the git submodules will fix the error:
 COPY failed: file not found in build context or excluded by .dockerignore: stat target/docker-configomat/configomat.sh: file does not exist
 ```
 
-### Docker Version
+### About Docker
+
+#### Version
 
 We make use of build-features that require a recent version of Docker. Depending on your distribution, please have a look at [the official installation documentation for Docker](https://docs.docker.com/engine/install/) to get the latest version. Otherwise, you may encounter issues, for example with the `--link` flag for a `#!dockerfile COPY` command.
+
+#### Environment
+
+If you are not using `make` to build the image, note that you will need to provide `DOCKER_BUILDKIT=1` to the `docker build` command for the build to succeed.
+
+#### Build Arguments
+
+The `Dockerfile` takes additional, so-called build arguments. These are
+
+1. `VCS_VERSION`: the image version (default = edge)
+2. `VCS_REVISION`: the image revision (default = unknown)
+
+When using `make` to build the image, these are filled with proper values. You can build the image without supplying these arguments just fine though.
+

--- a/docs/content/examples/tutorials/docker-build.md
+++ b/docs/content/examples/tutorials/docker-build.md
@@ -29,7 +29,7 @@ COPY failed: file not found in build context or excluded by .dockerignore: stat 
 
 #### Version
 
-We make use of build-features that require a recent version of Docker. Depending on your distribution, please have a look at [the official installation documentation for Docker](https://docs.docker.com/engine/install/) to get the latest version. Otherwise, you may encounter issues, for example with the `--link` flag for a `#!dockerfile COPY` command.
+We make use of build-features that require a recent version of Docker. Depending on your distribution, please have a look at [the official installation documentation for Docker](https://docs.docker.com/engine/install/) to get the latest version. Otherwise, you may encounter issues, for example with the `--link` flag for a [`#!dockerfile COPY`]((https://docs.docker.com/engine/reference/builder/#copy) command.
 
 #### Environment
 

--- a/docs/content/examples/tutorials/docker-build.md
+++ b/docs/content/examples/tutorials/docker-build.md
@@ -4,6 +4,8 @@ title: 'Tutorials | Docker Build'
 
 ## Building your own Docker image
 
+### Submodules
+
 You'll need to retrieve the git submodules prior to building your own Docker image. From within your copy of the git repo run the following to retrieve the submodules and build the Docker image:
 
 ```sh
@@ -12,11 +14,17 @@ docker build -t mailserver/docker-mailserver .
 ```
 
 Or, you can clone and retrieve the submodules in one command:
+
 ```sh
 git clone --recurse-submodules https://github.com/docker-mailserver/docker-mailserver
 ```
 
 Retrieving the git submodules will fix the error:
-```
+
+```txt
 COPY failed: file not found in build context or excluded by .dockerignore: stat target/docker-configomat/configomat.sh: file does not exist
 ```
+
+### Docker Version
+
+We make use of build-features that require a recent version of Docker. Depending on your distribution, please have a look at [the official installation documentation for Docker](https://docs.docker.com/engine/install/) to get the latest version. Otherwise, you may encounter issues, for example with the `--link` flag for a `#!dockerfile COPY` command.

--- a/docs/content/examples/tutorials/docker-build.md
+++ b/docs/content/examples/tutorials/docker-build.md
@@ -29,7 +29,7 @@ COPY failed: file not found in build context or excluded by .dockerignore: stat 
 
 #### Version
 
-We make use of build-features that require a recent version of Docker. Depending on your distribution, please have a look at [the official installation documentation for Docker](https://docs.docker.com/engine/install/) to get the latest version. Otherwise, you may encounter issues, for example with the `--link` flag for a [`#!dockerfile COPY`]((https://docs.docker.com/engine/reference/builder/#copy) command.
+We make use of build-features that require a recent version of Docker. Depending on your distribution, please have a look at [the official installation documentation for Docker](https://docs.docker.com/engine/install/) to get the latest version. Otherwise, you may encounter issues, for example with the `--link` flag for a [`#!dockerfile COPY`](https://docs.docker.com/engine/reference/builder/#copy) command.
 
 #### Environment
 


### PR DESCRIPTION
# Description

See #2791. Adds a note that we require a recent version of Docker when building.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
