### PR TITLE
fix: add information to Logwatch's mailer so `Envelope From` is properly set

### DIFF
--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -1088,6 +1088,7 @@ function _setup_logwatch
 {
   echo 'LogFile = /var/log/mail/freshclam.log' >>/etc/logwatch/conf/logfiles/clam-update.conf
   echo "MailFrom = ${LOGWATCH_SENDER}" >>/etc/logwatch/conf/logwatch.conf
+  echo "Mailer = \"sendmail -t -f ${LOGWATCH_SENDER}\"" >>/etc/logwatch/conf/logwatch.conf
 
   case "${LOGWATCH_INTERVAL}" in
     ( 'daily' | 'weekly' )


### PR DESCRIPTION
# Description

I came across this when looking at Rspamd logs. Logwatch does not set the "Envelope From" header properly and the return path is also wrong (it uses `root@mail.<DOMAINNAME>`).

With the new addition, the correct header is set as specified in `LOGWATCH_SENDER`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
