### PR TITLE
improvement: run `source` instead of `/bin/bash` for `user-patches.sh`

### DIFF
--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -1055,7 +1055,7 @@ function _setup_user_patches
   if [[ -f ${USER_PATCHES} ]]
   then
     _log 'debug' 'Applying user patches'
-    /bin/bash "${USER_PATCHES}"
+    source "${USER_PATCHES}"
   else
     _log 'trace' "No optional '${USER_PATCHES}' provided"
   fi


### PR DESCRIPTION
# Description

Running `source` will "execute" the file as well, but it allows tinkering with existing code. I have a use case where I want to override a specific function, which I can do with `source`, but I cannot right now, because it is run in a "subshell", where changes are not propagates.

This change changes the current behavior slightly: if you use `set -e`, then this option is set for the whole rest of the script setup of DMS. Tell me whether you think this is a breaking change :)

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
