### PR TITLE
tests(fix): Avoid introducing CRLF into `postfix-accounts.cf` during setup

### DIFF
--- a/test/tests.bats
+++ b/test/tests.bats
@@ -44,8 +44,8 @@ setup_file() {
   wait_for_finished_setup_in_container mail
 
   # generate accounts after container has been started
-  docker run --rm -e MAIL_USER=added@localhost.localdomain -e MAIL_PASS=mypassword -t "${NAME}" /bin/sh -c 'echo "${MAIL_USER}|$(doveadm pw -s SHA512-CRYPT -u ${MAIL_USER} -p ${MAIL_PASS})"' >> "${PRIVATE_CONFIG}/postfix-accounts.cf"
-  docker exec mail addmailuser pass@localhost.localdomain 'may be \a `p^a.*ssword'
+  docker exec mail setup email add 'added@localhost.localdomain' 'mypassword'
+  docker exec mail setup email add 'pass@localhost.localdomain' 'may be \a `p^a.*ssword'
 
   # setup sieve
   docker cp "${PRIVATE_CONFIG}/sieve/dovecot.sieve" mail:/var/mail/localhost.localdomain/user1/.dovecot.sieve


### PR DESCRIPTION
# Description

`test/tests.bats` has been extremely unreliable during the setup stage. This should finally resolve that. Big thanks to @casperklein and @georglauterbach who have helped rule out other causes to narrow it down to this.

Recent changes I introduced to `tests.bats` better surfaced change detection problems more consistently, to the point failure frequency was extremely probable. I investigated and identified the cause :tada: 

Currently when a change detection would be triggered and during processing, a `CRLF` is found and converted to a `LF`, which modifies the `postfix-accounts.cf` file, triggering another change event :grimacing: 

Marked for `v11.2.0` as it's only a change to our tests and should make existing PRs much happier :)

---

## Solution: Avoid introducing `CRLF` into config by adding accounts only via `setup email add`

There is no need for the first approach used in `tests.bats` to add an account, and it is [the culprit for causing the CRLF to appear](https://github.com/docker-mailserver/docker-mailserver/pull/2815#discussion_r990740402).

It is unclear why a `CRLF` is added to the end of the file, only when using `docker run` with the DMS docker image to output a `postfix-accounts.cf` config line via `echo` and using that stdout result to append (`>>`) to the `postfix-accounts.cf`.

It did not seem to occur via `docker exec` and performing a similar command within the container to update the file internally, nor without docker by updating `postfix-accounts.cf` in the same manner directly to the file at the volume mount location.

## Additional Details

### Potential run-time modification of configs intended for fixing to keep in mind

In future, the following could be considered for removal, which may require better handling of the scripts (_or ideally, porting to a more capable language where this type of problem would not cause bugs when processing configs_):

https://github.com/docker-mailserver/docker-mailserver/blob/ff969509f8b9c49e399327887c9a29f6fd664b80/target/scripts/helpers/accounts.sh#L25

https://github.com/docker-mailserver/docker-mailserver/blob/ff969509f8b9c49e399327887c9a29f6fd664b80/target/scripts/helpers/accounts.sh#L32

https://github.com/docker-mailserver/docker-mailserver/blob/ff969509f8b9c49e399327887c9a29f6fd664b80/target/scripts/helpers/accounts.sh#L181

https://github.com/docker-mailserver/docker-mailserver/blob/ff969509f8b9c49e399327887c9a29f6fd664b80/target/scripts/helpers/accounts.sh#L187

https://github.com/docker-mailserver/docker-mailserver/blob/ff969509f8b9c49e399327887c9a29f6fd664b80/target/scripts/helpers/aliases.sh#L20

I do not have the time to ensure removing those modifications would not risk causing problems with our scripts that read them. We also have another issue open regarding making a copy of config files to read to avoid issues with something else modifying the file while we process it.

### History of these particular lines

- `sed -i -e '$a\' /tmp/postfix/accounts.cf` introduced in [Aug 2015 by original DMS project author](https://github.com/docker-mailserver/docker-mailserver/commit/63a7be0e975b39b72fe666a61517e32d32b98f55). No PR, but does [reference an issue the commit is meant to resolve](https://github.com/docker-mailserver/docker-mailserver/issues/13) - however I don't see anything in the discussion that looks related to it being added. I assume it's mostly specific to compatibility with shell scripts and unix utilities that expect it?
- `sed -i 's/\r//g' /tmp/docker-mailserver/postfix-accounts.cf` introduced [April 2016](https://github.com/docker-mailserver/docker-mailserver/pull/160), which [references an issue where a user experienced a bug](https://github.com/docker-mailserver/docker-mailserver/issues/159) from their `postfix-accounts.cf` having a `CRLF` present, scripts did not generate accounts in Dovecot `/etc/dovecot/userdb` properly.
- `sed -i -e "s|, |,|g" -e "s|,$||g" "${DATABASE_VIRTUAL}"` introduced in [March 2018](https://github.com/docker-mailserver/docker-mailserver/pull/897) to better support alias management (_notably `setup alias del`_) so that `,` would be normalized to always having a space suffix `, `.

Technically, if config files are only managed by our `setup` command, then there should be no need for any of these I think? Users may manually edit the files directly or have setup some other way to modify / create the configs, like the legacy `make generate-accounts` approach and what we see here in `tests.bats`.

Thus these are more a precaution / safe-guard. If we don't care about external config updates being made while the container is running, and not having change events "repair" / fix those potential issues, then we could move these into startup or `setup` fixes, or into the docs.

Otherwise they're not likely to cause much trouble, they were just silently messing with this particular test file for some time. While `make generate-accounts` probably introduces CRLF as well, those were handled during startup before a checksum was made for the change detector, thus already fixed ahead of time.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
