### PR TITLE
tests: Use `mail.example.test` as common container hostname

### DIFF
--- a/test/helper/setup.bash
+++ b/test/helper/setup.bash
@@ -110,7 +110,7 @@ function common_container_create() {
   run docker create \
     --tty \
     --name "${CONTAINER_NAME}" \
-    --hostname "${TEST_FQDN:-mail.my-domain.com}" \
+    --hostname "${TEST_FQDN:-mail.example.test}" \
     --volume "${TEST_FILES_VOLUME}" \
     --volume "${TEST_CONFIG_VOLUME}" \
     --env ENABLE_AMAVIS=0 \

--- a/test/tests/serial/test_helper.bats
+++ b/test/tests/serial/test_helper.bats
@@ -86,7 +86,7 @@ TEST_NAME_PREFIX='test helper functions:'
 # NOTE: Test requires external network access available
 @test "${TEST_NAME_PREFIX} wait_for_smtp_port_in_container returns immediately when port found" {
   local CONTAINER_NAME
-  CONTAINER_NAME=$(docker run --rm -d alpine sh -c "sleep 10")
+  CONTAINER_NAME=$(docker run --rm -d alpine sh -c "sleep 100")
 
   docker exec "${CONTAINER_NAME}" apk add netcat-openbsd
   docker exec "${CONTAINER_NAME}" nc -l 25 &


### PR DESCRIPTION
# Description

- Minor change to the common container hostname (_presently only affects parallel set tests, serial has been left alone_). This is preferred going forward as it's a private TLD that won't make external DNS lookups.
- Had an unrelated recurring test failure on a weak internet connection, bumped the sleep to match what is used in previous test cases.