### PR TITLE
update: bump Fail2Ban version to v1.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,7 @@ EOF
 # -----------------------------------------------
 
 COPY target/fail2ban/jail.local /etc/fail2ban/jail.local
+COPY target/fail2ban/fail2ban.d/fixes.local /etc/fail2ban/fail2ban.d/fixes.local
 RUN <<EOF
   ln -s /var/log/mail/mail.log /var/log/mail.log
   # disable sshd jail

--- a/target/fail2ban/fail2ban.d/fixes.local
+++ b/target/fail2ban/fail2ban.d/fixes.local
@@ -1,0 +1,9 @@
+# * Contains settings that act as fixes, mostly for tests.
+# ! When adding new content, provide a comment on why the fix is necessary.
+
+[Definition]
+
+# Fail2Ban will complain when using `fail2ban-client -d` about this option
+# not being set. This screws up `assert_output` in BATS tests. Therefore,
+# the default value is explictly set here.
+allowipv6 = auto;

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -131,7 +131,7 @@ function _install_dovecot
 
 function _install_fail2ban
 {
-  local FAIL2BAN_DEB_URL='https://github.com/fail2ban/fail2ban/releases/download/1.0.2/fail12ban_1.0.2-1.upstream1_all.deb'
+  local FAIL2BAN_DEB_URL='https://github.com/fail2ban/fail2ban/releases/download/1.0.2/fail2ban_1.0.2-1.upstream1_all.deb'
   local FAIL2BAN_DEB_ASC_URL="${FAIL2BAN_DEB_URL}.asc"
   local FAIL2BAN_GPG_FINGERPRINT='8738 559E 26F6 71DF 9E2C  6D9E 683B F1BE BD0A 882C'
   local FAIL2BAN_GPG_PUBLIC_KEY_ID='0x683BF1BEBD0A882C'

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -131,7 +131,7 @@ function _install_dovecot
 
 function _install_fail2ban
 {
-  local FAIL2BAN_DEB_URL='https://github.com/fail2ban/fail2ban/releases/download/0.11.2/fail2ban_0.11.2-1.upstream1_all.deb'
+  local FAIL2BAN_DEB_URL='https://github.com/fail2ban/fail2ban/releases/download/1.0.2/fail12ban_1.0.2-1.upstream1_all.deb'
   local FAIL2BAN_DEB_ASC_URL="${FAIL2BAN_DEB_URL}.asc"
   local FAIL2BAN_GPG_FINGERPRINT='8738 559E 26F6 71DF 9E2C  6D9E 683B F1BE BD0A 882C'
   local FAIL2BAN_GPG_PUBLIC_KEY_ID='0x683BF1BEBD0A882C'


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

Bump F2B version to the next major version (v1.0.2). Same as #2903 which got reverted due to release of v11.3.1.

## Type of change

- [x] Component update
- [x] _possibly_ breaking change (nothing that is breaking observed for DMS yet though)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] New and existing unit tests pass locally with my changes
