### PR TITLE
Bugfix: './setup.sh email list' does not display aliases correctly

### DIFF
--- a/target/bin/listmailuser
+++ b/target/bin/listmailuser
@@ -101,7 +101,7 @@ function _alias_list_for_account
     --ignore-case
     --extended-regexp
     -e "\s${MAIL_ACCOUNT}($|,)" # match first and second sample line
-    -e ",${MAIL_ACCOUNT}($|,)"  # match third and fourth sample line
+    -e  ",${MAIL_ACCOUNT}($|,)" # match third and fourth sample line
     "${DATABASE_VIRTUAL}"
   )
 

--- a/target/bin/listmailuser
+++ b/target/bin/listmailuser
@@ -87,6 +87,7 @@ function _bytes_to_human_readable_size
 # Returns a comma delimited list of aliases associated to a recipient (ideally the recipient is a mail account):
 function _alias_list_for_account
 {
+  local GREP_OPTIONS
   local MAIL_ACCOUNT=${1}
 
 # postfix-virtual.cf sample lines:

--- a/target/bin/listmailuser
+++ b/target/bin/listmailuser
@@ -90,15 +90,9 @@ function _alias_list_for_account
   local MAIL_ACCOUNT=${1}
 
   # `__db_list_already_contains_value` would be a more reliable check:
-  function _account_has_an_alias
-  {
-    local ANY_ALIAS='\S\+\s'
-    grep -qis "^${ANY_ALIAS}.*${MAIL_ACCOUNT}" "${DATABASE_VIRTUAL}"
-  }
-
-  if _account_has_an_alias
+  if grep -qis "\s${MAIL_ACCOUNT}$" "${DATABASE_VIRTUAL}"
   then
-    grep "${MAIL_ACCOUNT}" "${DATABASE_VIRTUAL}" | awk '{print $1;}' | sed ':a;N;$!ba;s/\n/, /g'
+    grep "\s${MAIL_ACCOUNT}$" "${DATABASE_VIRTUAL}" | awk '{print $1;}' | sed ':a;N;$!ba;s/\n/, /g'
   fi
 }
 

--- a/target/bin/listmailuser
+++ b/target/bin/listmailuser
@@ -100,7 +100,7 @@ function _alias_list_for_account
   GREP_OPTIONS=(
     --ignore-case
     --extended-regexp
-    -e "\s${MAIL_ACCOUNT}($|,)" # match first and secand sample line
+    -e "\s${MAIL_ACCOUNT}($|,)" # match first and second sample line
     -e ",${MAIL_ACCOUNT}($|,)"  # match third and fourth sample line
     "${DATABASE_VIRTUAL}"
   )

--- a/target/bin/listmailuser
+++ b/target/bin/listmailuser
@@ -89,10 +89,24 @@ function _alias_list_for_account
 {
   local MAIL_ACCOUNT=${1}
 
-  # `__db_list_already_contains_value` would be a more reliable check:
-  if grep -qis "\s${MAIL_ACCOUNT}$" "${DATABASE_VIRTUAL}"
+# postfix-virtual.cf sample lines:
+#
+# all@example.com foo@example.com
+# all@example.com foo@example.com,another@example.com
+# all@example.com another@example.com,foo@example.com,yetanother@example.com
+# all@example.com another@example.com,foo@example.com
+
+  GREP_OPTIONS=(
+    --ignore-case
+    --extended-regexp
+    -e "\s${MAIL_ACCOUNT}($|,)" # match first and secand sample line
+    -e ",${MAIL_ACCOUNT}($|,)"  # match third and fourth sample line
+    "${DATABASE_VIRTUAL}"
+  )
+
+  if grep --quiet --no-messages "${GREP_OPTIONS[@]}"
   then
-    grep "\s${MAIL_ACCOUNT}$" "${DATABASE_VIRTUAL}" | awk '{print $1;}' | sed ':a;N;$!ba;s/\n/, /g'
+    grep "${GREP_OPTIONS[@]}" | awk '{print $1;}' | sed ':a;N;$!ba;s/\n/, /g'
   fi
 }
 

--- a/target/bin/listmailuser
+++ b/target/bin/listmailuser
@@ -90,12 +90,12 @@ function _alias_list_for_account
   local GREP_OPTIONS
   local MAIL_ACCOUNT=${1}
 
-# postfix-virtual.cf sample lines:
-#
-# all@example.com foo@example.com
-# all@example.com foo@example.com,another@example.com
-# all@example.com another@example.com,foo@example.com,yetanother@example.com
-# all@example.com another@example.com,foo@example.com
+  # postfix-virtual.cf sample lines:
+  #
+  # all@example.com foo@example.com
+  # all@example.com foo@example.com,another@example.com
+  # all@example.com another@example.com,foo@example.com,yetanother@example.com
+  # all@example.com another@example.com,foo@example.com
 
   GREP_OPTIONS=(
     --ignore-case


### PR DESCRIPTION
# Description

Details see [here](https://github.com/docker-mailserver/docker-mailserver/issues/2877).

Before:

```bash
./setup.sh email list
* media@example.com
    [ aliases -> facebook@example.com ]

* socialmedia@example.com
    [ aliases -> facebook@example.com ]
```

After:

```bash
./setup.sh email list
* media@example.com

* socialmedia@example.com
    [ aliases -> facebook@example.com ]
```


<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #2877

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
