### PR TITLE
test: fix `wait_until_change_detection_event_completes` for change detection < 1s

### DIFF
--- a/test/test_helper/common.bash
+++ b/test/test_helper/common.bash
@@ -32,11 +32,11 @@ function repeat_until_success_or_timeout {
   until "${@}"
   do
     if [[ -n ${FATAL_FAILURE_TEST_COMMAND} ]] && ! eval "${FATAL_FAILURE_TEST_COMMAND}"; then
-      echo "\`${FATAL_FAILURE_TEST_COMMAND}\` failed, early aborting repeat_until_success of \`${*}\`" >&2
+      echo "\`${FATAL_FAILURE_TEST_COMMAND}\` failed, early aborting repeat_until_success_or_timeout of \`${*}\`" >&2
       return 1
     fi
 
-    sleep 1
+    sleep 0.1
 
     if [[ $(( SECONDS - STARTTIME )) -gt ${TIMEOUT} ]]; then
       echo "Timed out on command: ${*}" >&2
@@ -181,7 +181,7 @@ function wait_until_change_detection_event_completes() {
 
   # Ensure the container is configured with the required `LOG_LEVEL` ENV:
   assert_regex \
-    $(docker exec "${CONTAINER_NAME}" env | grep '^LOG_LEVEL=') \
+    "$(docker exec "${CONTAINER_NAME}" env | grep '^LOG_LEVEL=')" \
     '=(debug|trace)$'
 
   local CHANGE_EVENT_START='Change detected'
@@ -194,7 +194,8 @@ function wait_until_change_detection_event_completes() {
   }
 
   function __is_changedetector_processing() {
-    [[ $(__change_event_status) == "${CHANGE_EVENT_START}" ]]
+    [[ $(__change_event_status) == "${CHANGE_EVENT_START}" ]] \
+    || [[ $(__change_event_status) == "${CHANGE_EVENT_END}" ]]
   }
 
   function __is_changedetector_finished() {


### PR DESCRIPTION
# Description

in case the change detection happens within one tick __change_event_status might return CHANGE_EVENT_END right after the previous tick returned an empty string ""

also reduce ticks in docker container to .1 s (we can expect an up-to-date bash inside the container)

on our CI systems and DEV machines the change detection happen well bellow 1s:
```
[  DEBUG  ]  2023-01-02 09:30:30  Starting changedetector
[  DEBUG  ]  2023-01-02 09:30:40  Changedetector is ready
[   INF   ]  2023-01-02 09:30:40  Change detected
[  DEBUG  ]  Creating master user 'masterusername'
[  DEBUG  ]  Creating user 'user1' for domain 'localhost.localdomain'
[  DEBUG  ]  Creating user 'user2' for domain 'otherdomain.tld'
[  DEBUG  ]  Creating user 'user3' for domain 'localhost.localdomain' with attributes 'userdb_mail=mbox:~/mail:INBOX=~/inbox'
[  DEBUG  ]  Creating user 'user' for domain 'example.com'
[  DEBUG  ]  Adding alias 'alias1@localhost.localdomain' for user 'user1@localhost.localdomain' to Dovecot's userdb
[  DEBUG  ]  Alias 'alias2@localhost.localdomain' is non-local (or mapped to a non-existing account) and will not be added to Dovecot's userdb
[  DEBUG  ]  Adding alias '@localdomain2.com' for user 'user1@localhost.localdomain' to Dovecot's userdb
[  DEBUG  ]  2023-01-02 09:30:40  Reloading services due to detected changes
[  DEBUG  ]  2023-01-02 09:30:40  Completed handling of detected change

```
which lead to tests failing most of the times the as one output of the `tail -1` was `` followed by the next output being ` Completed handling of detected change` and the following never being true within the timeout:
```
[[ Completed handling of detected change == \C\h\a\n\g\e\ \d\e\t\e\c\t\e\d ]]
```

## Output of failed tests:
```
not ok 212 setup_file failed
# (from function `repeat_until_success_or_timeout' in file test/test_helper/common.bash, line 43,
#  from function `wait_until_change_detection_event_completes' in file test/test_helper/common.bash, line 208,
#  from function `setup_file' in test file test/tests/serial/tests.bats, line 50)
#   `wait_until_change_detection_event_completes mail' failed
# 675cd226dc803f82837b33fc6109ee21ff5191d576e890ffa33ae212510845b0
# [   INF   ]  mail.my-domain.com is up and running
# Timed out on command: __is_changedetector_processing
# mail
# bats warning: Executed 212 instead of expected 309 tests
```

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Info @wt-io-it

---

MAINTAINER EDIT (by @georglauterbach): Fixes #2966