### PR TITLE
Fix: only chmod when there are files

### DIFF
--- a/target/scripts/startup/setup.d/dovecot.sh
+++ b/target/scripts/startup/setup.d/dovecot.sh
@@ -87,8 +87,8 @@ function _setup_dovecot_sieve
   fi
 
   chown dovecot:root -R /usr/lib/dovecot/sieve-*
-  find /usr/lib/dovecot/sieve-* -type d -exec chmod 755 {} \;
-  find /usr/lib/dovecot/sieve-{filter,pipe} -type f -exec chmod +x {} \;
+  find /usr/lib/dovecot/sieve-* -type d -exec chmod 755 {} +
+  find /usr/lib/dovecot/sieve-{filter,pipe} -type f -exec chmod +x {} +
 }
 
 function _setup_dovecot_quota

--- a/target/scripts/startup/setup.d/dovecot.sh
+++ b/target/scripts/startup/setup.d/dovecot.sh
@@ -88,7 +88,7 @@ function _setup_dovecot_sieve
 
   chown dovecot:root -R /usr/lib/dovecot/sieve-*
   find /usr/lib/dovecot/sieve-* -type d -exec chmod 755 {} \;
-  chmod +x /usr/lib/dovecot/sieve-{filter,pipe}/*
+  find /usr/lib/dovecot/sieve-{filter,pipe} -type f -exec chmod +x {} \;
 }
 
 function _setup_dovecot_quota

--- a/target/scripts/startup/setup.d/dovecot.sh
+++ b/target/scripts/startup/setup.d/dovecot.sh
@@ -87,7 +87,7 @@ function _setup_dovecot_sieve
   fi
 
   chown dovecot:root -R /usr/lib/dovecot/sieve-*
-  find /usr/lib/dovecot/sieve-* -type d -exec chmod 755 {} +
+  find /usr/lib/dovecot/sieve-*             -type d -exec chmod 755 {} +
   find /usr/lib/dovecot/sieve-{filter,pipe} -type f -exec chmod +x {} +
 }
 


### PR DESCRIPTION
# Description

Fix for:

```
[   INF   ]  Welcome to docker-mailserver 11.3.1
[   INF   ]  Checking configuration
[   INF   ]  Configuring mail server
chmod: cannot access '/usr/lib/dovecot/sieve-filter/*': No such file or directory
chmod: cannot access '/usr/lib/dovecot/sieve-pipe/*': No such file or directory  
```

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->


## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
