### PR TITLE
chore: Remove legacy ENV `SASL_PASSWD`

### DIFF
--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -685,11 +685,6 @@ Specify what password attribute to use for password verification.
 - **empty** => Nothing is added to the configuration but the documentation says it is `userPassword` by default.
 - Any value => Fills the `ldap_password_attr` option
 
-##### SASL_PASSWD
-
-- **empty** => No sasl_passwd will be created
-- string => `/etc/postfix/sasl_passwd` will be created with the string as password
-
 ##### SASLAUTHD_LDAP_AUTH_METHOD
 
 - **empty** => `bind` will be used as a default value

--- a/mailserver.env
+++ b/mailserver.env
@@ -474,10 +474,6 @@ SASLAUTHD_LDAP_TLS_CACERT_DIR=
 # Any value => Fills the `ldap_password_attr` option
 SASLAUTHD_LDAP_PASSWORD_ATTR=
 
-# empty => No sasl_passwd will be created
-# string => `/etc/postfix/sasl_passwd` will be created with the string as password
-SASL_PASSWD=
-
 # empty => `bind` will be used as a default value
 # `fastbind` => The fastbind method is used
 # `custom` => The custom method uses userPassword attribute to verify the password

--- a/target/scripts/helpers/relay.sh
+++ b/target/scripts/helpers/relay.sh
@@ -47,9 +47,7 @@
 # NOTE: Present support has enforced wrapping the relay host with `[]` (prevents DNS MX record lookup),
 # which restricts what is supported by RELAY_HOST, although you usually do want to provide MX host directly.
 # NOTE: Present support expects to always append a port with an implicit default of `25`.
-# NOTE: DEFAULT_RELAY_HOST imposes neither restriction, but would only be compatible with SASL_PASSWD then when
-# auth is needed. However that seems tied to RELAY_HOST to enable the /etc/postfix/sasl_passwd table lookup,
-# which introduces issues if you would want DEFAULT_RELAY_HOST to use credentials..
+# NOTE: DEFAULT_RELAY_HOST imposes neither restriction.
 #
 # TODO: RELAY_PORT should be optional, it will use the transport default port (`postconf smtp_tcp_port`),
 # That shouldn't be a breaking change, as long as the mapping is maintained correctly.
@@ -65,8 +63,7 @@ function _env_relay_host
 function _relayhost_sasl
 {
   if [[ ! -f /tmp/docker-mailserver/postfix-sasl-password.cf ]] \
-    && [[ -z ${RELAY_USER} || -z ${RELAY_PASSWORD} ]] \
-    && [[ -z ${SASL_PASSWD} ]]
+    && [[ -z ${RELAY_USER} || -z ${RELAY_PASSWORD} ]]
   then
     _log 'warn' "Missing relay-host mapped credentials provided via ENV, or from postfix-sasl-password.cf"
     return 1
@@ -78,19 +75,6 @@ function _relayhost_sasl
   : >/etc/postfix/sasl_passwd
   chown root:root /etc/postfix/sasl_passwd
   chmod 0600 /etc/postfix/sasl_passwd
-
-  # SASL_PASSWD is a legacy ENV, not likely in use by any users.
-  #
-  # Single ENV for specifying `<DEFAULT_RELAY_HOST>    <RELAY_USER>:<RELAY_PASSWORD>`,
-  # Where `<DEFAULT_RELAY_HOST>` must match the equivalent ENV,
-  # while the other two have no dependency to their equivalent ENV.
-  # SASL_PASSWD requires `smtp_sasl_password_maps` to be enabled - but that has only
-  # ever been via this function which relies upon RELAY_HOST. Hence redundant.
-  # TODO: Deprecate. Remove on next major version?
-  if [[ -n ${SASL_PASSWD} ]]
-  then
-    echo "${SASL_PASSWD}" >> /etc/postfix/sasl_passwd
-  fi
 
   local DATABASE_SASL_PASSWD='/tmp/docker-mailserver/postfix-sasl-password.cf'
   if [[ -f ${DATABASE_SASL_PASSWD} ]]

--- a/target/scripts/helpers/relay.sh
+++ b/target/scripts/helpers/relay.sh
@@ -63,7 +63,7 @@ function _env_relay_host
 function _relayhost_sasl
 {
   if [[ ! -f /tmp/docker-mailserver/postfix-sasl-password.cf ]] \
-    && [[ -z ${RELAY_USER} || -z ${RELAY_PASSWORD} ]]
+    && [[ -z ${RELAY_USER} ]] || [[ -z ${RELAY_PASSWORD} ]]
   then
     _log 'warn' "Missing relay-host mapped credentials provided via ENV, or from postfix-sasl-password.cf"
     return 1

--- a/test/tests/serial/mail_special_use_folders.bats
+++ b/test/tests/serial/mail_special_use_folders.bats
@@ -7,7 +7,6 @@ setup_file() {
   docker run -d --name mail_special_use_folders \
     -v "${PRIVATE_CONFIG}":/tmp/docker-mailserver \
     -v "$(pwd)/test/test-files":/tmp/docker-mailserver-test:ro \
-    -e SASL_PASSWD="external-domain.com username:password" \
     -e ENABLE_CLAMAV=0 \
     -e ENABLE_SPAMASSASSIN=0 \
     -e PERMIT_DOCKER=host \

--- a/test/tests/serial/mail_undef_spam_subject.bats
+++ b/test/tests/serial/mail_undef_spam_subject.bats
@@ -30,7 +30,6 @@ function setup() {
     -e SA_SPAM_SUBJECT="SPAM: " \
     -e VIRUSMAILS_DELETE_DELAY=7 \
     -e ENABLE_SRS=1 \
-    -e SASL_PASSWD="external-domain.com username:password" \
     -e ENABLE_MANAGESIEVE=1 \
     -e PERMIT_DOCKER=host \
     --name "${CONTAINER}" \

--- a/test/tests/serial/mail_with_mdbox.bats
+++ b/test/tests/serial/mail_with_mdbox.bats
@@ -7,7 +7,6 @@ setup_file() {
   docker run -d --name mail_with_mdbox_format \
     -v "${PRIVATE_CONFIG}":/tmp/docker-mailserver \
     -v "$(pwd)/test/test-files":/tmp/docker-mailserver-test:ro \
-    -e SASL_PASSWD="external-domain.com username:password" \
     -e ENABLE_CLAMAV=0 \
     -e ENABLE_SPAMASSASSIN=0 \
     -e DOVECOT_MAILBOX_FORMAT=mdbox \

--- a/test/tests/serial/mail_with_sdbox.bats
+++ b/test/tests/serial/mail_with_sdbox.bats
@@ -7,7 +7,6 @@ setup_file() {
   docker run -d --name mail_with_sdbox_format \
     -v "${PRIVATE_CONFIG}":/tmp/docker-mailserver \
     -v "$(pwd)/test/test-files":/tmp/docker-mailserver-test:ro \
-    -e SASL_PASSWD="external-domain.com username:password" \
     -e ENABLE_CLAMAV=0 \
     -e ENABLE_SPAMASSASSIN=0 \
     -e DOVECOT_MAILBOX_FORMAT=sdbox \


### PR DESCRIPTION
# Description

As per [deprecation notice from v11.3 release notes](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v11.3.0), and a [related prior PR](https://github.com/docker-mailserver/docker-mailserver/pull/2605); this ENV is to be removed.

It's no longer considered useful, and none of the tests that configured it were actually using it for relaying anything.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] New and existing unit tests pass locally with my changes
