### PR TITLE
fix: Workaround `postconf` write settling logic

### DIFF
--- a/target/bin/restrict-access
+++ b/target/bin/restrict-access
@@ -44,8 +44,7 @@ case "${MODE}" in
           sed -i 's|smtpd_sender_restrictions =|smtpd_sender_restrictions = check_sender_access texthash:/tmp/docker-mailserver/postfix-send-access.cf,|' /etc/postfix/main.cf \
         || sed -i 's|smtpd_recipient_restrictions =|smtpd_recipient_restrictions = check_recipient_access texthash:/tmp/docker-mailserver/postfix-receive-access.cf,|' /etc/postfix/main.cf
 
-      _adjust_mtime_for_postfix_maincf
-      postfix reload
+      _reload_postfix
     fi
 
     echo -e "${USER} \t\t REJECT" >>"${DATABASE}"

--- a/target/bin/restrict-access
+++ b/target/bin/restrict-access
@@ -44,7 +44,8 @@ case "${MODE}" in
           sed -i 's|smtpd_sender_restrictions =|smtpd_sender_restrictions = check_sender_access texthash:/tmp/docker-mailserver/postfix-send-access.cf,|' /etc/postfix/main.cf \
         || sed -i 's|smtpd_recipient_restrictions =|smtpd_recipient_restrictions = check_recipient_access texthash:/tmp/docker-mailserver/postfix-receive-access.cf,|' /etc/postfix/main.cf
 
-      service postfix reload >/dev/null
+      _adjust_mtime_for_postfix_maincf
+      postfix reload
     fi
 
     echo -e "${USER} \t\t REJECT" >>"${DATABASE}"

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -96,12 +96,6 @@ function _reload_amavis
   fi
 }
 
-function _reload_postfix
-{
-  _adjust_mtime_for_postfix_maincf
-  postfix reload
-}
-
 # Also note that changes are performed in place and are not atomic
 # We should fix that and write to temporary files, stop, swap and start
 function _postfix_dovecot_changes

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -59,7 +59,7 @@ function _check_for_changes
     _log_with_date 'debug' 'Reloading services due to detected changes'
 
     [[ ${ENABLE_AMAVIS} -eq 1 ]] && _reload_amavis
-    postfix reload
+    _reload_postfix
     [[ ${SMTP_ONLY} -ne 1 ]] && dovecot reload
 
     _remove_lock
@@ -94,6 +94,12 @@ function _reload_amavis
     # reading this file again in case of new domains, otherwise they will be ignored.
     amavisd-new reload
   fi
+}
+
+function _reload_postfix
+{
+  _adjust_mtime_for_postfix_maincf
+  postfix reload
 }
 
 # Also note that changes are performed in place and are not atomic

--- a/target/scripts/helpers/aliases.sh
+++ b/target/scripts/helpers/aliases.sh
@@ -54,6 +54,7 @@ function _handle_postfix_aliases_config
   local DATABASE_ALIASES='/tmp/docker-mailserver/postfix-aliases.cf'
   [[ -f ${DATABASE_ALIASES} ]] && cat "${DATABASE_ALIASES}" >>/etc/aliases
 
+  _adjust_mtime_for_postfix_maincf
   postalias /etc/aliases
 }
 

--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -57,3 +57,9 @@ function _adjust_mtime_for_postfix_maincf
     touch -d '2 seconds ago' /etc/postfix/main.cf
   fi
 }
+
+function _reload_postfix
+{
+  _adjust_mtime_for_postfix_maincf
+  postfix reload
+}

--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -44,3 +44,13 @@ function _require_n_parameters_or_print_usage
   [[ ${1:-} == 'help' ]]  && { __usage ; exit 0 ; }
   [[ ${#} -lt ${COUNT} ]] && { __usage ; exit 1 ; }
 }
+
+# NOTE: Postfix commands that read `main.cf` will stall execution,
+# until the config file has not be written to for at least 2 seconds.
+# After we modify the config explicitly, we can safely assume (reasonably)
+# that the write stream has completed, and it is safe to read the config.
+# https://github.com/docker-mailserver/docker-mailserver/issues/2985
+function _adjust_mtime_for_postfix_maincf
+{
+  touch -d '2 seconds ago' /etc/postfix/main.cf
+}

--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -52,5 +52,8 @@ function _require_n_parameters_or_print_usage
 # https://github.com/docker-mailserver/docker-mailserver/issues/2985
 function _adjust_mtime_for_postfix_maincf
 {
-  touch -d '2 seconds ago' /etc/postfix/main.cf
+  if [[ $(( $(date '+%s') - $(stat -c '%Y' '/etc/postfix/main.cf') )) -lt 2 ]]
+  then
+    touch -d '2 seconds ago' /etc/postfix/main.cf
+  fi
 }

--- a/target/scripts/startup/daemons-stack.sh
+++ b/target/scripts/startup/daemons-stack.sh
@@ -32,7 +32,6 @@ function _start_daemon_cron           { _default_start_daemon 'cron'           ;
 function _start_daemon_opendkim       { _default_start_daemon 'opendkim'       ; }
 function _start_daemon_opendmarc      { _default_start_daemon 'opendmarc'      ; }
 function _start_daemon_postsrsd       { _default_start_daemon 'postsrsd'       ; }
-function _start_daemon_postfix        { _default_start_daemon 'postfix'        ; }
 function _start_daemon_rsyslog        { _default_start_daemon 'rsyslog'        ; }
 function _start_daemon_update_check   { _default_start_daemon 'update-check'   ; }
 function _start_daemon_rspamd         { _default_start_daemon 'rspamd'         ; }
@@ -41,6 +40,12 @@ function _start_daemon_redis          { _default_start_daemon 'redis'          ;
 function _start_daemon_saslauthd
 {
   _default_start_daemon "saslauthd_${SASLAUTHD_MECHANISMS}"
+}
+
+function _start_daemon_postfix
+{
+  _adjust_mtime_for_postfix_maincf
+  _default_start_daemon 'postfix'
 }
 
 function _start_daemon_postgrey

--- a/test/helper/common.bash
+++ b/test/helper/common.bash
@@ -28,6 +28,14 @@ function _default_teardown() {
   docker rm -f "${CONTAINER_NAME}"
 }
 
+function _reload_postfix() {
+  local CONTAINER_NAME=${1:-${CONTAINER_NAME}}
+
+  # Reloading Postfix config after modifying it in <2 sec will cause Postfix to delay, workaround that:
+  docker exec "${CONTAINER_NAME}" touch -d '2 seconds ago' /etc/postfix/main.cf
+  docker exec "${CONTAINER_NAME}" postfix reload
+}
+
 # -------------------------------------------------------------------
 
 # @param ${1} program name [REQUIRED]

--- a/test/test_helper/common.bash
+++ b/test/test_helper/common.bash
@@ -9,6 +9,14 @@ NAME=${NAME:-mailserver-testing:ci}
 TEST_TIMEOUT_IN_SECONDS=${TEST_TIMEOUT_IN_SECONDS:-120}
 NUMBER_OF_LOG_LINES=${NUMBER_OF_LOG_LINES:-10}
 
+function _reload_postfix() {
+  local CONTAINER_NAME=$1
+
+  # Reloading Postfix config after modifying it in <2 sec will cause Postfix to delay, workaround that:
+  docker exec "${CONTAINER_NAME}" touch -d '2 seconds ago' /etc/postfix/main.cf
+  docker exec "${CONTAINER_NAME}" postfix reload
+}
+
 # @param ${1} timeout
 # @param --fatal-test <command eval string> additional test whose failure aborts immediately
 # @param ... test to run

--- a/test/tests/parallel/set1/spam_virus/postgrey_enabled.bats
+++ b/test/tests/parallel/set1/spam_virus/postgrey_enabled.bats
@@ -54,9 +54,7 @@ function teardown_file() { _default_teardown ; }
     -e 's/reject_rbl_client.*inet:127\.0\.0\.1:10023$//g' \
     -e 's/smtpd_recipient_restrictions =/smtpd_recipient_restrictions = check_policy_service inet:127.0.0.1:10023/g' \
     /etc/postfix/main.cf
-  # Reloading Postfix config after modifying it in <2 sec will cause Postfix to delay, workaround that:
-  _run_in_container touch -d '2 seconds ago' /etc/postfix/main.cf
-  _run_in_container postfix reload
+  _reload_postfix
 
   # Send test mail (it should fail to deliver):
   _send_test_mail '/tmp/docker-mailserver-test/email-templates/postgrey.txt' '25'

--- a/test/tests/serial/mail_smtponly.bats
+++ b/test/tests/serial/mail_smtponly.bats
@@ -9,6 +9,7 @@ function setup_file() {
     -t "${NAME}"
 
   wait_for_finished_setup_in_container mail_smtponly
+  wait_for_smtp_port_in_container mail_smtponly
 }
 
 function teardown_file() {

--- a/test/tests/serial/mail_smtponly.bats
+++ b/test/tests/serial/mail_smtponly.bats
@@ -45,8 +45,8 @@ function teardown_file() {
 @test "checking smtp_only: mail send should work" {
   run docker exec mail_smtponly /bin/sh -c "postconf smtp_host_lookup=no"
   assert_success
-  run docker exec mail_smtponly /bin/sh -c "/etc/init.d/postfix reload"
-  assert_success
+
+  _reload_postfix mail_smtponly
 
   wait_for_smtp_port_in_container mail_smtponly
   run docker exec mail_smtponly /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/smtp-only.txt"

--- a/test/tests/serial/permit_docker.bats
+++ b/test/tests/serial/permit_docker.bats
@@ -65,8 +65,7 @@ teardown_file() {
   run docker exec mail_smtponly_second_network /bin/sh -c "postconf smtp_host_lookup=no"
   assert_success
 
-  run docker exec mail_smtponly_second_network /bin/sh -c "/etc/init.d/postfix reload"
-  assert_success
+  _reload_postfix mail_smtponly_second_network
 
   # we should be able to send from the other container on the second network!
   run docker exec mail_smtponly_second_network_sender /bin/sh -c "nc mail_smtponly_second_network 25 < /tmp/docker-mailserver-test/email-templates/smtp-only.txt"
@@ -78,8 +77,7 @@ teardown_file() {
   run docker exec mail_smtponly_force_authentication /bin/sh -c "postconf smtp_host_lookup=no"
   assert_success
 
-  run docker exec mail_smtponly_force_authentication /bin/sh -c "/etc/init.d/postfix reload"
-  assert_success
+  _reload_postfix mail_smtponly_force_authentication
 
   # the mailserver should require authentication and a protocol error should occur when using TLS
   run docker exec mail_smtponly_force_authentication /bin/sh -c "nc localhost 25 < /tmp/docker-mailserver-test/email-templates/smtp-only.txt"


### PR DESCRIPTION
# Description

After updating `main.cf`, to avoid an enforced delay from reading the config by postfix tools, we can ensure the modified time is at least 2 seconds in the past as a workaround. This should be ok with our usage AFAIK.

Shaves off 2+ seconds roughly off each container startup, reduces roughly 2+ minutes off tests.

Fixes #2985

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
