### PR TITLE
ci: make helpers more robust

### DIFF
--- a/test/helper/change-detection.bash
+++ b/test/helper/change-detection.bash
@@ -37,7 +37,7 @@ function _wait_until_expected_count_is_matched() {
   }
 
   local EXPECTED_COUNT=${1:-}
-  local CONTAINER_NAME=$(__handle_container_name "${2:-}")
+  eval "${__SET_CONTAINER_NAME_WITH_POS_ARG_2}"
 
   # Ensure the container is configured with the required `LOG_LEVEL` ENV:
   assert_regex "$(_exec_in_container env | grep '^LOG_LEVEL=')" '=(debug|trace)$'
@@ -73,7 +73,7 @@ function _wait_until_change_detection_event_completes() {
 
 function _get_logs_since_last_change_detection() {
   # shellcheck disable=SC2034
-  local CONTAINER_NAME=$(__handle_container_name "${1:-}")
+  eval "${__SET_CONTAINER_NAME_WITH_POS_ARG_1}"
   local MATCH_IN_FILE='/var/log/supervisor/changedetector.log'
   local MATCH_STRING='Change detected'
 

--- a/test/helper/common.bash
+++ b/test/helper/common.bash
@@ -86,11 +86,16 @@ function _run_in_container_bash() { _run_in_container /bin/bash -c "${@}" ; }
 #
 # The regex is given to `grep -E`, so make sure it is compatible.
 #
+# This function assumes `CONTAINER_NAME` to be properly set (to the container
+# name the command should be executed in)! This condition is checked.
+#
 # ## Note
 #
 # If no regex is provided, this function will default to one that strips
 # empty lines and Bash comments from the output.
 function _run_in_container_bash_and_filter_output() {
+  _check_if_var_is_set 'CONTAINER_NAME'
+
   local COMMAND=${1:?Command must be provided}
   local FILTER_REGEX=${2:-^[[:space:]]*$|^ *#}
 
@@ -375,7 +380,14 @@ function _count_files_in_directory_in_container()
 #
 # @param ${1} = directory
 # @param ${2} = Additional options to `find`
+#
+# ## Attention
+#
+# This function assumes `CONTAINER_NAME` to be properly set (to the container
+# name the command should be executed in)! This condition is checked.
 function _should_have_content_in_directory() {
+  _check_if_var_is_set 'CONTAINER_NAME'
+
   local DIRECTORY=${1:?No directory provided}
   local FIND_OPTIONS=${2:-}
 

--- a/test/helper/sending.bash
+++ b/test/helper/sending.bash
@@ -17,17 +17,19 @@
 # ## Attention
 #
 # This function assumes `CONTAINER_NAME` to be properly set (to the container
-# name the command should be executed in)!
+# name the command should be executed in)! This condition is checked.
+#
+# This function will mark setup/tests/teardown as failed in case sending the email
+# fails or another required condition is not met!
 #
 # This function will just send the email in an "asynchronous" fashion, i.e. it will
 # send the email but it will not make sure the mail queue is empty after the mail
 # has been sent.
 function _send_email() {
+  _check_if_var_is_set 'CONTAINER_NAME'
+
   local TEMPLATE_FILE=${1:?Must provide name of template file}
   local NC_PARAMETERS=${2:-0.0.0.0 25}
-
-  assert_not_equal "${NC_PARAMETERS}" ''
-  assert_not_equal "${CONTAINER_NAME:-}" ''
 
   _run_in_container_bash "nc ${NC_PARAMETERS} < /tmp/docker-mailserver-test/${TEMPLATE_FILE}.txt"
   assert_success
@@ -42,13 +44,16 @@ function _send_email() {
 # No. 2 is especially useful in case you send more than one email in a single
 # test file and need to assert certain log entries for each mail individually.
 #
-# @param ${1} = template file (path) name
-# @param ${2} = parameters for `nc` [OPTIONAL] (default: `0.0.0.0 25`)
+# @param ${1} = ENV variable name to store the ID in
+# @param ...  = parameters to `_send_mail`
 #
 # ## Attention
 #
 # This function assumes `CONTAINER_NAME` to be properly set (to the container
-# name the command should be executed in)!
+# name the command should be executed in)! This condition is checked.
+#
+# This function will mark setup/tests/teardown as failed in case sending the email
+# fails or another required condition is not met!
 #
 # ## Safety
 #
@@ -57,24 +62,24 @@ function _send_email() {
 # chosen. Sending more than one mail at any given point in time with this function
 # is UNDEFINED BEHAVIOR!
 function _send_email_and_get_id() {
-  local TEMPLATE_FILE=${1:?Must provide name of template file}
-  local NC_PARAMETERS=${2:-0.0.0.0 25}
-  local MAIL_ID
+  _check_if_var_is_set 'CONTAINER_NAME'
 
-  assert_not_equal "${NC_PARAMETERS}" ''
-  assert_not_equal "${CONTAINER_NAME:-}" ''
+  local -n ENV_VAR_NAME=${1:?ENV var name to put ID into must be provided}
+  shift 1
 
   _wait_for_empty_mail_queue_in_container
-  _send_email "${TEMPLATE_FILE}"
+  _send_email "${@}"
   _wait_for_empty_mail_queue_in_container
 
   # The unique ID Postfix (and other services) use may be different in length
   # on different systems (e.g. amd64 (11) vs aarch64 (10)). Hence, we use a
   # range to safely capture it.
-  MAIL_ID=$(_exec_in_container tac /var/log/mail.log              \
+  _run_in_container_bash "tac /var/log/mail/mail.log \
     | grep -E -m 1 'postfix/smtpd.*: [A-Z0-9]+: client=localhost' \
-    | grep -E -o '[A-Z0-9]{9,12}' || true)
+    | grep -E -o '[A-Z0-9]{9,12}'"
+  assert_success
 
-  assert_not_equal "${MAIL_ID}" ''
-  echo "${MAIL_ID}"
+  # shellcheck disable=SC2154
+  ENV_VAR_NAME="${lines[0]}"
+  assert_not_equal "${ENV_VAR_NAME}" ''
 }

--- a/test/helper/setup.bash
+++ b/test/helper/setup.bash
@@ -33,7 +33,7 @@ function __abort() {
 # Check if a variable is set.
 #
 # @param ${1} = variable name that is to be checked
-function __check_if_var_is_set() {
+function _check_if_var_is_set() {
   local -n REF=${1:?No variable name given to __check_if_set}
   [[ ${REF+set} == 'set' ]] || __abort "'${!REF}' is not set"
 }
@@ -47,7 +47,7 @@ function __check_if_var_is_set() {
 function __initialize_variables() {
   for VARIABLE in 'REPOSITORY_ROOT' 'IMAGE_NAME' 'CONTAINER_NAME'
   do
-    __check_if_var_is_set "${VARIABLE}"
+    _check_if_var_is_set "${VARIABLE}"
   done
 
   export SETUP_FILE_MARKER TEST_TIMEOUT_IN_SECONDS NUMBER_OF_LOG_LINES

--- a/test/tests/parallel/set1/spam_virus/rspamd.bats
+++ b/test/tests/parallel/set1/spam_virus/rspamd.bats
@@ -31,9 +31,10 @@ function setup_file() {
 
   # We will send 3 emails: the first one should pass just fine; the second one should
   # be rejected due to spam; the third one should be rejected due to a virus.
-  export MAIL_ID1=$(_send_email_and_get_id 'email-templates/existing-user1')
-  export MAIL_ID2=$(_send_email_and_get_id 'email-templates/rspamd-spam')
-  export MAIL_ID3=$(_send_email_and_get_id 'email-templates/rspamd-virus')
+  export MAIL_ID1 MAIL_ID2 MAIL_ID3
+  _send_email_and_get_id 'MAIL_ID1' 'email-templates/existing-user1'
+  _send_email_and_get_id 'MAIL_ID2' 'email-templates/rspamd-spam'
+  _send_email_and_get_id 'MAIL_ID3' 'email-templates/rspamd-virus'
 
   # add a nested option to a module
   _exec_in_container_bash "echo -e 'complicated {\n    anOption = someValue;\n}' >/etc/rspamd/override.d/testmodule_complicated.conf"

--- a/test/tests/serial/mail_with_imap.bats
+++ b/test/tests/serial/mail_with_imap.bats
@@ -15,7 +15,7 @@ function setup_file() {
   )
 
   _common_container_setup 'CUSTOM_SETUP_ARGUMENTS'
-  _wait_for_smtp_port_in_container mail_with_imap
+  _wait_for_smtp_port_in_container
 }
 
 function teardown_file() { _default_teardown ; }


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
A PR I was not fond of making, but current helpers are not actually failing as intended when an argument is wrong/unset. This PR corrects issues observed after investigating errors in #3134.

I'd strongly advise to go through this commit-by-commit. I tried to  provide good commit messages; the code is documented as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
