### PR TITLE
fix(changedetector): Use service `reload` commands instead of `supervisorctl restart <service>`

### DIFF
--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -56,13 +56,11 @@ function _check_for_changes
     _ssl_changes
     _postfix_dovecot_changes
 
-    # While some config changes may be properly applied by Postfix or Dovecot
-    # via their 'reload' commands; some may require restarting?:
-    _log_with_date 'debug' 'Restarting services due to detected changes'
+    _log_with_date 'debug' 'Reloading services due to detected changes'
 
     [[ ${ENABLE_AMAVIS} -eq 1 ]] && _reload_amavis
-    supervisorctl restart postfix
-    [[ ${SMTP_ONLY} -ne 1 ]] && supervisorctl restart dovecot
+    postfix reload
+    [[ ${SMTP_ONLY} -ne 1 ]] && dovecot reload
 
     _remove_lock
     _log_with_date 'debug' 'Completed handling of detected change'

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -111,6 +111,7 @@ function _postfix_dovecot_changes
   || [[ ${CHANGED} =~ ${DMS_DIR}/dovecot-quotas.cf   ]] \
   || [[ ${CHANGED} =~ ${DMS_DIR}/dovecot-masters.cf  ]]
   then
+    _log_with_date 'trace' 'Regenerating accounts (Dovecot + Postfix)'
     [[ ${SMTP_ONLY} -ne 1 ]] && _create_accounts
   fi
 
@@ -124,6 +125,7 @@ function _postfix_dovecot_changes
   || [[ ${CHANGED} =~ ${DMS_DIR}/postfix-relaymap.cf      ]] \
   || [[ ${CHANGED} =~ ${DMS_DIR}/postfix-sasl-password.cf ]]
   then
+    _log_with_date 'trace' 'Regenerating relay config (Postfix)'
     _rebuild_relayhost
   fi
 
@@ -136,6 +138,7 @@ function _postfix_dovecot_changes
   if [[ ${CHANGED} =~ ${DMS_DIR}/postfix-accounts.cf ]] \
   || [[ ${CHANGED} =~ ${DMS_DIR}/postfix-virtual.cf  ]]
   then
+    _log_with_date 'trace' 'Regenerating vhosts (Postfix)'
     _create_postfix_vhost
   fi
 

--- a/test/helper/common.bash
+++ b/test/helper/common.bash
@@ -181,18 +181,15 @@ function wait_until_change_detection_event_completes() {
     [[ $(__change_event_status) == "${CHANGE_EVENT_END}" ]]
   }
 
-  if [[ ! $(__is_changedetector_processing) ]]
+  # A new change event is expected,
+  # If the last event status is not yet `CHANGE_EVENT_START`, wait until it is:
+  if [[ $(__is_changedetector_processing) -ne 0 ]]
   then
-    # A new change event is expected, wait for it:
     repeat_until_success_or_timeout 60 __is_changedetector_processing
   fi
 
   # Change event is in progress, wait until it finishes:
   repeat_until_success_or_timeout 60 __is_changedetector_finished
-
-  # NOTE: Although the change event has completed, services like Postfix and Dovecot
-  # may still be in the process of restarting.
-  # You may still want to wait longer if depending on those to be ready.
 }
 
 # An account added to `postfix-accounts.cf` must wait for the `changedetector` service

--- a/test/helper/common.bash
+++ b/test/helper/common.bash
@@ -183,7 +183,7 @@ function wait_until_change_detection_event_completes() {
 
   # A new change event is expected,
   # If the last event status is not yet `CHANGE_EVENT_START`, wait until it is:
-  if [[ $(__is_changedetector_processing) -ne 0 ]]
+  if ! __is_changedetector_processing
   then
     repeat_until_success_or_timeout 60 __is_changedetector_processing
   fi

--- a/test/test_helper/common.bash
+++ b/test/test_helper/common.bash
@@ -203,7 +203,7 @@ function wait_until_change_detection_event_completes() {
 
   # A new change event is expected,
   # If the last event status is not yet `CHANGE_EVENT_START`, wait until it is:
-  if [[ $(__is_changedetector_processing) -ne 0 ]]
+  if ! __is_changedetector_processing
   then
     repeat_until_success_or_timeout 60 __is_changedetector_processing
   fi

--- a/test/test_helper/common.bash
+++ b/test/test_helper/common.bash
@@ -201,18 +201,15 @@ function wait_until_change_detection_event_completes() {
     [[ $(__change_event_status) == "${CHANGE_EVENT_END}" ]]
   }
 
-  if [[ ! $(__is_changedetector_processing) ]]
+  # A new change event is expected,
+  # If the last event status is not yet `CHANGE_EVENT_START`, wait until it is:
+  if [[ $(__is_changedetector_processing) -ne 0 ]]
   then
-    # A new change event is expected, wait for it:
     repeat_until_success_or_timeout 60 __is_changedetector_processing
   fi
 
   # Change event is in progress, wait until it finishes:
   repeat_until_success_or_timeout 60 __is_changedetector_finished
-
-  # NOTE: Although the change event has completed, services like Postfix and Dovecot
-  # may still be in the process of restarting.
-  # You may still want to wait longer if depending on those to be ready.
 }
 
 # An account added to `postfix-accounts.cf` must wait for the `changedetector` service

--- a/test/tests/serial/mail_changedetector.bats
+++ b/test/tests/serial/mail_changedetector.bats
@@ -38,17 +38,17 @@ function teardown_file() {
   echo "" >> "$(private_config_path mail_changedetector_one)/postfix-accounts.cf"
   sleep 25
 
-  run docker exec mail_changedetector_one /bin/bash -c "supervisorctl tail -3000 changedetector"
-  assert_output --partial "postfix: stopped"
-  assert_output --partial "postfix: started"
-  assert_output --partial "Change detected"
-  assert_output --partial "Removed lock"
+  run docker exec mail_changedetector_one /bin/bash -c 'supervisorctl tail -3000 changedetector'
+  assert_output --partial 'Change detected'
+  assert_output --partial 'Reloading services due to detected changes'
+  assert_output --partial 'Removed lock'
+  assert_output --partial 'Completed handling of detected change'
 
-  run docker exec mail_changedetector_two /bin/bash -c "supervisorctl tail -3000 changedetector"
-  assert_output --partial "postfix: stopped"
-  assert_output --partial "postfix: started"
-  assert_output --partial "Change detected"
-  assert_output --partial "Removed lock"
+  run docker exec mail_changedetector_two /bin/bash -c 'supervisorctl tail -3000 changedetector'
+  assert_output --partial 'Change detected'
+  assert_output --partial 'Reloading services due to detected changes'
+  assert_output --partial 'Removed lock'
+  assert_output --partial 'Completed handling of detected change'
 }
 
 @test "checking changedetector: lock file found, blocks, and doesn't get prematurely removed" {

--- a/test/tests/serial/setup-cli.bats
+++ b/test/tests/serial/setup-cli.bats
@@ -53,8 +53,8 @@ function teardown_file() {
 
   # Wait for change detection event to complete (create maildir and add account to Dovecot UserDB+PassDB)
   wait_until_account_maildir_exists "${TEST_NAME}" "${MAIL_ACCOUNT}"
-  # Dovecot is stopped briefly at the end of processing a change event (should change to reload in future),
-  # to more accurately use `wait_for_service` ensure you wait until `changedetector` is done.
+
+  # To more accurately use `wait_for_service` here, ensure you wait until `changedetector` is done.
   wait_until_change_detection_event_completes "${TEST_NAME}"
   wait_for_service "${TEST_NAME}" dovecot
 

--- a/test/tests/serial/setup-cli.bats
+++ b/test/tests/serial/setup-cli.bats
@@ -55,14 +55,10 @@ function teardown_file() {
   # Mail account and storage directory should now be valid
   wait_until_change_detection_event_completes "${TEST_NAME}"
 
-  # Verify mail storage directory exists:
-  local LOCAL_PART="${MAIL_ACCOUNT%@*}"
-  local DOMAIN_PART="${MAIL_ACCOUNT#*@}"
-  local MAIL_ACCOUNT_STORAGE_DIR="/var/mail/${DOMAIN_PART}/${LOCAL_PART}"
-  run docker exec "${TEST_NAME}" bash -c "[[ -d ${MAIL_ACCOUNT_STORAGE_DIR} ]]"
-  assert_success
+  # Verify mail storage directory exists (polls if storage is slow, eg remote mount):
+  wait_until_account_maildir_exists "${TEST_NAME}" "${MAIL_ACCOUNT}"
 
-  # Verify account authentication is successful:
+  # Verify account authentication is successful (account added to Dovecot UserDB+PassDB):
   wait_for_service "${TEST_NAME}" dovecot
   local RESPONSE
   RESPONSE=$(docker exec "${TEST_NAME}" doveadm auth test "${MAIL_ACCOUNT}" "${MAIL_PASS}" | grep 'passdb')


### PR DESCRIPTION
# Description

With `reload` a change detection event during local testing can be processed in less than a second according to logs. Previously this was 5+ seconds (_plus additional downtime for Postfix/Dovecot to become available again_).

In the past it was apparently an issue to use `<service> reload` due to a concern with the PID for wrapper scripts that `supervisorctl` managed, thus `supervisorctl <service> restart` had been used. Past discussions with maintainers suggest this is not likely an issue anymore, and `reload` should be fine to switch to now :+1: 

---

**NOTE:** It may not be an issue in the CI, but on _**local systems running tests may risk failure in `setup-cli.bats` from a false positive**_ due to 1 second polling window of the test helper method, and a change event being possible to occur entirely between the two checks undetected by the current approach.

If this is a problem, we may need to think of a better way to catch the change. The `letsencrypt` test counts how many change events are expected to have been processed, and this could technically be leveraged by the test helper too.

---

**NOTE:** These two lines (_with regex pattern for postfix_) are output in the terminal when using the services respective `reload` commands:

```
postfix/master.*: reload -- version .*, configuration /etc/postfix
dovecot: master: Warning: SIGHUP received - reloading configuration
```

I wasn't sure how to match them as they did not appear in the `changedetector` log (_**EDIT:** they appear in the main log output, eg `docker logs <container name>`_).

Instead I've just monitored the `changedetector` log messages, which should be ok for logic that previously needed to ensure Dovecot / Postfix was back up after the `restart` was issued.

---

This was a change I wanted to get into a major release at some point. I don't have the usual extensive details / references to support the change however.

This should help reduce downtime during change events, especially in situations like reported here?:

- https://github.com/docker-mailserver/docker-mailserver/issues/2613#issuecomment-1144214566
- https://github.com/docker-mailserver/docker-mailserver/pull/2623#issuecomment-1148181045

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) - **Potentially?**

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
