### PR TITLE
config/ENV: improve Postfix config for spoof protection

### DIFF
--- a/docs/content/config/advanced/kubernetes.md
+++ b/docs/content/config/advanced/kubernetes.md
@@ -287,7 +287,7 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: data
-        
+
         # certificates
         - name: certificates-rsa
           secret:
@@ -401,7 +401,7 @@ metadata:
 # ...
     spec:
       hostNetwork: true
-    
+
     # ...
       containers:
         # ...

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -89,7 +89,7 @@ The purpose of this setting is to opt-out of starting an internal Redis instance
 ??? note "Configuring rspamd for an external Redis instance"
 
     You will need to [provide configuration][config-rspamd-redis] at `/etc/rspamd/local.d/redis.conf` similar to:
-    
+
     ```
     servers = "redis.example.test:6379";
     expand_keys = true;
@@ -204,8 +204,8 @@ Please read [the SSL page in the documentation][docs-tls] for more information.
 
 Configures the handling of creating mails with forged sender addresses.
 
-- **empty** => Mail address spoofing allowed. Any logged in user may create email messages with a forged sender address. See also [Wikipedia](https://en.wikipedia.org/wiki/Email_spoofing)(not recommended, but default for backwards compatibility reasons)
-- 1 => (recommended) Mail spoofing denied. Each user may only send with his own or his alias addresses. Addresses with [extension delimiters](http://www.postfix.org/postconf.5.html#recipient_delimiter) are not able to send messages.
+- **0** => (not recommended) Mail address spoofing allowed. Any logged in user may create email messages with a [forged sender address](https://en.wikipedia.org/wiki/Email_spoofing).
+- 1 => Mail spoofing denied. Each user may only send with his own or his alias addresses. Addresses with [extension delimiters](http://www.postfix.org/postconf.5.html#recipient_delimiter) are not able to send messages.
 
 ##### ENABLE_SRS
 

--- a/mailserver.env
+++ b/mailserver.env
@@ -86,11 +86,8 @@ TLS_LEVEL=
 
 # Configures the handling of creating mails with forged sender addresses.
 #
-# empty => (not recommended, but default for backwards compatibility reasons)
-#           Mail address spoofing allowed. Any logged in user may create email messages with a forged sender address.
-#           See also https://en.wikipedia.org/wiki/Email_spoofing
-# 1 => (recommended) Mail spoofing denied. Each user may only send with his own or his alias addresses.
-#       Addresses with extension delimiters(http://www.postfix.org/postconf.5.html#recipient_delimiter) are not able to send messages.
+# **0** => (not recommended) Mail address spoofing allowed. Any logged in user may create email messages with a forged sender address (see also https://en.wikipedia.org/wiki/Email_spoofing).
+# 1 => Mail spoofing denied. Each user may only send with his own or his alias addresses. Addresses with extension delimiters(http://www.postfix.org/postconf.5.html#recipient_delimiter) are not able to send messages.
 SPOOF_PROTECTION=
 
 # Enables the Sender Rewriting Scheme. SRS is needed if your mail server acts as forwarder. See [postsrsd](https://github.com/roehling/postsrsd/blob/master/README.md#sender-rewriting-scheme-crash-course) for further explanation.

--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -50,10 +50,12 @@ smtpd_helo_restrictions = permit_mynetworks, reject_invalid_helo_hostname, permi
 smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
 smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unauth_destination, check_policy_service unix:private/policyd-spf, reject_unauth_pipelining, reject_invalid_helo_hostname, reject_non_fqdn_helo_hostname, reject_unknown_recipient_domain
 smtpd_client_restrictions = permit_mynetworks, permit_sasl_authenticated, reject_unauth_destination, reject_unauth_pipelining
-smtpd_sender_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unknown_sender_domain, reject_unknown_client_hostname
+smtpd_sender_restrictions = $dms_smtpd_sender_restrictions
 disable_vrfy_command = yes
 
+# Custom defined parameters for DMS:
 dms_smtpd_sender_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unknown_sender_domain, reject_unknown_client_hostname
+# Submission ports 587 and 465 support for SPOOF_PROTECTION=1
 mua_sender_restrictions = reject_authenticated_sender_login_mismatch, $dms_smtpd_sender_restrictions
 
 # Postscreen settings to drop zombies/open relays/spam early

--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -53,7 +53,8 @@ smtpd_client_restrictions = permit_mynetworks, permit_sasl_authenticated, reject
 smtpd_sender_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unknown_sender_domain, reject_unknown_client_hostname
 disable_vrfy_command = yes
 
-mua_sender_restrictions = reject_authenticated_sender_login_mismatch, $smtpd_sender_restrictions
+dms_smtpd_sender_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unknown_sender_domain, reject_unknown_client_hostname
+mua_sender_restrictions = reject_authenticated_sender_login_mismatch, $dms_smtpd_sender_restrictions
 
 # Postscreen settings to drop zombies/open relays/spam early
 postscreen_dnsbl_action = enforce

--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -53,6 +53,8 @@ smtpd_client_restrictions = permit_mynetworks, permit_sasl_authenticated, reject
 smtpd_sender_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unknown_sender_domain, reject_unknown_client_hostname
 disable_vrfy_command = yes
 
+mua_sender_restrictions = reject_authenticated_sender_login_mismatch, $smtpd_sender_restrictions
+
 # Postscreen settings to drop zombies/open relays/spam early
 postscreen_dnsbl_action = enforce
 postscreen_dnsbl_sites =

--- a/target/postfix/master.cf
+++ b/target/postfix/master.cf
@@ -24,6 +24,7 @@ submission     inet  n       -       n       -       -       smtpd
   -o smtpd_sasl_authenticated_header=yes
   -o smtpd_client_restrictions=permit_sasl_authenticated,reject
   -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
+  -o smtpd_sender_restrictions=$mua_sender_restrictions
   -o milter_macro_daemon_name=ORIGINATING
   -o cleanup_service_name=sender-cleanup
 
@@ -37,6 +38,7 @@ smtps          inet  n       -       n       -       -       smtpd
   -o smtpd_sasl_authenticated_header=yes
   -o smtpd_client_restrictions=permit_sasl_authenticated,reject
   -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
+  -o smtpd_sender_restrictions=$mua_sender_restrictions
   -o milter_macro_daemon_name=ORIGINATING
   -o cleanup_service_name=sender-cleanup
 

--- a/target/scripts/startup/setup.d/security/spoofing.sh
+++ b/target/scripts/startup/setup.d/security/spoofing.sh
@@ -25,6 +25,6 @@ function _setup_spoof_protection
   else
     _log 'debug' 'Spoof protection is disabled'
     # shellcheck disable=SC2016
-    postconf 'mua_sender_restrictions = $smtpd_sender_restrictions'
+    postconf 'mua_sender_restrictions = $dms_smtpd_sender_restrictions'
   fi
 }

--- a/target/scripts/startup/setup.d/security/spoofing.sh
+++ b/target/scripts/startup/setup.d/security/spoofing.sh
@@ -6,10 +6,6 @@ function _setup_spoof_protection
   then
     _log 'trace' 'Enabling and configuring spoof protection'
 
-    sed -i \
-      's|smtpd_sender_restrictions =|smtpd_sender_restrictions = reject_authenticated_sender_login_mismatch,|' \
-      /etc/postfix/main.cf
-
     if [[ ${ACCOUNT_PROVISIONER} == 'LDAP' ]]
     then
       if [[ -z ${LDAP_QUERY_FILTER_SENDERS} ]]
@@ -28,5 +24,7 @@ function _setup_spoof_protection
     fi
   else
     _log 'debug' 'Spoof protection is disabled'
+    # shellcheck disable=SC2016
+    postconf 'mua_sender_restrictions = $smtpd_sender_restrictions'
   fi
 }


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
Make `SPOOF_PROTECTION=1` the default and improve Postfix configuration to eliminate the currently shown warning.

Reviewing commit-by-commit advised.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #3117

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
