### PR TITLE
setup.sh: Remove __err function

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,7 +19,6 @@ USE_SELINUX=
 USE_TTY=
 VOLUME=
 
-RED=$(echo -ne '\e[31m\e[1m')
 WHITE=$(echo -ne '\e[37m')
 ORANGE=$(echo -ne '\e[38;5;214m')
 LBLUE=$(echo -ne '\e[94m')

--- a/setup.sh
+++ b/setup.sh
@@ -27,22 +27,6 @@ RESET=$(echo -ne '\e[0m')
 
 set -euEo pipefail
 shopt -s inherit_errexit 2>/dev/null || true
-trap '__err "${BASH_SOURCE}" "${FUNCNAME[0]:-?}" "${BASH_COMMAND:-?}" "${LINENO:-?}" "${?:-?}"' ERR
-
-function __err
-{
-  [[ ${5} -gt 1 ]] && exit 1
-
-  local ERR_MSG="\n--- ${RED}UNCHECKED ERROR${RESET}"
-  ERR_MSG+="\n  - script    = ${1}"
-  ERR_MSG+="\n  - function  = ${2}"
-  ERR_MSG+="\n  - command   = ${3}"
-  ERR_MSG+="\n  - line      = ${4}"
-  ERR_MSG+="\n  - exit code = ${5}"
-  ERR_MSG+='\n\nThis should not have happened. Please file a bug report.\n'
-
-  echo -e "${ERR_MSG}"
-}
 
 function _show_local_usage
 {


### PR DESCRIPTION
# Description

This bugs me already for a while. "Unchecked error" is triggered on all errors, also on those that are expected. I think it's fine to remove this completely. `setup.sh` is not that large, that we need such a kind of debug function IMO.

```bash
# ./setup.sh alias list
[  ERROR  ]  '/tmp/docker-mailserver/postfix-virtual.cf' does not exist
[  ERROR  ]  Aborting

--- UNCHECKED ERROR
  - script    = ./setup.sh
  - function  = _run_in_new_container
  - command   = ${CRI} run --rm "${USE_TTY}" -v "${CONFIG_PATH}:${DMS_CONFIG}${USE_SELINUX}" "${IMAGE_NAME}" "${@}"
  - line      = 147
  - exit code = 1

This should not have happened. Please file a bug report.
```


<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
