### PR TITLE
issue with existing alias which doesn't exist

### DIFF
--- a/target/scripts/helpers/database/db.sh
+++ b/target/scripts/helpers/database/db.sh
@@ -134,9 +134,10 @@ function __db_list_already_contains_value
   # 1. Extract the current value of the entry (`\1`),
   # 2. If a value list, split into separate lines (`\n`+`g`) at V_DELIMITER,
   # 3. Check each line for an exact match of the target VALUE
+  grep "^${KEY_LOOKUP}" "${DATABASE}" | \
   sed -e "s/^${KEY_LOOKUP}\(.*\)/\1/" \
-      -e "s/${V_DELIMITER}/\n/g"      \
-      "${DATABASE}" | grep -qi "^${_VALUE_}$"
+      -e "s/${V_DELIMITER}/\n/g"      | \
+  grep -qi "^${_VALUE_}$"
 }
 
 


### PR DESCRIPTION
# Description

Issue with adding new recipient to existing alias
If new recipient exists as alias in db then setup is throwing error.

Fixes part of script checks only the relevant alias and compares recipients for it.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
