### PR TITLE
Add `version` to `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
   mailserver:
     image: docker.io/mailserver/docker-mailserver:latest


### PR DESCRIPTION
# Description

I got an error:

```
ERROR: The Compose file './docker-compose.yml' is invalid because:
Unsupported config option for services: 'mailserver'
```

when I used the provided docker-compose.yml with an older version of docker-compose (1.25.0, the version on Debian bullseye, the current stable release)

Explicitly specifying the version fixed it.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
