### PR TITLE
fix: Only listen on `127.0.0.1` for the Dovecot `quota-status` service

### DIFF
--- a/target/dovecot/90-quota.conf
+++ b/target/dovecot/90-quota.conf
@@ -42,8 +42,8 @@ service quota-warning {
 service quota-status {
     executable = quota-status -p postfix
     inet_listener {
-    port = 65265
-    # You can choose any port you want
+        address = 127.0.0.1
+        port = 65265
     }
     client_limit = 1
 }


### PR DESCRIPTION
# Description

Docker-Mailserver has dovecot listen on port 65265 for any address. When using host networking, that isn't necessarily desirable. Fix existing indentation.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
  Fairly confident.
- [x] I have performed a self-review of my own code
  And a test.
- [ ] I have commented my code, particularly in hard-to-understand areas
  Not sure it's worth it.
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
  The docs don't mention the port. All existing code already uses localhost.
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
  Not sure it's worth it.
- [x] New and existing unit tests pass locally with my changes
