### PR TITLE
tests: Wait until container is not in starting state anymore, before running health check

### DIFF
--- a/test/tests.bats
+++ b/test/tests.bats
@@ -4,7 +4,6 @@ export IMAGE_NAME
 IMAGE_NAME="${NAME}"
 
 setup_file() {
-  export START_TIME
   local PRIVATE_CONFIG
   PRIVATE_CONFIG=$(duplicate_config_for_container . mail)
   mv "${PRIVATE_CONFIG}/user-patches/user-patches.sh" "${PRIVATE_CONFIG}/user-patches.sh"
@@ -42,7 +41,6 @@ setup_file() {
     --health-cmd "ss --listening --tcp | grep -P 'LISTEN.+:smtp' || exit 1" \
     "${NAME}"
 
-  START_TIME=$(date +%s)
   wait_for_finished_setup_in_container mail
 
   # generate accounts after container has been started
@@ -112,14 +110,11 @@ teardown_file() {
 # Be careful with re-locating this test if earlier tests could potentially fail it by
 # triggering the `changedetector` service.
 @test "checking container healthcheck" {
-  local NOW
-  NOW=$(date +%s)
-  # ensure, that at least 33 seconds have passed since container start
-  while (( NOW - START_TIME < 34 )); do
+  # ensure, that at least 30 seconds have passed since container start
+  while [[ "$(docker inspect --format='{{.State.Health.Status}}' mail)" == "starting" ]]; do
     sleep 1
-    NOW=$(date +%s)
   done
-  run bash -c "docker inspect mail | jq -r '.[].State.Health.Status'"
+  run docker inspect --format='{{.State.Health.Status}}' mail
   assert_output "healthy"
   assert_success
 }

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -114,8 +114,8 @@ teardown_file() {
 @test "checking container healthcheck" {
   local NOW
   NOW=$(date +%s)
-  # ensure, that at least 30 seconds have passed since container start
-  while (( NOW - START_TIME < 31 )); do
+  # ensure, that at least 33 seconds have passed since container start
+  while (( NOW - START_TIME < 34 )); do
     sleep 1
     NOW=$(date +%s)
   done


### PR DESCRIPTION
# Description

It seams, that Docker does not start a container immediately, after successfully running the `docker run..` command. Therefor the 30 seconds wait time for the health test can be to low. ~Hopefully, adding three more seconds solve that issue.~

<!-- Link the issue which will be fixed (if any) here: -->
Fixes: https://github.com/docker-mailserver/docker-mailserver/actions/runs/3162276455/jobs/5148743130#step:5:227

This fix now waits, until docker itself reports, that the container is not in the starting state anymore.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
