### PR TITLE
143 missing in  example

### DIFF
--- a/docs/content/examples/tutorials/basic-installation.md
+++ b/docs/content/examples/tutorials/basic-installation.md
@@ -34,6 +34,7 @@ In this setup `docker-mailserver` is not intended to receive email externally, s
             domainname: example.com
             ports:
               - "25:25"
+              - "143:143"
               - "587:587"
               - "465:465"
             volumes:


### PR DESCRIPTION
# Description

Editing about the 143 port missing. It exists on the README.md but not on the example on the docs. It frustrated me for dozens of minutes lmao.

Fixes #

## Type of change

<!-- Delete options that are not relevant. -->
- [x] Improvement (non-breaking change that does improve existing functionality)
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
