### PR TITLE
fix: Postfix service should proxy signals received

### DIFF
--- a/target/supervisor/conf.d/supervisor-app.conf
+++ b/target/supervisor/conf.d/supervisor-app.conf
@@ -131,7 +131,7 @@ autostart=false
 autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
-command=postfix start-fg
+command=/usr/bin/pidproxy /var/spool/postfix/pid/master.pid /usr/sbin/postfix start-fg
 
 [program:changedetector]
 startsecs=0


### PR DESCRIPTION
# Description

`postfix start-fg` was not properly responding to signals received to stop. This caused `supervisorctl restart postfix` and `supervisor stop postfix` to not work as expected (_stopping the Postfix master process, before attempting to start the service again_).

Supervisor does not support custom commands for restarting or stopping a service, relying only on managing the process via  a signal. In the past we used a wrapper script to TRAP the signals and trigger commands that way.

However there is a feature which allows us to proxy signals to a different process by referencing a PID file. As Postfix master process creates a pid file when started, we can avoid a wrapper script and the `supervisorctl` functionality works as intended :+1:

---

Fixes #3116 

This is a fix to a change scheduled for upcoming v12: https://github.com/docker-mailserver/docker-mailserver/pull/3033

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
