### PR TITLE
ci(fix): Temporarily avoid specifying `provenance`

### DIFF
--- a/.github/workflows/generic_test.yml
+++ b/.github/workflows/generic_test.yml
@@ -34,12 +34,14 @@ jobs:
           path: /tmp/.buildx-cache
           key: cache-buildx-${{ inputs.cache-key }}
 
+      # Configures buildx to use `docker-container` driver,
+      # Ensures consistent BuildKit version (not coupled to Docker Engine),
+      # and increased compatibility of the build cache vs mixing buildx drivers.
       - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@v2.4.0
 
       # Importing from the cache should create the image within approx 30 seconds:
-      # NOTE: Earlier `buildx` + `qemu` steps are not needed as no cache is exported,
-      # and only a single platform (AMD64) is loaded:
+      # NOTE: `qemu` step is not needed as we only test for AMD64.
       - name: 'Build AMD64 image from cache'
         uses: docker/build-push-action@v4.0.0
         with:

--- a/.github/workflows/generic_test.yml
+++ b/.github/workflows/generic_test.yml
@@ -34,8 +34,11 @@ jobs:
           path: /tmp/.buildx-cache
           key: cache-buildx-${{ inputs.cache-key }}
 
+      - name: 'Set up Docker Buildx'
+        uses: docker/setup-buildx-action@v2.4.0
+
       # Importing from the cache should create the image within approx 30 seconds:
-      # Earlier `buildx` + `qemu` steps are not needed as no cache is exported,
+      # NOTE: Earlier `buildx` + `qemu` steps are not needed as no cache is exported,
       # and only a single platform (AMD64) is loaded:
       - name: 'Build AMD64 image from cache'
         uses: docker/build-push-action@v4.0.0
@@ -47,9 +50,8 @@ jobs:
           # Rebuilds the AMD64 image from the cache:
           platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
-          # TODO: Enable this once Docker Engine is v23 or buildx is consistently >=0.10.2
           # Disable provenance attestation: https://docs.docker.com/build/attestations/slsa-provenance/
-          # provenance: false
+          provenance: false
 
       - name: 'Run tests'
         run: make generate-accounts tests/${{ matrix.part }}

--- a/.github/workflows/generic_test.yml
+++ b/.github/workflows/generic_test.yml
@@ -47,8 +47,9 @@ jobs:
           # Rebuilds the AMD64 image from the cache:
           platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
+          # TODO: Enable this once Docker Engine is v23 or buildx is consistently >=0.10.2
           # Disable provenance attestation: https://docs.docker.com/build/attestations/slsa-provenance/
-          provenance: false
+          # provenance: false
 
       - name: 'Run tests'
         run: make generate-accounts tests/${{ matrix.part }}


### PR DESCRIPTION
# Description

As the test workflow does not use the `docker-container` buildx driver (_our build and publish workflows do_), it uses the Docker Engine bundled BuildKit version (_BuildKit release over 2 years old_) which until the recent v23 release (Feb 2023) does not support attestations. Github should have v23 available in runners sometime this month.

This driver difference is causing the current CI failures for test workflow runs:

- `docker/build-push-action` v4 will only [add the `--provenance` option to buildx command, if explicitly configured in the action](https://github.com/docker/build-push-action/pull/784/files). By not adding a value we can avoid causing this failure happening in buildx.
- The option is only valid in buildx `0.10.0` when there is a version of BuildKit that supports it. The option will cause buildx to fail early if the feature is not available the detected BuildKit (_only when supported, does it acknowledge an opt-out_). This appears to be resolved in newer buildx releases, at least `0.10.2`.

---

As the test workflows don't do anything with Docker beyond re-use the build cache to import a local image for testing, the value of `--provenance` isn't relevant to this workflow regardless.

Alternative options considered were:
- Also use a `docker-container` driver to always use the same BuildKit version (_only during the rebuild of the image, not that relevant to this workflow_).
- Continue to allow CI failure until Github's updates to Docker Engine (_expected to arrive within a week_).
- Reverting the action version won't make a difference, [previously we used v3.3](https://github.com/docker-mailserver/docker-mailserver/pull/3008) for the past 3 weeks (_It by [default enabled provenance when supported](https://github.com/docker/build-push-action/pull/781#issue-1559752499)_). It was just the addition of `--provenance` option to buildx.

## References

- CI failure investigation: https://github.com/docker-mailserver/docker-mailserver/pull/3060#issuecomment-1421662676
- Upstream issue: https://github.com/docker/buildx/issues/1608
- Upgrade of `docker/build-push-action` to v4 PR that introduced the issue (_due to `provenance: false`, not v4_): https://github.com/docker-mailserver/docker-mailserver/pull/3066

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
