### PR TITLE
Revert "Change OpenDMARC policy default to reject"

### DIFF
--- a/target/opendmarc/opendmarc.conf
+++ b/target/opendmarc/opendmarc.conf
@@ -3,7 +3,7 @@ UMask    0002
 PidFile  /var/run/opendmarc.pid
 Syslog   true
 
-RejectFailures  true
+RejectFailures  false
 
 IgnoreHosts  /etc/opendmarc/ignore.hosts
 HistoryFile  /var/run/opendmarc/opendmarc.dat


### PR DESCRIPTION
Reverts docker-mailserver/docker-mailserver#2933

I accidentally merged this before 11.3 release, sorry about that :(

Unless it's considered acceptable for a minor release inclusion, which it might as it seems to be a fix?