### PR TITLE
ci: Drop support for ARM v7 platform

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,7 +22,7 @@ body:
 
         We provide official support for
 
-        1. OS/ARCH: Linux on amd64/x86_64 or ARMv7 or ARM64
+        1. OS/ARCH: Linux on AMD64 (x86_64) and ARM64 (AArch64)
         2. Containerization platform: Docker and Docker Compose (i.e. based on Docker Engine)
 
         Other configurations are not officially supported, but there are maintainers that may be able to help you. This is the case for
@@ -52,7 +52,7 @@ body:
   - type: textarea
     id: when-does-it-occur
     attributes:
-      label:  What happened and when does this occur?
+      label: What happened and when does this occur?
       description: Tell us what happened. Use [fenced code blocks](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks) when pasting lots of text!
       placeholder: Although `LOG_LEVEL=debug` is set, I see no debug output.
       render: Markdown
@@ -61,7 +61,7 @@ body:
   - type: textarea
     id: what-did-you-expect-to-happen
     attributes:
-      label:  What did you expect to happen?
+      label: What did you expect to happen?
       description: Tell us what you expected.
       placeholder: I expected to see debug messages.
       render: Markdown
@@ -111,9 +111,8 @@ body:
     attributes:
       label: What instruction set architecture is DMS running on?
       options:
-        - x86_64 / AMD64
-        - ARM64 / ARM v8 (and newer)
-        - ARM v7
+        - AMD64 / x86_64
+        - ARM64 / AArch64 (ARM v8 and newer)
         - Other (unsupported)
     validations:
       required: true

--- a/.github/workflows/generic_build.yml
+++ b/.github/workflows/generic_build.yml
@@ -76,13 +76,12 @@ jobs:
       - name: 'Set up QEMU'
         uses: docker/setup-qemu-action@v2.1.0
         with:
-          platforms: arm64,arm
+          platforms: arm64
 
       - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@v2.2.1
 
-      # NOTE: AMD64 can build within 2 minutes, ARM adds 13 minutes. 330MB each
-      # ARMv7 can build in parallel, adding no extra time (but does add 150MB cache size).
+      # NOTE: AMD64 can build within 2 minutes
       - name: 'Build images'
         uses: docker/build-push-action@v3.2.0
         with:

--- a/.github/workflows/generic_publish.yml
+++ b/.github/workflows/generic_publish.yml
@@ -37,7 +37,7 @@ jobs:
       - name: 'Set up QEMU'
         uses: docker/setup-qemu-action@v2.1.0
         with:
-          platforms: arm64,arm
+          platforms: arm64
 
       - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@v2.2.1
@@ -78,7 +78,7 @@ jobs:
           build-args: |
             VCS_REVISION=${{ github.sha }}
             VCS_VERSION=${{ steps.get-version.outputs.version }}
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/scheduled_builds.yml
+++ b/.github/workflows/scheduled_builds.yml
@@ -13,7 +13,7 @@ jobs:
     name: 'Build Images'
     uses: docker-mailserver/docker-mailserver/.github/workflows/generic_build.yml@master
     with:
-      platforms: linux/amd64,linux/arm/v7,linux/arm64
+      platforms: linux/amd64,linux/arm64
 
   publish-images:
     name: 'Publish Images'

--- a/.github/workflows/test_merge_requests.yml
+++ b/.github/workflows/test_merge_requests.yml
@@ -30,8 +30,8 @@ jobs:
     name: 'Build ARM64 Image'
     # Dependency ensures the cache-key is only created for AMD64 builds.
     # ARM64 will not be able to use this cache, building from scratch each time.
-    # Expect about 13 minutes build time until adopting `type=gha` with scopes for cache.
+    # Expect about 2 minutes extra build time until adopting `type=gha` with scopes for cache.
     needs: build-image-amd64
     uses: docker-mailserver/docker-mailserver/.github/workflows/generic_build.yml@master
     with:
-      platforms: linux/arm/v7,linux/arm64
+      platforms: linux/arm64


### PR DESCRIPTION
# Description

This platform has had a deprecation notice for 6 months. It is not worth continuing to maintain support for.

See https://github.com/docker-mailserver/docker-mailserver/issues/2642 (_deprecation notice tracking issue_) for more details.

Closes #2642 