### PR TITLE
ci(fix): Only apply permissions at the job level

### DIFF
--- a/.github/workflows/generic_vulnerability-scan.yml
+++ b/.github/workflows/generic_vulnerability-scan.yml
@@ -14,9 +14,6 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read
-
 jobs:
   scan-image:
     permissions:


### PR DESCRIPTION
# Description

Fix for https://github.com/docker-mailserver/docker-mailserver/pull/3106 as a recent run of the Action failed.

If permissions are specified at the workflow level, any that are not explicitly set [become `none` and jobs cannot request that to change](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs).

Permissions are therefore scoped to the job itself (_[Github Actions docs for the step requiring the permission](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#example-workflow-for-sarif-files-generated-outside-of-a-repository)_).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
