### PR TITLE
config: remove `chroot` for Dovecot & PostSRSd

### DIFF
--- a/target/dovecot/10-master.conf
+++ b/target/dovecot/10-master.conf
@@ -18,14 +18,10 @@ service imap-login {
   inet_listener imap {
     #port = 143
   }
-
   inet_listener imaps {
     #port = 993
     #ssl = yes
   }
-
-  # Remove chroot
-  chroot =
 
   # Number of connections to handle before starting a new process. Typically
   # the only useful values are 0 (unlimited) or 1. 1 is more secure, but 0
@@ -43,14 +39,10 @@ service pop3-login {
   inet_listener pop3 {
     #port = 110
   }
-
   inet_listener pop3s {
     #port = 995
     #ssl = yes
   }
-
-  # Remove chroot
-  chroot =
 }
 
 !include lmtp-master.inc
@@ -123,7 +115,4 @@ service dict {
   }
 }
 
-# Remove chroot
-service anvil {
-  chroot =
-}
+!include chroot.inc

--- a/target/dovecot/10-master.conf
+++ b/target/dovecot/10-master.conf
@@ -18,10 +18,14 @@ service imap-login {
   inet_listener imap {
     #port = 143
   }
+
   inet_listener imaps {
     #port = 993
     #ssl = yes
   }
+
+  # Remove chroot
+  chroot =
 
   # Number of connections to handle before starting a new process. Typically
   # the only useful values are 0 (unlimited) or 1. 1 is more secure, but 0
@@ -39,10 +43,14 @@ service pop3-login {
   inet_listener pop3 {
     #port = 110
   }
+
   inet_listener pop3s {
     #port = 995
     #ssl = yes
   }
+
+  # Remove chroot
+  chroot =
 }
 
 !include lmtp-master.inc
@@ -113,4 +121,9 @@ service dict {
     #user =
     #group =
   }
+}
+
+# Remove chroot
+service anvil {
+  chroot =
 }

--- a/target/dovecot/chroot.inc
+++ b/target/dovecot/chroot.inc
@@ -1,0 +1,47 @@
+# This file removes `chroot` environments that
+#
+# 1. are not strictly needed
+# 2. can cause problems
+#
+# See https://github.com/docker-mailserver/docker-mailserver/pull/3208#pullrequestreview-1366106516
+# and it's related PRs.
+
+service aggregator {
+  chroot =
+}
+
+service anvil {
+  chroot =
+}
+
+service director {
+  chroot =
+}
+
+service ipc {
+  chroot =
+}
+
+service old-stats {
+  chroot =
+}
+
+service imap-login {
+  chroot =
+}
+
+service managesieve-login {
+  chroot =
+}
+
+service pop3-login {
+  chroot =
+}
+
+service submission-login {
+  chroot =
+}
+
+service imap-urlauth-login {
+  chroot =
+}

--- a/target/postsrsd/postsrsd
+++ b/target/postsrsd/postsrsd
@@ -36,6 +36,3 @@ SRS_REVERSE_PORT=10002
 # This is highly recommended as postsrsd handles untrusted input.
 #
 RUN_AS=postsrsd
-
-# Jail daemon in chroot environment
-CHROOT=/var/lib/postsrsd


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
Removed `chroot` jail for Dovecot & PostSRSd.

Related: #3160 (see <https://github.com/docker-mailserver/docker-mailserver/pull/3160#issuecomment-1465326589>)
See also: <https://github.com/orgs/docker-mailserver/discussions/3172#discussioncomment-5276395>
See also: <https://github.com/docker-mailserver/docker-mailserver/pull/3146#issuecomment-1490189454>
<!-- Link the issue which will be fixed (if any) here: -->
Fixes #3174

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
