### PR TITLE
bugfix: special bits for maildrop and public directory

### DIFF
--- a/target/scripts/startup/setup.d/mail_state.sh
+++ b/target/scripts/startup/setup.d/mail_state.sh
@@ -85,8 +85,8 @@ function _setup_save_states
     chgrp -R postdrop /var/mail-state/spool-postfix/{maildrop,public}
     # After changing the group, special bits (set-gid, sticky) may be stripped, restore them:
     # Ref: https://github.com/docker-mailserver/docker-mailserver/pull/3149#issuecomment-1454981309
-    chmod 1730 /var/spool/postfix/maildrop
-    chmod 2710 /var/spool/postfix/public
+    chmod 1730 /var/mail-state/spool-postfix/maildrop
+    chmod 2710 /var/mail-state/spool-postfix/public
   elif [[ ${ONE_DIR} -eq 1 ]]
   then
     _log 'warn' "'ONE_DIR=1' but no volume was mounted to '${STATEDIR}'"

--- a/target/scripts/startup/setup.d/mail_state.sh
+++ b/target/scripts/startup/setup.d/mail_state.sh
@@ -83,9 +83,10 @@ function _setup_save_states
     chown root:root /var/mail-state/spool-postfix
     # These two require the postdrop(103) group:
     chgrp -R postdrop /var/mail-state/spool-postfix/{maildrop,public}
-    # After changing the group, special bits (set-gid, sticky) are lost and we need to restore them:
-    chmod 3730 /var/spool/postfix/maildrop
-    chmod 2730 /var/spool/postfix/public
+    # After changing the group, special bits (set-gid, sticky) may be stripped, restore them:
+    # Ref: https://github.com/docker-mailserver/docker-mailserver/pull/3149#issuecomment-1454981309
+    chmod 1730 /var/spool/postfix/maildrop
+    chmod 2710 /var/spool/postfix/public
   elif [[ ${ONE_DIR} -eq 1 ]]
   then
     _log 'warn' "'ONE_DIR=1' but no volume was mounted to '${STATEDIR}'"

--- a/target/scripts/startup/setup.d/mail_state.sh
+++ b/target/scripts/startup/setup.d/mail_state.sh
@@ -83,6 +83,9 @@ function _setup_save_states
     chown root:root /var/mail-state/spool-postfix
     # These two require the postdrop(103) group:
     chgrp -R postdrop /var/mail-state/spool-postfix/{maildrop,public}
+    # After changing the group, special bits (set-gid, sticky) are lost and we need to restore them:
+    chmod 3730 /var/spool/postfix/maildrop
+    chmod 2730 /var/spool/postfix/public
   elif [[ ${ONE_DIR} -eq 1 ]]
   then
     _log 'warn' "'ONE_DIR=1' but no volume was mounted to '${STATEDIR}'"


### PR DESCRIPTION
# Description

After changing the group, special bits are lost, but they should be set for the directories `/var/spool/postfix/{maildrop,public}`, otherwise you see the following error:

```txt
postfix/postdrop[17400]: warning: mail_queue_enter: create file maildrop/729504.17400: Permission denied
```

The web page <https://linux.m2osw.com/snapwebsites-postfixpostdrop18189-warning-mailqueueenter-create-file-maildrop25937318189-permission> provides the solution to restoring the correct permissions.

---

This is a blocker for v12.0.0.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
