### PR TITLE
fix: adjust DNSBL return code interpretation

### DIFF
--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -48,17 +48,18 @@ smtpd_helo_required = yes
 smtpd_delay_reject = yes
 smtpd_helo_restrictions = permit_mynetworks, reject_invalid_helo_hostname, permit
 smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
-smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unauth_destination, check_policy_service unix:private/policyd-spf, reject_unauth_pipelining, reject_invalid_helo_hostname, reject_non_fqdn_helo_hostname, reject_unknown_recipient_domain, reject_rbl_client zen.spamhaus.org
+smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unauth_destination, check_policy_service unix:private/policyd-spf, reject_unauth_pipelining, reject_invalid_helo_hostname, reject_non_fqdn_helo_hostname, reject_unknown_recipient_domain, reject_rbl_client zen.spamhaus.org=127.0.0.[2..11]
 smtpd_client_restrictions = permit_mynetworks, permit_sasl_authenticated, reject_unauth_destination, reject_unauth_pipelining
 smtpd_sender_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unknown_sender_domain, reject_unknown_client_hostname
 disable_vrfy_command = yes
 
 # Postscreen settings to drop zombies/open relays/spam early
 postscreen_dnsbl_action = enforce
-postscreen_dnsbl_sites = zen.spamhaus.org*3
-    bl.mailspike.net
+postscreen_dnsbl_sites =
+    zen.spamhaus.org=127.0.0.[2..11]*3
+    bl.mailspike.net=127.0.0.[2;14;13;12;11;10]
     b.barracudacentral.org*2
-    bl.spameatingmonkey.net
+    bl.spameatingmonkey.net=127.0.0.2
     dnsbl.sorbs.net
     psbl.surriel.com
     list.dnswl.org=127.0.[0..255].0*-2

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -399,7 +399,7 @@ function _setup_postgrey
   _log 'debug' 'Configuring Postgrey'
 
   sed -i -E \
-    's|, reject_rbl_client zen.spamhaus.org$|, reject_rbl_client zen.spamhaus.org, check_policy_service inet:127.0.0.1:10023|' \
+    's|, reject_rbl_client zen.spamhaus.org=127.0.0.[2..11]$|, reject_rbl_client zen.spamhaus.org=127.0.0.[2..11], check_policy_service inet:127.0.0.1:10023|' \
     /etc/postfix/main.cf
 
   sed -i -e \

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -1078,7 +1078,7 @@ function _setup_dnsbl_disable
   _log 'debug' 'Disabling postfix DNS block list (zen.spamhaus.org)'
 
   sedfile -i \
-    '/^smtpd_recipient_restrictions = / s/, reject_rbl_client zen.spamhaus.org//' \
+    '/^smtpd_recipient_restrictions = / s/, reject_rbl_client zen.spamhaus.org=127.0.0.\[2..11\]//' \
     /etc/postfix/main.cf
 
   _log 'debug' 'Disabling postscreen DNS block lists'

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -399,7 +399,7 @@ function _setup_postgrey
   _log 'debug' 'Configuring Postgrey'
 
   sedfile -i -E \
-    's|(smtpd_recipient_restrictions.*)|\1, check_policy_service inet:127.0.0.1:10023|' \
+    's|(^smtpd_recipient_restrictions =.*)|\1, check_policy_service inet:127.0.0.1:10023|' \
     /etc/postfix/main.cf
 
   sed -i -e \

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -398,8 +398,8 @@ function _setup_postgrey
 {
   _log 'debug' 'Configuring Postgrey'
 
-  sed -i -E \
-    's|, reject_rbl_client zen.spamhaus.org=127.0.0.[2..11]$|, reject_rbl_client zen.spamhaus.org=127.0.0.[2..11], check_policy_service inet:127.0.0.1:10023|' \
+  sedfile -i -E \
+    's|(smtpd_recipient_restrictions.*)|\1, check_policy_service inet:127.0.0.1:10023|' \
     /etc/postfix/main.cf
 
   sed -i -e \

--- a/test/mail_dnsbl.bats
+++ b/test/mail_dnsbl.bats
@@ -36,7 +36,7 @@ function setup_file() {
 
 @test "checking enabled postscreen DNS block lists --> postscreen_dnsbl_sites" {
   run docker exec "${CONTAINER}" postconf postscreen_dnsbl_sites
-  assert_output 'postscreen_dnsbl_sites = zen.spamhaus.org*3 bl.mailspike.net b.barracudacentral.org*2 bl.spameatingmonkey.net dnsbl.sorbs.net psbl.surriel.com list.dnswl.org=127.0.[0..255].0*-2 list.dnswl.org=127.0.[0..255].1*-3 list.dnswl.org=127.0.[0..255].[2..3]*-4'
+  assert_output 'postscreen_dnsbl_sites = zen.spamhaus.org=127.0.0.[2..11]*3 bl.mailspike.net=127.0.0.[2;14;13;12;11;10] b.barracudacentral.org*2 bl.spameatingmonkey.net=127.0.0.2 dnsbl.sorbs.net psbl.surriel.com list.dnswl.org=127.0.[0..255].0*-2 list.dnswl.org=127.0.[0..255].1*-3 list.dnswl.org=127.0.[0..255].[2..3]*-4'
 }
 
 # ENABLE_DNSBL=0

--- a/test/mail_with_postgrey.bats
+++ b/test/mail_with_postgrey.bats
@@ -25,7 +25,7 @@ function teardown_file() {
 }
 
 @test "checking postgrey: /etc/postfix/main.cf correctly edited" {
-  run docker exec mail_with_postgrey /bin/bash -c "grep 'zen.spamhaus.org=127.0.0.[2..11], check_policy_service inet:127.0.0.1:10023' /etc/postfix/main.cf | wc -l"
+  run docker exec mail_with_postgrey /bin/bash -c "grep -F 'zen.spamhaus.org=127.0.0.[2..11], check_policy_service inet:127.0.0.1:10023' /etc/postfix/main.cf | wc -l"
   assert_success
   assert_output 1
 }

--- a/test/mail_with_postgrey.bats
+++ b/test/mail_with_postgrey.bats
@@ -25,7 +25,7 @@ function teardown_file() {
 }
 
 @test "checking postgrey: /etc/postfix/main.cf correctly edited" {
-  run docker exec mail_with_postgrey /bin/bash -c "grep 'zen.spamhaus.org, check_policy_service inet:127.0.0.1:10023' /etc/postfix/main.cf | wc -l"
+  run docker exec mail_with_postgrey /bin/bash -c "grep 'zen.spamhaus.org=127.0.0.[2..11], check_policy_service inet:127.0.0.1:10023' /etc/postfix/main.cf | wc -l"
   assert_success
   assert_output 1
 }


### PR DESCRIPTION
# Description

Adjusts the DNSBL return codes interpretation. Now, only "valid" return codes, i.e. the ones that indicate spam, are taken into account.

Fixes #2889

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
