### PR TITLE
fix: regex in quota activation code

### DIFF
--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -231,7 +231,7 @@ function _setup_dovecot_quota
           "s|mail_plugins = \$mail_plugins|mail_plugins = \$mail_plugins quota|g" \
           /etc/dovecot/conf.d/10-mail.conf
         sed -i \
-          "s|mail_plugins = \$mail_plugin|mail_plugins = \$mail_plugins imap_quota|g" \
+          "s|mail_plugins = \$mail_plugins|mail_plugins = \$mail_plugins imap_quota|g" \
           /etc/dovecot/conf.d/20-imap.conf
       fi
 


### PR DESCRIPTION
# Description

quota activation make dovecot crashes because of imap_quota**s** absence

# Fixes

regex correction (missing **s**)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
