### PR TITLE
postfix header filter: correct the casing for Mime vs. MIME

### DIFF
--- a/target/postfix/sender_header_filter.pcre
+++ b/target/postfix/sender_header_filter.pcre
@@ -2,7 +2,7 @@
 /^\s*Received:.*amavisd-new/        IGNORE
 /^\s*X-Originating-IP:/             IGNORE
 /^\s*X-Mailer:/                     IGNORE
-/^\s*Mime-Version: 1.0.*/           REPLACE Mime-Version: 1.0
+/^\s*Mime-Version: 1.0.*/           REPLACE MIME-Version: 1.0
 /^\s*User-Agent/                    IGNORE
 /^\s*X-Enigmail/                    IGNORE
 /^\s*X-Mailer/                      IGNORE


### PR DESCRIPTION
# Description

This occured to me when looking at my Rspamd logs. Messages I sent were given a penalty (0.5) for not using the correct case (uppercase).

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
