### PR TITLE
ci: update to new output format on GH actions

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           git pull
           git checkout contributors-update
-          echo "::set-output name=head_sha::$(git rev-parse contributors-update)"
+          echo "head_sha=$(git rev-parse contributors-update)" >>${GITHUB_OUTPUT}
 
       - name: 'Commit Status: Set Lint status to success (skipped)'
         uses: myrotvorets/set-commit-status-action@1.1.5

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           git pull
           git checkout contributors-update
-          echo "head_sha=$(git rev-parse contributors-update)" >>${GITHUB_OUTPUT}
+          echo "head_sha=$(git rev-parse contributors-update)" >>"${GITHUB_OUTPUT}"
 
       - name: 'Commit Status: Set Lint status to success (skipped)'
         uses: myrotvorets/set-commit-status-action@1.1.5

--- a/.github/workflows/generic_build.yml
+++ b/.github/workflows/generic_build.yml
@@ -55,7 +55,7 @@ jobs:
               | awk '{ print $1 }' \
           )
 
-          echo "::set-output name=digest::${IMAGE_CHECKSUM}"
+          echo "digest=${IMAGE_CHECKSUM}" >>${GITHUB_OUTPUT}
 
       # Attempts to restore the build cache from a prior build run.
       # If the exact key is not restored, then upon a successful job run

--- a/.github/workflows/generic_build.yml
+++ b/.github/workflows/generic_build.yml
@@ -55,7 +55,7 @@ jobs:
               | awk '{ print $1 }' \
           )
 
-          echo "digest=${IMAGE_CHECKSUM}" >>${GITHUB_OUTPUT}
+          echo "digest=${IMAGE_CHECKSUM}" >>"${GITHUB_OUTPUT}"
 
       # Attempts to restore the build cache from a prior build run.
       # If the exact key is not restored, then upon a successful job run

--- a/.github/workflows/generic_publish.yml
+++ b/.github/workflows/generic_publish.yml
@@ -69,7 +69,7 @@ jobs:
       - name: 'Acquire the image version'
         id: get-version
         shell: bash
-        run: echo "::set-output name=version::$(<VERSION)"
+        run: echo "version=$(<VERSION)" >>${GITHUB_OUTPUT}
 
       - name: 'Build and publish images'
         uses: docker/build-push-action@v3.2.0

--- a/.github/workflows/generic_publish.yml
+++ b/.github/workflows/generic_publish.yml
@@ -69,7 +69,7 @@ jobs:
       - name: 'Acquire the image version'
         id: get-version
         shell: bash
-        run: echo "version=$(<VERSION)" >>${GITHUB_OUTPUT}
+        run: echo "version=$(<VERSION)" >>"${GITHUB_OUTPUT}"
 
       - name: 'Build and publish images'
         uses: docker/build-push-action@v3.2.0


### PR DESCRIPTION
# Description

See <https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/>

## Type of change

- [x] Update to component due to deprecation notice

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas