### PR TITLE
ci: remove CI ENV & disable fail-fast

### DIFF
--- a/.github/workflows/generic_test.yml
+++ b/.github/workflows/generic_test.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         part: [serial, parallel/set1, parallel/set2, parallel/set3]
+      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -49,5 +50,3 @@ jobs:
 
       - name: 'Run tests'
         run: make generate-accounts tests/${{ matrix.part }}
-        env:
-          CI: true


### PR DESCRIPTION
# Description

1. BATS will actaully correctly determine that it is running in a CI environment, so we can omit the `CI` variable (not needed at all) (see a run in a fork if mine: <https://github.com/georglauterbach/docker-mailserver/actions/runs/4103019817/jobs/7076744395>)
2. When a current test is failing, all other parallel jobs are stopped by GH actions due to their fail-fast approach. While this is nice for many use cases, it's not in our case - so I disabled it. Now, all tests are running to completion.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
