### PR TITLE
postfix: adjust header checks for outgoing emails

### DIFF
--- a/target/postfix/sender_header_filter.pcre
+++ b/target/postfix/sender_header_filter.pcre
@@ -1,11 +1,3 @@
-/^\s*Received:.*with ESMTPSA/       IGNORE
-/^\s*Received:.*amavisd-new/        IGNORE
-/^\s*X-Originating-IP:/             IGNORE
-/^\s*X-Mailer:/                     IGNORE
-/^\s*Mime-Version: 1.0.*/           REPLACE MIME-Version: 1.0
-/^\s*User-Agent/                    IGNORE
-/^\s*X-Enigmail/                    IGNORE
-/^\s*X-Mailer/                      IGNORE
-/^\s*X-Originating-IP/              IGNORE
-/^\s*Received: from.*127.0.0.1/     IGNORE
-
+/^Received: .*/            IGNORE
+/^User-Agent: .*/          IGNORE
+/^Mime-Version: 1.0.*/     REPLACE MIME-Version: 1.0


### PR DESCRIPTION
# Description

I consulted the Arch wiki and found the first two options in the new adjusted file (`Received` & `User-Agent`) (here
https://wiki.archlinux.org/title/postfix). This immediately made sense to me, so I added them.

I then looked through various emails I sent (with different mail clients as well). I could find none of the headers in the file except for the MIME version, which contained user agent information, so I kept the replacement there as well.

I removed the other entries; they seemed either useless or pretty niche to me.

---

References:

1. https://github.com/docker-mailserver/docker-mailserver/pull/3040#issuecomment-1407877464
2. https://github.com/docker-mailserver/docker-mailserver/pull/3040#issuecomment-1408106883

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
