### PR TITLE
fix: order of DKIM/DMARC milters matters

### DIFF
--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -634,51 +634,52 @@ function _setup_SRS
 
 function _setup_dkim_dmarc
 {
+  if [[ ${ENABLE_OPENDKIM} -eq 1 ]]
+  then
+    _log 'debug' 'Setting up DKIM'
+
+    mkdir -p /etc/opendkim/keys/
+    touch /etc/opendkim/SigningTable
+    touch /etc/opendkim/TrustedHosts
+
+    _log 'trace' "Adding OpenDKIM to Postfix's milters"
+    # shellcheck disable=SC2016
+    sed -i -E 's|^(smtpd_milters =.*)|\1 \$dkim_milter|g' /etc/postfix/main.cf
+    # shellcheck disable=SC2016
+    sed -i -E 's|^(non_smtpd_milters =.*)|\1 \$dkim_milter|g' /etc/postfix/main.cf
+
+    # check if any keys are available
+    if [[ -e "/tmp/docker-mailserver/opendkim/KeyTable" ]]
+    then
+      cp -a /tmp/docker-mailserver/opendkim/* /etc/opendkim/
+
+      local KEYS
+      KEYS=$(find /etc/opendkim/keys/ -type f -maxdepth 1)
+      _log 'trace' "DKIM keys added for: ${KEYS}"
+      _log 'trace' "Changing permissions on '/etc/opendkim'"
+
+      chown -R opendkim:opendkim /etc/opendkim/
+      chmod -R 0700 /etc/opendkim/keys/
+    else
+      _log 'debug' 'No DKIM key(s) provided - check the documentation on how to get your keys'
+      [[ ! -f /etc/opendkim/KeyTable ]] && touch /etc/opendkim/KeyTable
+    fi
+
+    # setup nameservers parameter from /etc/resolv.conf if not defined
+    if ! grep '^Nameservers' /etc/opendkim.conf
+    then
+      echo "Nameservers $(grep '^nameserver' /etc/resolv.conf | awk -F " " '{print $2}' | paste -sd ',' -)" >>/etc/opendkim.conf
+
+      _log 'trace' "Nameservers added to '/etc/opendkim.conf'"
+    fi
+  fi
+
   if [[ ${ENABLE_OPENDMARC} -eq 1 ]]
   then
     _log 'trace' "Adding OpenDMARC to Postfix's milters"
 
     # shellcheck disable=SC2016
     sed -i -E 's|^(smtpd_milters =.*)|\1 \$dmarc_milter|g' /etc/postfix/main.cf
-  fi
-
-  [[ ${ENABLE_OPENDKIM} -eq 1 ]] || return 0
-
-  _log 'debug' 'Setting up DKIM'
-
-  mkdir -p /etc/opendkim/keys/
-  touch /etc/opendkim/SigningTable
-  touch /etc/opendkim/TrustedHosts
-
-  _log 'trace' "Adding OpenDKIM to Postfix's milters"
-  # shellcheck disable=SC2016
-  sed -i -E 's|^(smtpd_milters =.*)|\1 \$dkim_milter|g' /etc/postfix/main.cf
-  # shellcheck disable=SC2016
-  sed -i -E 's|^(non_smtpd_milters =.*)|\1 \$dkim_milter|g' /etc/postfix/main.cf
-
-  # check if any keys are available
-  if [[ -e "/tmp/docker-mailserver/opendkim/KeyTable" ]]
-  then
-    cp -a /tmp/docker-mailserver/opendkim/* /etc/opendkim/
-
-    local KEYS
-    KEYS=$(find /etc/opendkim/keys/ -type f -maxdepth 1)
-    _log 'trace' "DKIM keys added for: ${KEYS}"
-    _log 'trace' "Changing permissions on '/etc/opendkim'"
-
-    chown -R opendkim:opendkim /etc/opendkim/
-    chmod -R 0700 /etc/opendkim/keys/
-  else
-    _log 'debug' 'No DKIM key(s) provided - check the documentation on how to get your keys'
-    [[ ! -f /etc/opendkim/KeyTable ]] && touch /etc/opendkim/KeyTable
-  fi
-
-  # setup nameservers parameter from /etc/resolv.conf if not defined
-  if ! grep '^Nameservers' /etc/opendkim.conf
-  then
-    echo "Nameservers $(grep '^nameserver' /etc/resolv.conf | awk -F " " '{print $2}' | paste -sd ',' -)" >>/etc/opendkim.conf
-
-    _log 'trace' "Nameservers added to '/etc/opendkim.conf'"
   fi
 }
 


### PR DESCRIPTION
# Description

This PR fixes a regression introduced with #3016, where the postfix setting `smtpd_milters ` changed the order of the values 
from `smtpd_milters = $dkim_milter $dmarc_milter`
to `smtpd_milters = $dmarc_milter $dkim_milter`.

The changed order led to this kind of DMARC failures:

<details>
<summary>Details</summary>

```
Jan 31 21:00:05 mail postfix/postscreen[22649]: CONNECT from [209.85.128.51]:53204 to [172.19.0.2]:25
Jan 31 21:00:11 mail postfix/postscreen[22649]: PASS NEW [209.85.128.51]:53204
Jan 31 21:00:11 mail postfix/smtpd[22650]: connect from mail-wm1-f51.google.com[209.85.128.51]
Jan 31 21:00:11 mail postfix/smtpd[22650]: Anonymous TLS connection established from mail-wm1-f51.google.com[209.85.128.51]: TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits) key-exchange X25519 server-signature RSA-PSS (2048 bits) server-digest SHA256
Jan 31 21:00:11 mail postfix/smtpd[22650]: warning: restriction `reject_authenticated_sender_login_mismatch' ignored: no SASL support
Jan 31 21:00:11 mail policyd-spf[22655]: prepend Received-SPF: Pass (mailfrom) identity=mailfrom; client-ip=209.85.128.51; helo=mail-wm1-f51.google.com; envelope-from=foobar+caf_=postmaster=mydomain.tld@gmail.com; receiver=<UNKNOWN>
Jan 31 21:00:11 mail postfix/smtpd[22650]: A9F9335803BE: client=mail-wm1-f51.google.com[209.85.128.51]
Jan 31 21:00:11 mail postfix/cleanup[22656]: A9F9335803BE: message-id=<00000000000065e72305f393f049@google.com>
Jan 31 21:00:11 mail opendmarc[2523]: A9F9335803BE ignoring Authentication-Results at 15 from mx.google.com
Jan 31 21:00:11 mail opendmarc[2523]: A9F9335803BE: google.com fail
Jan 31 21:00:11 mail postfix/cleanup[22656]: A9F9335803BE: milter-reject: END-OF-MESSAGE from mail-wm1-f51.google.com[209.85.128.51]: 5.7.1 rejected by DMARC policy for google.com; from=<foobar+caf_=postmaster=mydomain.tld@gmail.com> to=<postmaster@mydomain.tld> proto=ESMTP helo=<mail-wm1-f51.google.com>
Jan 31 21:00:44 mail postfix/smtpd[22650]: disconnect from mail-wm1-f51.google.com[209.85.128.51] ehlo=2 starttls=1 mail=1 rcpt=1 bdat=0/1 rset=1 quit=1 commands=7/8
```
</details>

I switched back the order of the two conditions:

1. `[[ ${ENABLE_OPENDMARC} -eq 1 ]]`
2. `[[ ${ENABLE_OPENDKIM} -eq 1 ]]`

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
