### PR TITLE
tests(fix): `wait_until_change_detection_event_completes` to count

### DIFF
--- a/test/test_helper/common.bash
+++ b/test/test_helper/common.bash
@@ -173,7 +173,7 @@ function wait_for_changes_to_be_detected_in_container() {
   repeat_in_container_until_success_or_timeout "${TIMEOUT}" "${CONTAINER_NAME}" bash -c 'source /usr/local/bin/helpers/index.sh; _obtain_hostname_and_domainname; cmp --silent -- <(_monitored_files_checksums) "${CHKSUM_FILE}" >/dev/null'
 }
 
-# Relies on ENV `LOG_LEVEL=debug` or higher
+# NOTE: Relies on ENV `LOG_LEVEL=debug` or higher
 function wait_until_change_detection_event_completes() {
   local CONTAINER_NAME="${1}"
   # Ensure early failure if arg is missing:
@@ -184,31 +184,20 @@ function wait_until_change_detection_event_completes() {
     $(docker exec "${CONTAINER_NAME}" env | grep '^LOG_LEVEL=') \
     '=(debug|trace)$'
 
-  local CHANGE_EVENT_START='Change detected'
-  local CHANGE_EVENT_END='Completed handling of detected change' # debug log
-
-  function __change_event_status() {
-    docker exec "${CONTAINER_NAME}" \
-      grep -oE "${CHANGE_EVENT_START}|${CHANGE_EVENT_END}" /var/log/supervisor/changedetector.log \
-      | tail -1
-  }
-
-  function __is_changedetector_processing() {
-    [[ $(__change_event_status) == "${CHANGE_EVENT_START}" ]]
+  # NOTE: Change events can start and finish all within < 1 sec,
+  # Reliably track the completion of a change event by comparing the before/after count:
+  function __change_event_count() {
+    docker exec "${CONTAINER_NAME}" grep --count "${CHANGE_EVENT_END}" /var/log/supervisor/changedetector.log
   }
 
   function __is_changedetector_finished() {
-    [[ $(__change_event_status) == "${CHANGE_EVENT_END}" ]]
+    [[ $(__change_event_count) -gt "${NUM_CHANGE_EVENTS_BEFORE}" ]]
   }
 
-  # A new change event is expected,
-  # If the last event status is not yet `CHANGE_EVENT_START`, wait until it is:
-  if ! __is_changedetector_processing
-  then
-    repeat_until_success_or_timeout 60 __is_changedetector_processing
-  fi
+  # Count by completions of this debug log line from `check-for-changes.sh`:
+  local CHANGE_EVENT_END='Completed handling of detected change'
+  local NUM_CHANGE_EVENTS_BEFORE=$(__change_event_count)
 
-  # Change event is in progress, wait until it finishes:
   repeat_until_success_or_timeout 60 __is_changedetector_finished
 }
 


### PR DESCRIPTION
# Description

Follow-up to a recent PR for improving processing time of a change event: https://github.com/docker-mailserver/docker-mailserver/pull/2947#issuecomment-1363541724

The CI was not as slow as expected, so here is the proper fix (_at least I believe this should be reliable?_):

> Counting and comparing this observation instead is simpler, and more reliable at detecting change events that start and complete very quickly (_within the same second_).

Fixes #2966
Closes #2971

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
