### PR TITLE
config: ensure SASL socket file is not inside a volume mount

### DIFF
--- a/target/dovecot/10-master.conf
+++ b/target/dovecot/10-master.conf
@@ -100,7 +100,7 @@ service auth {
   }
 
   # Postfix smtp-auth
-  unix_listener /var/spool/postfix/private/auth {
+  unix_listener /var/tmp/sasl-auth.socket {
     mode = 0666
     user = docker
     group = docker

--- a/target/dovecot/10-master.conf
+++ b/target/dovecot/10-master.conf
@@ -100,7 +100,7 @@ service auth {
   }
 
   # Postfix smtp-auth
-  unix_listener /var/tmp/sasl-auth.socket {
+  unix_listener /dev/shm/sasl-auth.sock {
     mode = 0660
     user = postfix
     group = postfix

--- a/target/dovecot/10-master.conf
+++ b/target/dovecot/10-master.conf
@@ -101,9 +101,9 @@ service auth {
 
   # Postfix smtp-auth
   unix_listener /var/tmp/sasl-auth.socket {
-    mode = 0666
-    user = docker
-    group = docker
+    mode = 0660
+    user = postfix
+    group = postfix
   }
 
   # Auth process is run as this user.

--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -72,7 +72,7 @@ postscreen_bare_newline_action = enforce
 
 # SASL
 smtpd_sasl_auth_enable = no
-smtpd_sasl_path = /var/spool/postfix/private/auth
+smtpd_sasl_path = /var/tmp/sasl-auth.socket
 smtpd_sasl_type = dovecot
 
 smtpd_sasl_security_options = noanonymous

--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -72,7 +72,7 @@ postscreen_bare_newline_action = enforce
 
 # SASL
 smtpd_sasl_auth_enable = no
-smtpd_sasl_path = /var/tmp/sasl-auth.socket
+smtpd_sasl_path = /dev/shm/sasl-auth.sock
 smtpd_sasl_type = dovecot
 
 smtpd_sasl_security_options = noanonymous

--- a/target/postfix/master.cf
+++ b/target/postfix/master.cf
@@ -19,7 +19,7 @@ submission     inet  n       -       n       -       -       smtpd
   -o smtpd_tls_security_level=encrypt
   -o smtpd_sasl_auth_enable=yes
   -o smtpd_sasl_type=dovecot
-  -o smtpd_sasl_path=/var/tmp/sasl-auth.socket
+  -o smtpd_sasl_path=/dev/shm/sasl-auth.sock
   -o smtpd_reject_unlisted_recipient=no
   -o smtpd_sasl_authenticated_header=yes
   -o smtpd_client_restrictions=permit_sasl_authenticated,reject
@@ -32,7 +32,7 @@ smtps          inet  n       -       n       -       -       smtpd
   -o smtpd_tls_wrappermode=yes
   -o smtpd_sasl_auth_enable=yes
   -o smtpd_sasl_type=dovecot
-  -o smtpd_sasl_path=/var/tmp/sasl-auth.socket
+  -o smtpd_sasl_path=/dev/shm/sasl-auth.sock
   -o smtpd_reject_unlisted_recipient=no
   -o smtpd_sasl_authenticated_header=yes
   -o smtpd_client_restrictions=permit_sasl_authenticated,reject

--- a/target/postfix/master.cf
+++ b/target/postfix/master.cf
@@ -19,7 +19,7 @@ submission     inet  n       -       n       -       -       smtpd
   -o smtpd_tls_security_level=encrypt
   -o smtpd_sasl_auth_enable=yes
   -o smtpd_sasl_type=dovecot
-  -o smtpd_sasl_path=private/auth
+  -o smtpd_sasl_path=/var/tmp/sasl-auth.socket
   -o smtpd_reject_unlisted_recipient=no
   -o smtpd_sasl_authenticated_header=yes
   -o smtpd_client_restrictions=permit_sasl_authenticated,reject
@@ -32,7 +32,7 @@ smtps          inet  n       -       n       -       -       smtpd
   -o smtpd_tls_wrappermode=yes
   -o smtpd_sasl_auth_enable=yes
   -o smtpd_sasl_type=dovecot
-  -o smtpd_sasl_path=private/auth
+  -o smtpd_sasl_path=/var/tmp/sasl-auth.socket
   -o smtpd_reject_unlisted_recipient=no
   -o smtpd_sasl_authenticated_header=yes
   -o smtpd_client_restrictions=permit_sasl_authenticated,reject


### PR DESCRIPTION
See #3110 for more details

# Description

The sasl socket was on a path that would end up getting volume mounted (`/var/mail-state`) in some setups, this could cause issues. The socket is not actually state, so it doesn't need to end up there. 

Fixes #3110

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


*note, I've marked it as Draft because:*

- [ ] not sure hot to test this locally
- [x] discussion is still open if we maybe should move to `/dev/shm` instead.