### PR TITLE
Dockerfile: use heredocs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG DOVECOT_COMMUNITY_REPO=0
 ARG LOG_LEVEL=trace
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 
 # -----------------------------------------------
 # --- Install Basic Software --------------------
@@ -31,13 +31,14 @@ RUN chmod +x /usr/local/bin/sedfile
 # --- ClamAV & FeshClam -------------------------
 # -----------------------------------------------
 
-RUN \
-  echo '0 */6 * * * clamav /usr/bin/freshclam --quiet' >/etc/cron.d/clamav-freshclam && \
-  chmod 644 /etc/clamav/freshclam.conf && \
-  sedfile -i 's/Foreground false/Foreground true/g' /etc/clamav/clamd.conf && \
-  mkdir /var/run/clamav && \
-  chown -R clamav:root /var/run/clamav && \
+RUN <<EOF
+  echo '0 */6 * * * clamav /usr/bin/freshclam --quiet' >/etc/cron.d/clamav-freshclam
+  chmod 644 /etc/clamav/freshclam.conf
+  sedfile -i 's/Foreground false/Foreground true/g' /etc/clamav/clamd.conf
+  mkdir /var/run/clamav
+  chown -R clamav:root /var/run/clamav
   rm -rf /var/log/clamav/
+EOF
 
 # Copy over latest DB updates from official ClamAV image. Better than running `freshclam` (which requires extra RAM during build)
 # hadolint ignore=DL3021
@@ -54,14 +55,15 @@ RUN chmod 0 /etc/cron.d/dovecot-purge.disabled
 WORKDIR /usr/share/dovecot
 
 # hadolint ignore=SC2016,SC2086,SC2069
-RUN \
-  sedfile -i -e 's/include_try \/usr\/share\/dovecot\/protocols\.d/include_try \/etc\/dovecot\/protocols\.d/g' /etc/dovecot/dovecot.conf && \
-  sedfile -i -e 's/#mail_plugins = \$mail_plugins/mail_plugins = \$mail_plugins sieve/g' /etc/dovecot/conf.d/15-lda.conf && \
-  sedfile -i -e 's/^.*lda_mailbox_autocreate.*/lda_mailbox_autocreate = yes/g' /etc/dovecot/conf.d/15-lda.conf && \
-  sedfile -i -e 's/^.*lda_mailbox_autosubscribe.*/lda_mailbox_autosubscribe = yes/g' /etc/dovecot/conf.d/15-lda.conf && \
-  sedfile -i -e 's/^.*postmaster_address.*/postmaster_address = '${POSTMASTER_ADDRESS:="postmaster@domain.com"}'/g' /etc/dovecot/conf.d/15-lda.conf && \
-  mkdir -p /usr/lib/dovecot/sieve-pipe /usr/lib/dovecot/sieve-filter /usr/lib/dovecot/sieve-global && \
+RUN <<EOF
+  sedfile -i -e 's/include_try \/usr\/share\/dovecot\/protocols\.d/include_try \/etc\/dovecot\/protocols\.d/g' /etc/dovecot/dovecot.conf
+  sedfile -i -e 's/#mail_plugins = \$mail_plugins/mail_plugins = \$mail_plugins sieve/g' /etc/dovecot/conf.d/15-lda.conf
+  sedfile -i -e 's/^.*lda_mailbox_autocreate.*/lda_mailbox_autocreate = yes/g' /etc/dovecot/conf.d/15-lda.conf
+  sedfile -i -e 's/^.*lda_mailbox_autosubscribe.*/lda_mailbox_autosubscribe = yes/g' /etc/dovecot/conf.d/15-lda.conf
+  sedfile -i -e 's/^.*postmaster_address.*/postmaster_address = '${POSTMASTER_ADDRESS:="postmaster@domain.com"}'/g' /etc/dovecot/conf.d/15-lda.conf
+  mkdir -p /usr/lib/dovecot/sieve-pipe /usr/lib/dovecot/sieve-filter /usr/lib/dovecot/sieve-global
   chmod 755 -R /usr/lib/dovecot/sieve-pipe /usr/lib/dovecot/sieve-filter /usr/lib/dovecot/sieve-global
+EOF
 
 # -----------------------------------------------
 # --- LDAP & SpamAssassin's Cron ----------------
@@ -77,13 +79,12 @@ COPY \
   /etc/postfix/
 
 # hadolint ignore=SC2016
-RUN \
-  sedfile -i -r 's/^(CRON)=0/\1=1/g' /etc/default/spamassassin && \
-  sedfile -i -r 's/^\$INIT restart/supervisorctl restart amavis/g' \
-    /etc/spamassassin/sa-update-hooks.d/amavisd-new && \
-  mkdir -p /etc/spamassassin/kam/ && \
-  curl -sSfLo /etc/spamassassin/kam/kam.sa-channels.mcgrail.com.key \
-    https://mcgrail.com/downloads/kam.sa-channels.mcgrail.com.key
+RUN <<EOF
+  sedfile -i -r 's/^(CRON)=0/\1=1/g' /etc/default/spamassassin
+  sedfile -i -r 's/^\$INIT restart/supervisorctl restart amavis/g' /etc/spamassassin/sa-update-hooks.d/amavisd-new
+  mkdir -p /etc/spamassassin/kam/
+  curl -sSfLo /etc/spamassassin/kam/kam.sa-channels.mcgrail.com.key https://mcgrail.com/downloads/kam.sa-channels.mcgrail.com.key
+EOF
 
 # -----------------------------------------------
 # --- PostSRSD, Postgrey & Amavis ---------------
@@ -92,40 +93,52 @@ RUN \
 COPY target/postsrsd/postsrsd /etc/default/postsrsd
 COPY target/postgrey/postgrey /etc/default/postgrey
 COPY target/postgrey/postgrey.init /etc/init.d/postgrey
-RUN \
-  chmod 755 /etc/init.d/postgrey && \
-  mkdir /var/run/postgrey && \
-  chown postgrey:postgrey /var/run/postgrey && \
+RUN <<EOF
+  chmod 755 /etc/init.d/postgrey
+  mkdir /var/run/postgrey
+  chown postgrey:postgrey /var/run/postgrey
   curl -Lsfo /etc/postgrey/whitelist_clients https://postgrey.schweikert.ch/pub/postgrey_whitelist_clients
+EOF
 
 COPY target/amavis/conf.d/* /etc/amavis/conf.d/
-RUN \
-  sedfile -i -r 's/#(@|   \\%)bypass/\1bypass/g' /etc/amavis/conf.d/15-content_filter_mode && \
+RUN <<EOF
+  sedfile -i -r 's/#(@|   \\%)bypass/\1bypass/g' /etc/amavis/conf.d/15-content_filter_mode
   # add users clamav and amavis to each others group
-  adduser clamav amavis && \
-  adduser amavis clamav && \
+  adduser clamav amavis
+  adduser amavis clamav
   # no syslog user in Debian compared to Ubuntu
-  adduser --system syslog && \
-  useradd -u 5000 -d /home/docker -s /bin/bash -p "$(echo docker | openssl passwd -1 -stdin)" docker && \
-  echo "0 4 * * * /usr/local/bin/virus-wiper" | crontab - && \
+  adduser --system syslog
+  useradd -u 5000 -d /home/docker -s /bin/bash -p "$(echo docker | openssl passwd -1 -stdin)" docker
+  echo "0 4 * * * /usr/local/bin/virus-wiper" | crontab -
   chmod 644 /etc/amavis/conf.d/*
+EOF
 
 # overcomplication necessary for CI
-RUN \
-  for _ in {1..10}; do su - amavis -c "razor-admin -create" ; sleep 3 ; \
-  if su - amavis -c "razor-admin -register" ; then { EC=0 ; break ; } ; \
-  else EC=${?} ; fi ; done ; (exit ${EC})
+RUN <<EOF
+  for _ in {1..10}; do
+    su - amavis -c "razor-admin -create"
+    sleep 3
+    if su - amavis -c "razor-admin -register"; then
+      EC=0
+      break
+    else
+      EC=${?}
+    fi
+  done
+  exit ${EC}
+EOF
 
 # -----------------------------------------------
 # --- Fail2Ban, DKIM & DMARC --------------------
 # -----------------------------------------------
 
 COPY target/fail2ban/jail.local /etc/fail2ban/jail.local
-RUN \
-  ln -s /var/log/mail/mail.log /var/log/mail.log && \
+RUN <<EOF
+  ln -s /var/log/mail/mail.log /var/log/mail.log
   # disable sshd jail
-  rm /etc/fail2ban/jail.d/defaults-debian.conf && \
+  rm /etc/fail2ban/jail.d/defaults-debian.conf
   mkdir /var/run/fail2ban
+EOF
 
 COPY target/opendkim/opendkim.conf /etc/opendkim.conf
 COPY target/opendkim/default-opendkim /etc/default/opendkim
@@ -157,40 +170,42 @@ COPY \
   target/postfix/sender_login_maps.pcre \
   /etc/postfix/maps/
 
-RUN \
-  : >/etc/aliases && \
-  sedfile -i 's/START_DAEMON=no/START_DAEMON=yes/g' /etc/default/fetchmail && \
+RUN <<EOF
+  : >/etc/aliases
+  sedfile -i 's/START_DAEMON=no/START_DAEMON=yes/g' /etc/default/fetchmail
   mkdir /var/run/fetchmail && chown fetchmail /var/run/fetchmail
+EOF
 
 # -----------------------------------------------
 # --- Logs --------------------------------------
 # -----------------------------------------------
 
-RUN \
-  sedfile -i -r "/^#?compress/c\compress\ncopytruncate" /etc/logrotate.conf && \
-  mkdir -p /var/log/mail && \
-  chown syslog:root /var/log/mail && \
-  touch /var/log/mail/clamav.log && \
-  chown -R clamav:root /var/log/mail/clamav.log && \
-  touch /var/log/mail/freshclam.log && \
-  chown -R clamav:root /var/log/mail/freshclam.log && \
-  sedfile -i -r 's|/var/log/mail|/var/log/mail/mail|g' /etc/rsyslog.conf && \
-  sedfile -i -r 's|;auth,authpriv.none|;mail.none;mail.error;auth,authpriv.none|g' /etc/rsyslog.conf && \
-  sedfile -i -r 's|LogFile /var/log/clamav/|LogFile /var/log/mail/|g' /etc/clamav/clamd.conf && \
-  sedfile -i -r 's|UpdateLogFile /var/log/clamav/|UpdateLogFile /var/log/mail/|g' /etc/clamav/freshclam.conf && \
-  sedfile -i -r 's|/var/log/clamav|/var/log/mail|g' /etc/logrotate.d/clamav-daemon && \
-  sedfile -i -r 's|invoke-rc.d.*|/usr/bin/supervisorctl signal hup clamav >/dev/null \|\| true|g' /etc/logrotate.d/clamav-daemon && \
-  sedfile -i -r 's|/var/log/clamav|/var/log/mail|g' /etc/logrotate.d/clamav-freshclam && \
-  sedfile -i -r '/postrotate/,/endscript/d' /etc/logrotate.d/clamav-freshclam && \
-  sedfile -i -r 's|/var/log/mail|/var/log/mail/mail|g' /etc/logrotate.d/rsyslog && \
-  sedfile -i -r '/\/var\/log\/mail\/mail.log/d' /etc/logrotate.d/rsyslog && \
+RUN <<EOF
+  sedfile -i -r "/^#?compress/c\compress\ncopytruncate" /etc/logrotate.conf
+  mkdir -p /var/log/mail
+  chown syslog:root /var/log/mail
+  touch /var/log/mail/clamav.log
+  chown -R clamav:root /var/log/mail/clamav.log
+  touch /var/log/mail/freshclam.log
+  chown -R clamav:root /var/log/mail/freshclam.log
+  sedfile -i -r 's|/var/log/mail|/var/log/mail/mail|g' /etc/rsyslog.conf
+  sedfile -i -r 's|;auth,authpriv.none|;mail.none;mail.error;auth,authpriv.none|g' /etc/rsyslog.conf
+  sedfile -i -r 's|LogFile /var/log/clamav/|LogFile /var/log/mail/|g' /etc/clamav/clamd.conf
+  sedfile -i -r 's|UpdateLogFile /var/log/clamav/|UpdateLogFile /var/log/mail/|g' /etc/clamav/freshclam.conf
+  sedfile -i -r 's|/var/log/clamav|/var/log/mail|g' /etc/logrotate.d/clamav-daemon
+  sedfile -i -r 's|invoke-rc.d.*|/usr/bin/supervisorctl signal hup clamav >/dev/null \|\| true|g' /etc/logrotate.d/clamav-daemon
+  sedfile -i -r 's|/var/log/clamav|/var/log/mail|g' /etc/logrotate.d/clamav-freshclam
+  sedfile -i -r '/postrotate/,/endscript/d' /etc/logrotate.d/clamav-freshclam
+  sedfile -i -r 's|/var/log/mail|/var/log/mail/mail|g' /etc/logrotate.d/rsyslog
+  sedfile -i -r '/\/var\/log\/mail\/mail.log/d' /etc/logrotate.d/rsyslog
   # prevent syslog logrotate warnings
-  sedfile -i -e 's/\(printerror "could not determine current runlevel"\)/#\1/' /usr/sbin/invoke-rc.d && \
-  sedfile -i -e 's/^\(POLICYHELPER=\).*/\1/' /usr/sbin/invoke-rc.d && \
+  sedfile -i -e 's/\(printerror "could not determine current runlevel"\)/#\1/' /usr/sbin/invoke-rc.d
+  sedfile -i -e 's/^\(POLICYHELPER=\).*/\1/' /usr/sbin/invoke-rc.d
   # prevent syslog warning about imklog permissions
-  sedfile -i -e 's/^module(load=\"imklog\")/#module(load=\"imklog\")/' /etc/rsyslog.conf && \
+  sedfile -i -e 's/^module(load=\"imklog\")/#module(load=\"imklog\")/' /etc/rsyslog.conf
   # prevent email when /sbin/init or init system is not existing
   sedfile -i -e 's|invoke-rc.d rsyslog rotate > /dev/null|/usr/bin/supervisorctl signal hup rsyslog >/dev/null|g' /usr/lib/rsyslog/rsyslog-rotate
+EOF
 
 # -----------------------------------------------
 # --- Logwatch ----------------------------------
@@ -209,14 +224,15 @@ COPY target/supervisor/conf.d/* /etc/supervisor/conf.d/
 # --- Scripts & Miscellaneous--------------------
 # -----------------------------------------------
 
-RUN \
-  rm -rf /usr/share/locale/* && \
-  rm -rf /usr/share/man/* && \
-  rm -rf /usr/share/doc/* && \
-  touch /var/log/auth.log && \
-  update-locale && \
-  rm /etc/postsrsd.secret && \
+RUN <<EOF
+  rm -rf /usr/share/locale/*
+  rm -rf /usr/share/man/*
+  rm -rf /usr/share/doc/*
+  touch /var/log/auth.log
+  update-locale
+  rm /etc/postsrsd.secret
   rm /etc/cron.daily/00logwatch
+EOF
 
 COPY VERSION /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN /bin/bash /build/packages.sh
 COPY target/bin/sedfile /usr/local/bin/sedfile
 RUN chmod +x /usr/local/bin/sedfile
 
-
 # -----------------------------------------------
 # --- ClamAV & FeshClam -------------------------
 # -----------------------------------------------


### PR DESCRIPTION
# Description

Since version `1.3-lab` of Dockerfile, heredoc syntax is available.

This PR converts the countless `&& \` lines into better readable heredocs.

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->


## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
