### PR TITLE
ci: update stale bot to include only assigned

### DIFF
--- a/.github/workflows/handle_stalled.yml
+++ b/.github/workflows/handle_stalled.yml
@@ -27,7 +27,7 @@ jobs:
           stale-issue-message: |
             This issue has become stale because it has been open for 20 days without activity.
             This issue will be closed in 10 days automatically unless:
-            
+
             - a maintainer removes the `meta/stale` label or adds the `stale-bot/ignore` label
             - new activity occurs, such as a new comment
           close-issue-label: "meta/closed due to age or inactivity"

--- a/.github/workflows/handle_stalled.yml
+++ b/.github/workflows/handle_stalled.yml
@@ -21,12 +21,13 @@ jobs:
           days-before-stale: 20
           days-before-close: 10
 
+          include-only-assigned: true
           exempt-issue-labels: stale-bot/ignore
           stale-issue-label: meta/stale
           stale-issue-message: |
             This issue has become stale because it has been open for 20 days without activity.
             This issue will be closed in 10 days automatically unless:
-
+            
             - a maintainer removes the `meta/stale` label or adds the `stale-bot/ignore` label
             - new activity occurs, such as a new comment
           close-issue-label: "meta/closed due to age or inactivity"


### PR DESCRIPTION
# Description

feature idea (i'm fine if this gets rejected as well): `include-only-assigned` issues for stale bot workflow.

Instead of writing this myself i link to the comment that basically states my opinion: https://github.com/actions/stale/issues/596#issuecomment-1059949652

> Mainly I was just looking for a way to reduce spam'ish updates. For most of the projects I work with there's little point in the action/bot updating issues which aren't assigned (like this one). We would rather that it was more of a reminder to assignees that they've got something outstanding which they should be working on.

<!-- Link the issue which will be fixed (if any) here: -->


## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
