### PR TITLE
fix: Ensure state persisted to `/var/mail-state` retains correct group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,15 +38,13 @@ COPY --link --from=stage-base /etc/passwd /etc/group /etc/
 # Copy over latest DB updates from official ClamAV image.
 # Better than running `freshclam` (which requires extra RAM during build)
 # hadolint ignore=DL3021
-COPY --link --from=docker.io/clamav/clamav:latest /var/lib/clamav /var/lib/clamav
-RUN chown -R clamav:clamav /var/lib/clamav
+COPY --chown=clamav --from=docker.io/clamav/clamav:latest /var/lib/clamav /var/lib/clamav
 
 #
 # Configure stage provides config changes, and adds scripts
 #
 
 FROM stage-base AS stage-configure
-SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 
 # -----------------------------------------------
 # --- ClamAV & FeshClam -------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ EOF
 
 # Copy over latest DB updates from official ClamAV image. Better than running `freshclam` (which requires extra RAM during build)
 # hadolint ignore=DL3021
-COPY --link --from=docker.io/clamav/clamav:latest /var/lib/clamav /var/lib/clamav
+COPY --chown=clamav --link --from=docker.io/clamav/clamav:latest /var/lib/clamav /var/lib/clamav
 
 # -----------------------------------------------
 # --- Dovecot -----------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN chown -R clamav:clamav /var/lib/clamav
 #
 
 FROM stage-base AS stage-configure
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 
 # -----------------------------------------------
 # --- ClamAV & FeshClam -------------------------

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -148,7 +148,6 @@ function _register_functions
   # ? >> Fixes
 
   _register_fix_function '_fix_var_mail_permissions'
-  [[ ${ENABLE_AMAVIS} -eq 1 ]] && _register_fix_function '_fix_var_amavis_permissions'
 
   [[ ${ENABLE_CLAMAV} -eq 0 ]] && _register_fix_function '_fix_cleanup_clamav'
   [[ ${ENABLE_SPAMASSASSIN} -eq 0 ]] &&	_register_fix_function '_fix_cleanup_spamassassin'

--- a/target/scripts/startup/fixes-stack.sh
+++ b/target/scripts/startup/fixes-stack.sh
@@ -21,16 +21,6 @@ function _fix_var_mail_permissions
   _log 'trace' 'Permissions in /var/mail look OK'
 }
 
-function _fix_var_amavis_permissions
-{
-  local AMAVIS_STATE_DIR='/var/mail-state/lib-amavis'
-  [[ ${ONE_DIR} -eq 0 ]] && AMAVIS_STATE_DIR="/var/lib/amavis"
-  [[ ! -e ${AMAVIS_STATE_DIR} ]] && return 0
-
-  _log 'trace' 'Fixing Amavis permissions'
-  chown -hR amavis:amavis "${AMAVIS_STATE_DIR}" || _shutdown 'Failed to fix Amavis permissions'
-}
-
 function _fix_cleanup_clamav
 {
   _log 'trace' 'Cleaning up disabled ClamAV'

--- a/target/scripts/startup/misc-stack.sh
+++ b/target/scripts/startup/misc-stack.sh
@@ -60,10 +60,14 @@ function _misc_save_states
       fi
     done
 
+    # This ensures the user and group of the files from the external mount have their
+    # numeric ID values in sync. New releases where the installed packages order changes
+    # can change the values in the Docker image, causing an ownership mismatch.
     _log 'trace' 'Fixing /var/mail-state/* permissions'
-    [[ ${ENABLE_CLAMAV} -eq 1 ]] && chown -R clamav /var/mail-state/lib-clamav
-    [[ ${ENABLE_SPAMASSASSIN} -eq 1 ]] && chown -R debian-spamd /var/mail-state/lib-spamassassin
-    [[ ${ENABLE_POSTGREY} -eq 1 ]] && chown -R postgrey /var/mail-state/lib-postgrey
+    [[ ${ENABLE_CLAMAV}       -eq 1 ]] && chown -R clamav:clamav /var/mail-state/lib-clamav
+    [[ ${ENABLE_FETCHMAIL}    -eq 1 ]] && chown -R fetchmail:nogroup /var/mail-state/lib-fetchmail
+    [[ ${ENABLE_POSTGREY}     -eq 1 ]] && chown -R postgrey:postgrey /var/mail-state/lib-postgrey
+    [[ ${ENABLE_SPAMASSASSIN} -eq 1 ]] && chown -R debian-spamd:debian-spamd /var/mail-state/lib-spamassassin
 
     chown -R postfix:postfix /var/mail-state/lib-postfix
 

--- a/target/scripts/startup/misc-stack.sh
+++ b/target/scripts/startup/misc-stack.sh
@@ -67,6 +67,7 @@ function _misc_save_states
     # numeric ID values in sync. New releases where the installed packages order changes
     # can change the values in the Docker image, causing an ownership mismatch.
     _log 'trace' 'Fixing /var/mail-state/* permissions'
+    [[ ${ENABLE_AMAVIS}       -eq 1 ]] && chown -R amavis:amavis /var/mail-state/lib-amavis
     [[ ${ENABLE_CLAMAV}       -eq 1 ]] && chown -R clamav:clamav /var/mail-state/lib-clamav
     [[ ${ENABLE_FETCHMAIL}    -eq 1 ]] && chown -R fetchmail:nogroup /var/mail-state/lib-fetchmail
     [[ ${ENABLE_POSTGREY}     -eq 1 ]] && chown -R postgrey:postgrey /var/mail-state/lib-postgrey

--- a/target/scripts/startup/misc-stack.sh
+++ b/target/scripts/startup/misc-stack.sh
@@ -67,10 +67,10 @@ function _misc_save_states
     # numeric ID values in sync. New releases where the installed packages order changes
     # can change the values in the Docker image, causing an ownership mismatch.
     _log 'trace' 'Fixing /var/mail-state/* permissions'
-    [[ ${ENABLE_AMAVIS}       -eq 1 ]] && chown -R amavis:amavis /var/mail-state/lib-amavis
-    [[ ${ENABLE_CLAMAV}       -eq 1 ]] && chown -R clamav:clamav /var/mail-state/lib-clamav
-    [[ ${ENABLE_FETCHMAIL}    -eq 1 ]] && chown -R fetchmail:nogroup /var/mail-state/lib-fetchmail
-    [[ ${ENABLE_POSTGREY}     -eq 1 ]] && chown -R postgrey:postgrey /var/mail-state/lib-postgrey
+    [[ ${ENABLE_AMAVIS}       -eq 1 ]] && chown -R amavis:amavis             /var/mail-state/lib-amavis
+    [[ ${ENABLE_CLAMAV}       -eq 1 ]] && chown -R clamav:clamav             /var/mail-state/lib-clamav
+    [[ ${ENABLE_FETCHMAIL}    -eq 1 ]] && chown -R fetchmail:nogroup         /var/mail-state/lib-fetchmail
+    [[ ${ENABLE_POSTGREY}     -eq 1 ]] && chown -R postgrey:postgrey         /var/mail-state/lib-postgrey
     [[ ${ENABLE_SPAMASSASSIN} -eq 1 ]] && chown -R debian-spamd:debian-spamd /var/mail-state/lib-spamassassin
 
     chown -R postfix:postfix /var/mail-state/lib-postfix

--- a/target/scripts/startup/misc-stack.sh
+++ b/target/scripts/startup/misc-stack.sh
@@ -66,6 +66,8 @@ function _misc_save_states
     # This ensures the user and group of the files from the external mount have their
     # numeric ID values in sync. New releases where the installed packages order changes
     # can change the values in the Docker image, causing an ownership mismatch.
+    # NOTE: More details about users and groups added during image builds are documented here:
+    # https://github.com/docker-mailserver/docker-mailserver/pull/3011#issuecomment-1399120252
     _log 'trace' 'Fixing /var/mail-state/* permissions'
     [[ ${ENABLE_AMAVIS}       -eq 1 ]] && chown -R amavis:amavis             /var/mail-state/lib-amavis
     [[ ${ENABLE_CLAMAV}       -eq 1 ]] && chown -R clamav:clamav             /var/mail-state/lib-clamav

--- a/target/scripts/startup/misc-stack.sh
+++ b/target/scripts/startup/misc-stack.sh
@@ -65,14 +65,17 @@ function _misc_save_states
     [[ ${ENABLE_SPAMASSASSIN} -eq 1 ]] && chown -R debian-spamd /var/mail-state/lib-spamassassin
     [[ ${ENABLE_POSTGREY} -eq 1 ]] && chown -R postgrey /var/mail-state/lib-postgrey
 
-    chown -R postfix /var/mail-state/lib-postfix
+    chown -R postfix:postfix /var/mail-state/lib-postfix
 
+    # NOTE: The Postfix spool location has mixed owner/groups to take into account:
     # UID = postfix(101): active, bounce, corrupt, defer, deferred, flush, hold, incoming, maildrop, private, public, saved, trace
     # UID = root(0): dev, etc, lib, pid, usr
     # GID = postdrop(103): maildrop, public
     # GID for all other directories is root(0)
+    # NOTE: `spool-postfix/private/` will be set to `postfix:postfix` when Postfix starts / restarts
     # Set most common ownership:
     chown -R postfix:root /var/mail-state/spool-postfix
+    chown root:root /var/mail-state/spool-postfix
     # These two require the postdrop(103) group:
     chgrp -R postdrop /var/mail-state/spool-postfix/maildrop
     chgrp -R postdrop /var/mail-state/spool-postfix/public

--- a/target/scripts/startup/misc-stack.sh
+++ b/target/scripts/startup/misc-stack.sh
@@ -33,8 +33,8 @@ function _misc_save_states
     [[ ${ENABLE_FAIL2BAN} -eq 1 ]] && FILES+=('lib/fail2ban')
     [[ ${ENABLE_FETCHMAIL} -eq 1 ]] && FILES+=('lib/fetchmail')
     [[ ${ENABLE_POSTGREY} -eq 1 ]] && FILES+=('lib/postgrey')
-    [[ ${ENABLE_RSPAMD} -ne 1 ]] && FILES+=('lib/rspamd')
-    # [[ ${ENABLE_RSPAMD} -ne 1 ]] && FILES+=('lib/redis')
+    [[ ${ENABLE_RSPAMD} -eq 1 ]] && FILES+=('lib/rspamd')
+    # [[ ${ENABLE_RSPAMD} -eq 1 ]] && FILES+=('lib/redis')
     [[ ${ENABLE_SPAMASSASSIN} -eq 1 ]] && FILES+=('lib/spamassassin')
     [[ ${SMTP_ONLY} -ne 1 ]] && FILES+=('lib/dovecot')
 


### PR DESCRIPTION
# Description

This PR covers changes mostly related to `misc-stack.sh`:
- Some minor refactoring of the conditional handling in the symlink loop (see commit for details).
- Ensures `chown -R` is more explicit about not only setting the user, but also the correct group. Postfix also needed a little adjustment there.
- Moves the related functionality for Amavis to be handled with the rest instead of a separate function call.
- Fixes `misc-stack.sh` rspamd ENV condition to add to `FILES` array when enabled, not disabled. This typo was missed [during initial review](https://github.com/docker-mailserver/docker-mailserver/pull/2902).

Likewise we've had a [similar issue with our `Dockerfile` copying over ClamAV database files](https://github.com/docker-mailserver/docker-mailserver/issues/2942#issuecomment-1383512079) from their official image. This prompted reviewing `misc-stack.sh` which should fix the issue for the user.

Fixes #2942 

## References

- [I previously wrote a similar PR adjusting `misc-stack.sh`](https://github.com/docker-mailserver/docker-mailserver/pull/2273), particularly for Postfix. It may be useful reference for any future maintainer stumbling on these kind of changes.
- Contribution of the [original Amavis fix was in Feb 2017](https://github.com/docker-mailserver/docker-mailserver/pull/510). Another contributor [describes the bug in the associated issue](https://github.com/docker-mailserver/docker-mailserver/issues/507#issuecomment-277800277), which is the same bug we've recently had reported with ClamAV I think. Hence being more thorough with the `chown -R` usage in `misc-stack.sh` (_and making it more clear about the purpose via comment_).
- `COPY --link` was [introduced into the `Dockerfile` in the `v11.2` release](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v11.2.0) in [this Sep 2022 PR](https://github.com/docker-mailserver/docker-mailserver/pull/2755).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
