### PR TITLE
chore: Remove the Makefile `backup` target

### DIFF
--- a/.github/workflows/test_merge_requests.yml
+++ b/.github/workflows/test_merge_requests.yml
@@ -1,4 +1,4 @@
-name: 'Test Merge Requests'
+name: "Test Merge Requests"
 
 on:
   workflow_dispatch:
@@ -9,6 +9,7 @@ on:
       - .dockerignore
       - .gitmodules
       - Dockerfile
+      - Makefile
       - setup.sh
 
 permissions:
@@ -16,18 +17,18 @@ permissions:
 
 jobs:
   build-image-amd64:
-    name: 'Build AMD64 Image'
+    name: "Build AMD64 Image"
     uses: docker-mailserver/docker-mailserver/.github/workflows/generic_build.yml@master
 
   run-tests:
-    name: 'Test AMD64 Image'
+    name: "Test AMD64 Image"
     needs: build-image-amd64
     uses: docker-mailserver/docker-mailserver/.github/workflows/generic_test.yml@master
     with:
       cache-key: ${{ needs.build-image-amd64.outputs.build-cache-key }}
 
   job-build-arm:
-    name: 'Build ARM64 Image'
+    name: "Build ARM64 Image"
     # Dependency ensures the cache-key is only created for AMD64 builds.
     # ARM64 will not be able to use this cache, building from scratch each time.
     # Expect about 2 minutes extra build time until adopting `type=gha` with scopes for cache.

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,6 @@
 docs/site/
 docker-data/
 
-config.bak
-testconfig.bak
-
 #################################################
 ###  IDEs  ######################################
 #################################################
@@ -20,23 +17,6 @@ testconfig.bak
 ###  Tests  #####################################
 #################################################
 
-test/onedir/
 test/duplicate_configs/
-test/alias/
-test/quota/
-test/relay/
-test/config/key*
-test/config/empty/
 test/config/dovecot-masters.cf
-test/config/dovecot-lmtp/userdb
-test/config/opendkim/keys/domain.tld/
-test/config/opendkim/keys/example.com/
-test/config/opendkim/keys/localdomain2.com/
 test/config/postfix-accounts.cf
-test/config/postfix-aliases.cf
-test/config/postfix-receive-access.cf
-test/config/postfix-receive-access.cfe
-test/config/postfix-send-access.cf
-test/config/postfix-send-access.cfe
-test/config/relay-hosts/chksum
-test/config/relay-hosts/postfix-aliases.cf

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ BATS_PARALLEL_JOBS     ?= 2
 # --- Generic Targets ---------------------------
 # -----------------------------------------------
 
-all: lint build backup generate-accounts tests clean
+all: lint build generate-accounts tests clean
 
 build:
 	@ DOCKER_BUILDKIT=1 docker build \
@@ -28,14 +28,9 @@ generate-accounts: ALWAYS_RUN
 	@ cp test/config/templates/postfix-accounts.cf test/config/postfix-accounts.cf
 	@ cp test/config/templates/dovecot-masters.cf test/config/dovecot-masters.cf
 
-backup:
-# if backup directory exist, clean hasn't been called, therefore
-# we shouldn't overwrite it. It still contains the original content.
-	-@ [[ ! -d testconfig.bak ]] && cp -rp test/config testconfig.bak || :
-
+# `docker ps`:  Remove any lingering test containers
+# `.gitignore`: Remove `test/duplicate_configs` and files copied via `make generate-accounts`
 clean:
-# remove test containers and restore test/config directory
-	-@ [[ -d testconfig.bak ]] && { sudo rm -rf test/config ; mv testconfig.bak test/config ; } || :
 	-@ for CONTAINER in $$(docker ps -a --filter name='^dms-test_.*|^mail_.*|^hadolint$$|^eclint$$|^shellcheck$$' | sed 1d | cut -f 1-1 -d ' '); do docker rm -f $${CONTAINER}; done
 	-@ while read -r LINE; do [[ $${LINE} =~ test/.+ ]] && sudo rm -rf $${LINE}; done < .gitignore
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,9 @@ tests/serial: ALWAYS_RUN
 
 tests/parallel/set%: ALWAYS_RUN
 	@ shopt -s globstar ; ./test/bats/bin/bats $(BATS_FLAGS) \
-		--no-parallelize-within-files --jobs $(BATS_PARALLEL_JOBS) test/$@/**/*.bats
+		--no-parallelize-within-files \
+		--jobs $(BATS_PARALLEL_JOBS) \
+		test/$@/**/*.bats
 
 test/%: ALWAYS_RUN
 	@ shopt -s globstar nullglob ; ./test/bats/bin/bats $(BATS_FLAGS) test/tests/**/{$*,}.bats

--- a/test/tests/serial/no_container.bats
+++ b/test/tests/serial/no_container.bats
@@ -1,144 +1,27 @@
-load "${REPOSITORY_ROOT}/test/test_helper/common"
+load "${REPOSITORY_ROOT}/test/helper/common"
+load "${REPOSITORY_ROOT}/test/helper/setup"
+
+# Tests the `setup.sh` companion script.
+# Only test coverage below is that the config path `-p` and image `-i` options work as intended.
+# NOTE: Must be run in serial mode, as no existing containers should be present.
+BATS_TEST_NAME_PREFIX='[No Existing Container] '
 
 function setup_file() {
-  # Fail early if the test image is already running:
-  assert_not_equal "$(docker ps | grep -o "${NAME}")" "${NAME}"
-  # Test may fail if an existing DMS container is running,
-  # Which can occur from a prior test failing before reaching `no_container.bats`
-  # and that failure not properly handling teardown.
+  # Fail early if the testing image is already running:
+  assert_not_equal "$(docker ps | grep -o "${IMAGE_NAME}")" "${IMAGE_NAME}"
+
+  # Copy the base config that `setup.sh` will volume mount to a container it runs:
+  export TEST_TMP_CONFIG
+  TEST_TMP_CONFIG=$(duplicate_config_for_container . 'no_container')
 }
 
-@test "[No Existing Container] checking setup.sh: setup.sh alias list" {
-  mkdir -p ./test/alias/config && echo "test@example.org test@forward.com" > ./test/alias/config/postfix-virtual.cf
-  run ./setup.sh -p ./test/alias/config alias list
+@test "'setup.sh -p <PATH> -i <IMAGE>' should correctly use options" {
+  # Create a `postfix-virtual.cf` config to verify the container can access it:
+  local MAIL_ALIAS='no_container@example.test no_container@forward.test'
+  echo "${MAIL_ALIAS}" > "${TEST_TMP_CONFIG}/postfix-virtual.cf"
+
+  # Should run the testing image with a volume mount to the provided path:
+  run ./setup.sh -p "${TEST_TMP_CONFIG}" -i "${IMAGE_NAME}" alias list
   assert_success
-}
-
-@test "[No Existing Container] checking setup.sh: setup.sh alias add" {
-  mkdir -p ./test/alias/config && echo "" > ./test/alias/config/postfix-virtual.cf
-  ./setup.sh -p ./test/alias/config alias add alias@example.com target1@forward.com
-  ./setup.sh -p ./test/alias/config alias add alias@example.com target2@forward.com
-  sleep 5
-  run /bin/sh -c 'cat ./test/alias/config/postfix-virtual.cf | grep "alias@example.com target1@forward.com,target2@forward.com" | wc -l | grep 1'
-  assert_success
-}
-
-@test "[No Existing Container] checking setup.sh: setup.sh alias del" {
-  # start with a1 -> t1,t2 and a2 -> t1
-  mkdir -p ./test/alias/config && echo -e 'alias1@example.org target1@forward.com,target2@forward.com\nalias2@example.org target1@forward.com' > ./test/alias/config/postfix-virtual.cf
-
-  # we remove a1 -> t1 ==> a1 -> t2 and a2 -> t1
-  ./setup.sh -p ./test/alias/config alias del alias1@example.org target1@forward.com
-  run grep "target1@forward.com" ./test/alias/config/postfix-virtual.cf
-  assert_output  --regexp "^alias2@example.org +target1@forward.com$"
-
-  run grep "target2@forward.com" ./test/alias/config/postfix-virtual.cf
-  assert_output  --regexp "^alias1@example.org +target2@forward.com$"
-
-  # we remove a1 -> t2 ==> a2 -> t1
-  ./setup.sh -p ./test/alias/config alias del alias1@example.org target2@forward.com
-  run grep "alias1@example.org" ./test/alias/config/postfix-virtual.cf
-  assert_failure
-
-  run grep "alias2@example.org" ./test/alias/config/postfix-virtual.cf
-  assert_success
-
-  # we remove a2 -> t1 ==> empty
-  ./setup.sh -p ./test/alias/config alias del alias2@example.org target1@forward.com
-  run grep "alias2@example.org" ./test/alias/config/postfix-virtual.cf
-  assert_failure
-}
-
-# quota
-@test "[No Existing Container] checking setup.sh: setup.sh setquota" {
-  mkdir -p ./test/quota/config && echo "" > ./test/quota/config/dovecot-quotas.cf
-
-  run ./setup.sh -p ./test/quota/config email add quota_user@example.com test_password
-  run ./setup.sh -p ./test/quota/config email add quota_user2@example.com test_password
-
-  run ./setup.sh -p ./test/quota/config quota set quota_user@example.com 12M
-  assert_success
-  run ./setup.sh -p ./test/quota/config quota set 51M quota_user@example.com
-  assert_failure
-  run ./setup.sh -p ./test/quota/config quota set unknown@domain.com 150M
-  assert_failure
-
-  run ./setup.sh -p ./test/quota/config quota set quota_user2 51M
-  assert_failure
-
-  run /bin/sh -c 'cat ./test/quota/config/dovecot-quotas.cf | grep -E "^quota_user@example.com\:12M\$" | wc -l | grep 1'
-  assert_success
-
-  run ./setup.sh -p ./test/quota/config quota set quota_user@example.com 26M
-  assert_success
-  run /bin/sh -c 'cat ./test/quota/config/dovecot-quotas.cf | grep -E "^quota_user@example.com\:26M\$" | wc -l | grep 1'
-  assert_success
-
-  run grep "quota_user2@example.com" ./test/alias/config/dovecot-quotas.cf
-  assert_failure
-}
-
-@test "[No Existing Container] checking setup.sh: setup.sh delquota" {
-  mkdir -p ./test/quota/config && echo "" > ./test/quota/config/dovecot-quotas.cf
-
-  run ./setup.sh -p ./test/quota/config email add quota_user@example.com test_password
-  run ./setup.sh -p ./test/quota/config email add quota_user2@example.com test_password
-
-  run ./setup.sh -p ./test/quota/config quota set quota_user@example.com 12M
-  assert_success
-  run /bin/sh -c 'cat ./test/quota/config/dovecot-quotas.cf | grep -E "^quota_user@example.com\:12M\$" | wc -l | grep 1'
-  assert_success
-
-
-  run ./setup.sh -p ./test/quota/config quota del unknown@domain.com
-  assert_failure
-  run /bin/sh -c 'cat ./test/quota/config/dovecot-quotas.cf | grep -E "^quota_user@example.com\:12M\$" | wc -l | grep 1'
-  assert_success
-
-  run ./setup.sh -p ./test/quota/config quota del quota_user@example.com
-  assert_success
-  run grep "quota_user@example.com" ./test/alias/config/dovecot-quotas.cf
-  assert_failure
-}
-
-# debug
-
-@test "[No Existing Container] checking setup.sh: setup.sh relay add-domain" {
-  mkdir -p ./test/relay/config && echo -n > ./test/relay/config/postfix-relaymap.cf
-  ./setup.sh -p ./test/relay/config relay add-domain example1.org smtp.relay1.com 2525
-  ./setup.sh -p ./test/relay/config relay add-domain example2.org smtp.relay2.com
-  ./setup.sh -p ./test/relay/config relay add-domain example3.org smtp.relay3.com 2525
-  ./setup.sh -p ./test/relay/config relay add-domain example3.org smtp.relay.com 587
-
-  # check adding
-  run /bin/sh -c 'cat ./test/relay/config/postfix-relaymap.cf | grep -e "^@example1.org\s\+\[smtp.relay1.com\]:2525" | wc -l | grep 1'
-  assert_success
-  # test default port
-  run /bin/sh -c 'cat ./test/relay/config/postfix-relaymap.cf | grep -e "^@example2.org\s\+\[smtp.relay2.com\]:25" | wc -l | grep 1'
-  assert_success
-  # test modifying
-  run /bin/sh -c 'cat ./test/relay/config/postfix-relaymap.cf | grep -e "^@example3.org\s\+\[smtp.relay.com\]:587" | wc -l | grep 1'
-  assert_success
-}
-
-@test "[No Existing Container] checking setup.sh: setup.sh relay add-auth" {
-  mkdir -p ./test/relay/config && echo -n > ./test/relay/config/postfix-sasl-password.cf
-  ./setup.sh -p ./test/relay/config relay add-auth example.org smtp_user smtp_pass
-  ./setup.sh -p ./test/relay/config relay add-auth example2.org smtp_user2 smtp_pass2
-  ./setup.sh -p ./test/relay/config relay add-auth example2.org smtp_user2 smtp_pass_new
-
-  # test adding
-  run /bin/sh -c 'cat ./test/relay/config/postfix-sasl-password.cf | grep -e "^@example.org\s\+smtp_user:smtp_pass" | wc -l | grep 1'
-  assert_success
-  # test updating
-  run /bin/sh -c 'cat ./test/relay/config/postfix-sasl-password.cf | grep -e "^@example2.org\s\+smtp_user2:smtp_pass_new" | wc -l | grep 1'
-  assert_success
-}
-
-@test "[No Existing Container] checking setup.sh: setup.sh relay exclude-domain" {
-  mkdir -p ./test/relay/config && echo -n > ./test/relay/config/postfix-relaymap.cf
-  ./setup.sh -p ./test/relay/config relay exclude-domain example.org
-
-  run /bin/sh -c 'cat ./test/relay/config/postfix-relaymap.cf | grep -e "^@example.org\s*$" | wc -l | grep 1'
-  assert_success
+  assert_output --partial "* ${MAIL_ALIAS}"
 }


### PR DESCRIPTION
# Description

This is no longer serving any value to us. It was made redundant with changes added in Oct 2020.

- The `.gitignore` entries were [added in July 2019](https://github.com/docker-mailserver/docker-mailserver/pull/1196). They are no longer created by our tests.
- A new method to duplicate a base config folder for tests to use was [introduced in Oct 2020](https://github.com/docker-mailserver/docker-mailserver/commit/5fef8a5b780692f37cd5cee58cc948ca3d6f75f3#diff-c5122b538f758ede0753cfb05bc66d01eb445e4ffb97fff9b7140d55d0fa01c2). Part of the [early test extraction efforts](https://github.com/docker-mailserver/docker-mailserver/pull/1613).
- History of the Makefile `backup` target is detailed in a [comment from me in March 2022](https://github.com/docker-mailserver/docker-mailserver/issues/2465#issuecomment-1062313653). It was introduced in 2016. The linked comment discussed removing the `backup` target entirely (_I stumbled upon it and figured I should raise a PR for it_).
- `no_container.bats` was a test creating a bunch of paths, but did not seem all that useful as `setup-cli.bats` covers the bulk of functionality tested. Stripped it down to the only relevant test case.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
