### PR TITLE
Add update to `latest` symlink on `gh-pages` to docs-production-deploy workflow

### DIFF
--- a/.github/workflows/docs-production-deploy.yml
+++ b/.github/workflows/docs-production-deploy.yml
@@ -105,3 +105,33 @@ jobs:
           git add versions.json
           git commit -m "chore: Add ${{ env.DOCS_VERSION }} to version selector list"
           git push
+
+  update-latest-symlink:
+    permissions:
+      contents: write
+    name: 'update `latest` symlink if neccessary'
+    runs-on: ubuntu-22.04
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: add-version-to-docs
+    steps:
+      - name: 'Checkout the docs deployment branch'
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+
+      - name: 'Ensure `latest` symlink refers to the substring from tag name'
+        id: update-latest
+        run: |
+          DOCS_VERSION=$(grep -oE 'v[0-9]+\.[0-9]+' <<< "${GITHUB_REF}")
+          echo "DOCS_VERSION=${DOCS_VERSION}" >> "${GITHUB_ENV}"
+          ln -sf ${DOCS_VERSION} latest
+
+      - name: 'Push update for `latest` symlink'
+        # The step will fail if no change was made; ignore that failure
+        continue-on-error: true
+        run: |
+          git config user.name ${{ env.GIT_USER }}
+          git config user.email ${{ env.GIT_EMAIL }}
+          git add latest
+          git commit -m "chore: Update \`latest\` symlink to point to ${{ env.DOCS_VERSION }}"
+          git push


### PR DESCRIPTION
# Description

Add another step to the docs-production-deploy workflow to update a `latest` symlink on `gh-pages` that points to the latest documentation version. 

Begins to fix #3173

Ancillary PR that updates `versions.json` on `gh-pages` branch: #3182

If this looks like a good way of maintaining a `latest` version, I can open a PR with link changes from edge to latest where I think they are warranted.

I've made sure it works on my fork.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes