### PR TITLE
scripts: get all `policyd-spf` setup in one place

### DIFF
--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -48,7 +48,7 @@ smtpd_helo_required = yes
 smtpd_delay_reject = yes
 smtpd_helo_restrictions = permit_mynetworks, reject_invalid_helo_hostname, permit
 smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
-smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unauth_destination, check_policy_service unix:private/policyd-spf, reject_unauth_pipelining, reject_invalid_helo_hostname, reject_non_fqdn_helo_hostname, reject_unknown_recipient_domain
+smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unauth_destination, reject_unauth_pipelining, reject_invalid_helo_hostname, reject_non_fqdn_helo_hostname, reject_unknown_recipient_domain
 smtpd_client_restrictions = permit_mynetworks, permit_sasl_authenticated, reject_unauth_destination, reject_unauth_pipelining
 smtpd_sender_restrictions = $dms_smtpd_sender_restrictions
 disable_vrfy_command = yes
@@ -95,9 +95,6 @@ milter_protocol = 6
 milter_default_action = accept
 smtpd_milters =
 non_smtpd_milters =
-
-# SPF policy settings
-policyd-spf_time_limit = 3600
 
 # Header checks for content inspection on receiving
 header_checks = pcre:/etc/postfix/maps/header_checks.pcre

--- a/target/scripts/startup/setup.d/dmarc_dkim_spf.sh
+++ b/target/scripts/startup/setup.d/dmarc_dkim_spf.sh
@@ -101,10 +101,8 @@ EOF
   sedfile -i -E \
     's|^(smtpd_recipient_restrictions.*reject_unauth_destination)(.*)|\1, check_policy_service unix:private/policyd-spf\2|' \
     /etc/postfix/main.cf
-  cat >>/etc/postfix/main.cf <<EOF
-
-# SPF policy settings
-policyd-spf_time_limit = 3600
+  # SPF policy settings
+  postconf 'policyd-spf_time_limit = 3600'
 EOF
   else
     _log 'debug' 'Disabling policyd-spf'

--- a/target/scripts/startup/setup.d/dmarc_dkim_spf.sh
+++ b/target/scripts/startup/setup.d/dmarc_dkim_spf.sh
@@ -97,8 +97,16 @@ function _setup_policyd_spf
 policyd-spf    unix  -       n       n       -       0       spawn
     user=policyd-spf argv=/usr/bin/policyd-spf
 EOF
+
+  sedfile -i -E \
+    's|^(smtpd_recipient_restrictions.*reject_unauth_destination)(.*)|\1, check_policy_service unix:private/policyd-spf\2|' \
+    /etc/postfix/main.cf
+  cat >>/etc/postfix/main.cf <<EOF
+
+# SPF policy settings
+policyd-spf_time_limit = 3600
+EOF
   else
     _log 'debug' 'Disabling policyd-spf'
-    sedfile -i -E 's|check_policy_service unix:private/policyd-spf, ||g' /etc/postfix/main.cf
   fi
 }


### PR DESCRIPTION
# Description

Basically <https://github.com/docker-mailserver/docker-mailserver/pull/3246#discussion_r1162156066>.

Looking at <https://github.com/docker-mailserver/docker-mailserver/actions/runs/4699505235/jobs/8333061595?pr=3261>, we can see that `postconf` is complaining:

```txt
postconf: warning: /etc/postfix/main.cf: unused parameter: policyd-spf_time_limit=3600
```

This PR resolves the matter and puts all the code that integrates policyd-spf in one place.

---

The log says `'Disabling policyd-spf'`, when actually doing nothing, but this is okay, since

1. the default value is `1`
2. we will change the default after v12.1.0 to 0 anyway and therefore, the log messages

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
