### PR TITLE
Fetchmail cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -155,7 +155,6 @@ COPY target/opendmarc/ignore.hosts /etc/opendmarc/ignore.hosts
 # https://bugs.launchpad.net/spf-engine/+bug/1896912
 RUN echo 'Reason_Message = Message {rejectdefer} due to: {spf}.' >>/etc/postfix-policyd-spf-python/policyd-spf.conf
 
-COPY target/fetchmail/fetchmailrc /etc/fetchmailrc_general
 COPY target/postfix/main.cf target/postfix/master.cf /etc/postfix/
 
 # DH parameters for DHE cipher suites, ffdhe4096 is the official standard 4096-bit DH params now part of TLS 1.3

--- a/target/fetchmail/fetchmailrc
+++ b/target/fetchmail/fetchmailrc
@@ -1,7 +1,0 @@
-# General options
-
-set daemon 300
-set syslog
-
-# Fetch rules
-

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -1095,12 +1095,7 @@ function _setup_fetchmail
   CONFIGURATION='/tmp/docker-mailserver/fetchmail.cf'
   FETCHMAILRC='/etc/fetchmailrc'
 
-  if [[ -f ${CONFIGURATION} ]]
-  then
-    cat /etc/fetchmailrc_general "${CONFIGURATION}" >"${FETCHMAILRC}"
-  else
-    cat /etc/fetchmailrc_general >"${FETCHMAILRC}"
-  fi
+  [[ -f ${CONFIGURATION} ]] && cat "${CONFIGURATION}" >"${FETCHMAILRC}"
 
   chmod 700 "${FETCHMAILRC}"
   chown fetchmail:root "${FETCHMAILRC}"

--- a/target/supervisor/conf.d/supervisor-app.conf
+++ b/target/supervisor/conf.d/supervisor-app.conf
@@ -104,7 +104,7 @@ autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 user=fetchmail
-command=/usr/bin/fetchmail -f /etc/fetchmailrc -v --nodetach --daemon %(ENV_FETCHMAIL_POLL)s -i /var/lib/fetchmail/.fetchmail-UIDL-cache --pidfile /var/run/fetchmail/fetchmail.pid
+command=/usr/bin/fetchmail -f /etc/fetchmailrc --nodetach --daemon %(ENV_FETCHMAIL_POLL)s -i /var/lib/fetchmail/.fetchmail-UIDL-cache --pidfile /var/run/fetchmail/fetchmail.pid
 
 [program:postfix]
 startsecs=0

--- a/test/mail_fetchmail.bats
+++ b/test/mail_fetchmail.bats
@@ -31,11 +31,6 @@ function teardown_file() {
 # fetchmail
 #
 
-@test "checking fetchmail: gerneral options in fetchmailrc are loaded" {
-  run docker exec mail_fetchmail grep 'set syslog' /etc/fetchmailrc
-  assert_success
-}
-
 @test "checking fetchmail: fetchmail.cf is loaded" {
   run docker exec mail_fetchmail grep 'pop3.example.com' /etc/fetchmailrc
   assert_success

--- a/test/mail_fetchmail_parallel.bats
+++ b/test/mail_fetchmail_parallel.bats
@@ -37,16 +37,6 @@ function teardown_file() {
 # fetchmail
 #
 
-@test "checking fetchmail: gerneral options in fetchmail-1.rc are loaded" {
-  run docker exec mail_fetchmail_parallel grep 'set syslog' /etc/fetchmailrc.d/fetchmail-1.rc
-  assert_success
-}
-
-@test "checking fetchmail: gerneral options in fetchmail-2.rc are loaded" {
-  run docker exec mail_fetchmail_parallel grep 'set syslog' /etc/fetchmailrc.d/fetchmail-2.rc
-  assert_success
-}
-
 @test "checking fetchmail: fetchmail-1.rc is loaded with pop3.example.com" {
   run docker exec mail_fetchmail_parallel grep 'pop3.example.com' /etc/fetchmailrc.d/fetchmail-1.rc
   assert_success


### PR DESCRIPTION
# Description

While working on recent PRs and now using fetchmail myself, I noticed a few things that bugs me.

1. Fetchmail is heavily verbose in `mail.log`. This leads to a lot of log entries on each poll:
    <details>
    <summary>Details</summary>

    ```
    fetchmail: 6.4.16 querying pop.gmx.net (protocol POP3) at Sun Oct 23 12:31:02 2022: poll started
    Trying to connect to 212.227.17.185/995...connected.
    fetchmail: Loaded OpenSSL library 0x101010ef newer than headers 0x101010bf, trying to continue.
    fetchmail: Server certificate:
    fetchmail: Issuer Organization: T-Systems International GmbH
    fetchmail: Issuer CommonName: TeleSec ServerPass Extended Validation Class 3 CA
    fetchmail: Subject CommonName: mail.gmx.net
    fetchmail: Subject Alternative Name: mail.gmx.net
    fetchmail: Subject Alternative Name: mail.gmx.de
    fetchmail: Subject Alternative Name: smtp.gmx.net
    fetchmail: Subject Alternative Name: smtp.gmx.de
    fetchmail: Subject Alternative Name: imap.gmx.net
    fetchmail: Subject Alternative Name: imap.gmx.de
    fetchmail: Subject Alternative Name: pop.gmx.net
    fetchmail: Subject Alternative Name: pop.gmx.de
    fetchmail: pop.gmx.net key fingerprint: 37:6D:93:28:DE:58:A2:7B:6D:61:07:76:1F:56:70:6F
    fetchmail: SSL/TLS: using protocol TLSv1.3, cipher TLS_AES_256_GCM_SHA384, 256/256 secret/processed bits
    fetchmail: POP3< +OK POP server ready H migmx006 1N6tSP-1pA9Gr1Tln-018FlG
    fetchmail: POP3> CAPA
    fetchmail: POP3< +OK Capability list follows
    fetchmail: POP3< TOP
    fetchmail: POP3< UIDL
    fetchmail: POP3< USER
    fetchmail: POP3< SASL PLAIN
    fetchmail: POP3< IMPLEMENTATION trinity
    fetchmail: POP3< .
    fetchmail: POP3> USER *****@gmx.de
    fetchmail: POP3< +OK password required for user "*****@gmx.de"
    fetchmail: POP3> PASS *
    fetchmail: POP3< +OK mailbox "*****@gmx.de" has 0 messages (0 octets) H migmx006
    fetchmail: POP3> STAT
    fetchmail: POP3< +OK 0 0
    fetchmail: No mail for *****@gmx.de at pop.gmx.net
    fetchmail: POP3> QUIT
    fetchmail: POP3< +OK POP server signing off
    fetchmail: 6.4.16 querying pop.gmx.net (protocol POP3) at Sun Oct 23 12:31:02 2022: poll completed
    fetchmail: sleeping at Sun Oct 23 12:31:02 2022 for 300 seconds
    ```

    </details>
2. There were some defaults prepended to each user supplied fetchmail config:

`set syslog`: We log to files, no reason to also log to syslog.
`set daemon 300`: We already set the interval when calling fetchmail from supervisor.

These are no useful defaults IMO and should be removed. If needed, they can be configured in a users custom fetchmail configuration.

Edit: While answering #2858 I recognized, why the `set syslog` line makes sense, and should kept?

Edit2: Having a sane default like `set daemon 300` doesn't hurt. I will undo all changes related to point 2, so only point 1 remains: https://github.com/docker-mailserver/docker-mailserver/pull/2855/commits/fb315e5213c0c0fd66ab4a0c8edd0df5fcda68c5

Edit3:  New clean PR #2859

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
