### PR TITLE
docs: Add FAQ entry for troubleshooting delivery

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -334,13 +334,16 @@ If you got any problems with SPF and/or forwarding mails, give [SRS](https://git
 
 ### Why are my emails not being delivered?
 
-There are many reasons why email might be rejected: a misconfigured SSL certificate, a TLD or IP address with a bad reputation, misconfigured DNS records, etc.
+There are many reasons why email might be rejected, common causes are:
 
-These aren't problems with DMS, so deliverability issues shouldn't be filed on the issue tracker.
+- Wrong or untrustworthy SSL certificate.
+- A TLD (your domain) or IP address with a bad reputation.
+- Misconfigured DNS records.
 
-[mail-tester](https://www.mail-tester.com/) can test your deliverability.
+DMS does not manage those concerns, verify they are not causing your delivery problems before reporting a bug on our issue tracker. Resources that can help you troubleshoot:
 
-[helloinbox](https://www.helloinbox.email/) provides a checklist of things to improve your deliverability.
+- [mail-tester](https://www.mail-tester.com/) can test your deliverability.
+- [helloinbox](https://www.helloinbox.email/) provides a checklist of things to improve your deliverability.
 
 ### SpamAssasin
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -332,6 +332,16 @@ The default bantime is 180 days. This value can be [customized][fail2ban-customi
 
 If you got any problems with SPF and/or forwarding mails, give [SRS](https://github.com/roehling/postsrsd/blob/master/README.rst) a try. You enable SRS by setting `ENABLE_SRS=1`. See the variable description for further information.
 
+### Why are my emails not being delivered?
+
+There are many reasons why email might be rejected: a misconfigured SSL certificate, a TLD or IP address with a bad reputation, misconfigured DNS records, etc.
+
+These aren't problems with DMS, so deliverability issues shouldn't be filed on the issue tracker.
+
+[mail-tester](https://www.mail-tester.com/) can test your deliverability.
+
+[helloinbox](https://www.helloinbox.email/) provides a checklist of things to improve your deliverability.
+
 ### SpamAssasin
 
 #### How can I manage my custom SpamAssassin rules?


### PR DESCRIPTION
# Description

Add a new FAQ about email deliverability. There have been two issues filed about this in the last 2 days (#3180 and #3189). I suspect there have been many more. It might be helpful to have an FAQ to link to?

## Type of change

- [x] This change requires a documentation update

