### PR TITLE
Fix SRS link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ If you want to use a bare domain (`hostname` == `domainname`), see [FAQ](https:/
 
 #### SPF/Forwarding Problems
 
-If you got any problems with SPF and/or forwarding mails, give [SRS](https://github.com/roehling/postsrsd/blob/master/README.md) a try. You enable SRS by setting `ENABLE_SRS=1`. See the variable description for further information.
+If you got any problems with SPF and/or forwarding mails, give [SRS](https://github.com/roehling/postsrsd/blob/master/README.rst) a try. You enable SRS by setting `ENABLE_SRS=1`. See the variable description for further information.
 
 #### Ports
 


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
I fixed the link to the readme of the postsrsd repository. I have tried following the link, but it doesn't exist anymore.

<!-- Link the issue which will be fixed (if any) here: -->


## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
