### PR TITLE
tests: Reduce time taken by a third for testing cipher suites

### DIFF
--- a/test/tests/parallel/set2/tls_cipherlists.bats
+++ b/test/tests/parallel/set2/tls_cipherlists.bats
@@ -153,6 +153,7 @@ function _collect_cipherlists() {
     --mode parallel
     --overwrite
     --preference
+    --openssl /usr/bin/openssl
   )
   # NOTE: Batch testing ports via `--file` doesn't properly bubble up failure.
   # If the failure for a test is misleading consider testing a single port with:


### PR DESCRIPTION
# Description

This improvement is from [investigating the performance of `testssl.sh` containers](https://github.com/drwetter/testssl.sh/issues/2299#issuecomment-1409545691). The test goes from ~300 sec locally to ~200 sec.

Using `--openssl` uses the native `openssl` package within the image instead of the older `1.0.2` bundled from `testssl.sh`.

The test is only testing cipher suite compatibility is what we expect it to be, thus we do not need to run `testssl.sh` with a broader range of ciphers.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
