### PR TITLE
quality-of-life: improve the `clean` recipe (don't require `sudo` anymore)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ generate-accounts: ALWAYS_RUN
 # `.gitignore`: Remove `test/duplicate_configs` and files copied via `make generate-accounts`
 clean: ALWAYS_RUN
 	-@ while read -r LINE; do CONTAINERS+=("$${LINE}"); done < <(docker ps -qaf name='^(dms-test|mail)_.*') ; \
-	for CONTAINER in "$${CONTAINERS[@]}"; do docker rm -f "$${CONTAINER}"; done
+		for CONTAINER in "$${CONTAINERS[@]}"; do docker rm -f "$${CONTAINER}"; done
 	-@ while read -r LINE; do [[ $${LINE} =~ test/.+ ]] && FILES+=("/mnt$${LINE#test}"); done < .gitignore ; \
-	docker run --rm -v "$(REPOSITORY_ROOT)/test/:/mnt" docker.io/alpine:3.17.1 ash -c "rm -rf $${FILES[@]}"
+		docker run --rm -v "$(REPOSITORY_ROOT)/test/:/mnt" alpine ash -c "rm -rf $${FILES[@]}"
 
 # -----------------------------------------------
 # --- Tests  ------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ generate-accounts: ALWAYS_RUN
 # `.gitignore`: Remove `test/duplicate_configs` and files copied via `make generate-accounts`
 clean: ALWAYS_RUN
 	-@ for CONTAINER in $$(docker ps -a --filter name='^dms-test_.*|^mail_.*|^hadolint$$|^eclint$$|^shellcheck$$' | sed 1d | cut -f 1-1 -d ' '); do docker rm -f $${CONTAINER}; done
-	-@ declare -a FILES ; while read -r LINE; do [[ $${LINE} =~ test/.+ ]] && FILES+=("/mnt$${LINE#test}"); done < .gitignore ; docker run --rm --volume "$(REPOSITORY_ROOT)/test/:/mnt" docker.io/alpine:3.17.1 rm -rf "$${FILES[@]}"
+	-@ declare -a FILES ; while read -r LINE; do [[ $${LINE} =~ test/.+ ]] && FILES+=("/mnt$${LINE#test}"); done < .gitignore ; docker run --rm --volume "$(REPOSITORY_ROOT)/test/:/mnt" docker.io/alpine:3.17.1 ash -c "rm -rf '$${FILES[@]}'"
 
 # -----------------------------------------------
 # --- Tests  ------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ generate-accounts: ALWAYS_RUN
 # `.gitignore`: Remove `test/duplicate_configs` and files copied via `make generate-accounts`
 clean: ALWAYS_RUN
 	-@ for CONTAINER in $$(docker ps -a --filter name='^dms-test_.*|^mail_.*|^hadolint$$|^eclint$$|^shellcheck$$' | sed 1d | cut -f 1-1 -d ' '); do docker rm -f $${CONTAINER}; done
-	-@ while read -r LINE; do [[ $${LINE} =~ test/.+ ]] && sudo rm -rf $${LINE}; done < .gitignore
+	-@ declare -a FILES ; while read -r LINE; do [[ $${LINE} =~ test/.+ ]] && FILES+=("/mnt$${LINE#test}"); done < .gitignore ; docker run --rm --volume "$(REPOSITORY_ROOT)/test/:/mnt" docker.io/alpine:3.17.1 rm -rf "$${FILES[@]}"
 
 # -----------------------------------------------
 # --- Tests  ------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,10 @@ generate-accounts: ALWAYS_RUN
 # `docker ps`:  Remove any lingering test containers
 # `.gitignore`: Remove `test/duplicate_configs` and files copied via `make generate-accounts`
 clean: ALWAYS_RUN
-	-@ for CONTAINER in $$(docker ps -a --filter name='^dms-test_.*|^mail_.*|^hadolint$$|^eclint$$|^shellcheck$$' | sed 1d | cut -f 1-1 -d ' '); do docker rm -f $${CONTAINER}; done
-	-@ declare -a FILES ; while read -r LINE; do [[ $${LINE} =~ test/.+ ]] && FILES+=("/mnt$${LINE#test}"); done < .gitignore ; docker run --rm --volume "$(REPOSITORY_ROOT)/test/:/mnt" docker.io/alpine:3.17.1 ash -c "rm -rf '$${FILES[@]}'"
+	-@ while read -r LINE; do CONTAINERS+=("$${LINE}"); done < <(docker ps -qaf name='^(dms-test|mail)_.*') ; \
+	for CONTAINER in "$${CONTAINERS[@]}"; do docker rm -f "$${CONTAINER}"; done
+	-@ while read -r LINE; do [[ $${LINE} =~ test/.+ ]] && FILES+=("/mnt$${LINE#test}"); done < .gitignore ; \
+	docker run --rm -v "$(REPOSITORY_ROOT)/test/:/mnt" docker.io/alpine:3.17.1 ash -c "rm -rf $${FILES[@]}"
 
 # -----------------------------------------------
 # --- Tests  ------------------------------------

--- a/test/linting/lint.sh
+++ b/test/linting/lint.sh
@@ -21,7 +21,7 @@ function _eclint
   if docker run --rm --tty \
     --volume "${REPOSITORY_ROOT}:/ci:ro" \
     --workdir "/ci" \
-    --name eclint \
+    --name dms-test_eclint \
     "mstruebing/editorconfig-checker:${ECLINT_VERSION}" ec -config "/ci/test/linting/.ecrc.json"
   then
     _log 'info' 'ECLint succeeded'
@@ -36,6 +36,7 @@ function _hadolint
   if docker run --rm --tty \
     --volume "${REPOSITORY_ROOT}:/ci:ro" \
     --workdir "/ci" \
+    --name dms-test_hadolint \
     "hadolint/hadolint:v${HADOLINT_VERSION}-alpine" hadolint --config "/ci/test/linting/.hadolint.yaml" Dockerfile
   then
     _log 'info' 'Hadolint succeeded'
@@ -89,6 +90,7 @@ function _shellcheck
   if docker run --rm --tty \
     --volume "${REPOSITORY_ROOT}:/ci:ro" \
     --workdir "/ci" \
+    --name dms-test_shellcheck \
     "koalaman/shellcheck-alpine:v${SHELLCHECK_VERSION}" ${CMD_SHELLCHECK[@]}
   then
     _log 'info' 'ShellCheck succeeded'


### PR DESCRIPTION
# Description

This bugged me for a long time: we need `sudo` when running `make clean`, which is undesirable as you can image. I implemented a proper solution:

We run a small container (Alpine) and mount the files we need to remove into the container. This has the advantage that users that run Docker with an unprivilged user now don't have to type their sudo-password anymore and users that run Docker by default with password will need to type in the passward, but they need to do this anyways because of the command before.

---

To explain what I did: I introduced an array where I save files in. The `.gitignore` is still read, but the files read in the loop are now saved in the array. I adjust the path, prefixing `/mnt` and removing the `test` prefix from the file path before so the path is correct inside the container. I can then just mount the whole test directory at `/mnt` inside the container and run an `rm -rf` inside the container on the `FILES` array. Done. Enjoy :D

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
