### PR TITLE
Run fetchmail not in verbose mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Changed
 
-- **build** cleaned up `Makefile` and its targets ([#2833](https://github.com/docker-mailserver/docker-mailserver/pull/2833))
+- **configuration**: Run fetchmail not in verbose mode ([#2859](https://github.com/docker-mailserver/docker-mailserver/pull/2859))
+- **build**: cleaned up `Makefile` and its targets ([#2833](https://github.com/docker-mailserver/docker-mailserver/pull/2833))
 
 ### Fixed
 

--- a/target/supervisor/conf.d/supervisor-app.conf
+++ b/target/supervisor/conf.d/supervisor-app.conf
@@ -104,7 +104,7 @@ autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 user=fetchmail
-command=/usr/bin/fetchmail -f /etc/fetchmailrc -v --nodetach --daemon %(ENV_FETCHMAIL_POLL)s -i /var/lib/fetchmail/.fetchmail-UIDL-cache --pidfile /var/run/fetchmail/fetchmail.pid
+command=/usr/bin/fetchmail -f /etc/fetchmailrc --nodetach --daemon %(ENV_FETCHMAIL_POLL)s -i /var/lib/fetchmail/.fetchmail-UIDL-cache --pidfile /var/run/fetchmail/fetchmail.pid
 
 [program:postfix]
 startsecs=0


### PR DESCRIPTION
# Description

Fetchmail is heavily verbose in `mail.log`. This leads to a lot of log entries on each poll:
<details>
<summary>Details</summary>

```
    fetchmail: 6.4.16 querying pop.gmx.net (protocol POP3) at Sun Oct 23 12:31:02 2022: poll started
    Trying to connect to 212.227.17.185/995...connected.
    fetchmail: Loaded OpenSSL library 0x101010ef newer than headers 0x101010bf, trying to continue.
    fetchmail: Server certificate:
    fetchmail: Issuer Organization: T-Systems International GmbH
    fetchmail: Issuer CommonName: TeleSec ServerPass Extended Validation Class 3 CA
    fetchmail: Subject CommonName: mail.gmx.net
    fetchmail: Subject Alternative Name: mail.gmx.net
    fetchmail: Subject Alternative Name: mail.gmx.de
    fetchmail: Subject Alternative Name: smtp.gmx.net
    fetchmail: Subject Alternative Name: smtp.gmx.de
    fetchmail: Subject Alternative Name: imap.gmx.net
    fetchmail: Subject Alternative Name: imap.gmx.de
    fetchmail: Subject Alternative Name: pop.gmx.net
    fetchmail: Subject Alternative Name: pop.gmx.de
    fetchmail: pop.gmx.net key fingerprint: 37:6D:93:28:DE:58:A2:7B:6D:61:07:76:1F:56:70:6F
    fetchmail: SSL/TLS: using protocol TLSv1.3, cipher TLS_AES_256_GCM_SHA384, 256/256 secret/processed bits
    fetchmail: POP3< +OK POP server ready H migmx006 1N6tSP-1pA9Gr1Tln-018FlG
    fetchmail: POP3> CAPA
    fetchmail: POP3< +OK Capability list follows
    fetchmail: POP3< TOP
    fetchmail: POP3< UIDL
    fetchmail: POP3< USER
    fetchmail: POP3< SASL PLAIN
    fetchmail: POP3< IMPLEMENTATION trinity
    fetchmail: POP3< .
    fetchmail: POP3> USER *****@gmx.de
    fetchmail: POP3< +OK password required for user "*****@gmx.de"
    fetchmail: POP3> PASS *
    fetchmail: POP3< +OK mailbox "*****@gmx.de" has 0 messages (0 octets) H migmx006
    fetchmail: POP3> STAT
    fetchmail: POP3< +OK 0 0
    fetchmail: No mail for *****@gmx.de at pop.gmx.net
    fetchmail: POP3> QUIT
    fetchmail: POP3< +OK POP server signing off
    fetchmail: 6.4.16 querying pop.gmx.net (protocol POP3) at Sun Oct 23 12:31:02 2022: poll completed
    fetchmail: sleeping at Sun Oct 23 12:31:02 2022 for 300 seconds
```

</details>

This PR removes the verbose option from the fetchmail command in supervisord.

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->
Fixes: too much logging

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
