### PR TITLE
scripts: improve shutdown function by making PANIC_STRATEGY obsolete

### DIFF
--- a/target/scripts/helpers/accounts.sh
+++ b/target/scripts/helpers/accounts.sh
@@ -144,7 +144,7 @@ function _create_dovecot_alias_dummy_accounts
 
       if [[ -z ${REAL_ACC[1]} ]]
       then
-        _dms_panic__misconfigured 'postfix-accounts.cf' 'alias configuration' 'immediate'
+        _dms_panic__misconfigured 'postfix-accounts.cf' 'alias configuration'
       fi
 
       # test if user has a defined quota

--- a/target/scripts/helpers/error.sh
+++ b/target/scripts/helpers/error.sh
@@ -25,7 +25,6 @@ function dms_panic
   local PANIC_TYPE=${1:-}
   local PANIC_INFO=${2:-}
   local PANIC_SCOPE=${3-} # optional, must not be :- but just -
-  local PANIC_STRATEGY=${4:-} # optional
 
   local SHUTDOWN_MESSAGE
 
@@ -61,9 +60,9 @@ function dms_panic
 
   if [[ -n ${PANIC_SCOPE:-} ]]
   then
-    _shutdown "${PANIC_SCOPE} | ${SHUTDOWN_MESSAGE}" "${PANIC_STRATEGY}"
+    _shutdown "${PANIC_SCOPE} | ${SHUTDOWN_MESSAGE}"
   else
-    _shutdown "${SHUTDOWN_MESSAGE}" "${PANIC_STRATEGY}"
+    _shutdown "${SHUTDOWN_MESSAGE}"
   fi
 }
 
@@ -77,22 +76,14 @@ function _dms_panic__general       { dms_panic 'general'       "${1:-}" "${2:-}"
 
 # Call this method when you want to panic (i.e. emit an 'ERROR' log, and exit uncleanly).
 # `dms_panic` methods should be preferred if your failure type is supported.
+trap "exit 1" 10
+SCRIPT_PID="$$"
 function _shutdown
 {
   _log 'error' "${1:-_shutdown called without message}"
   _log 'error' 'Shutting down'
 
   sleep 1
-  kill 1
-
-  if [[ ${2:-wait} == 'immediate' ]]
-  then
-    # In case the user requested an immediate exit, he ensure he is not in a subshell
-    # call and exiting the whole script is safe. This way, we make the shutdown quicker.
-    exit 1
-  else
-    # We can simply wait until Supervisord has terminated all processes; this way,
-    # we do not return from a subshell call and continue as if nothing happened.
-    sleep 1000
-  fi
+  kill 1                   # Graceful DMS shutdown.
+  kill -10 "${SCRIPT_PID}" # Stop start-mailserver.sh execution, even when _shutdown() is called from a subshell.
 }

--- a/target/scripts/helpers/error.sh
+++ b/target/scripts/helpers/error.sh
@@ -77,7 +77,7 @@ function _dms_panic__general       { dms_panic 'general'       "${1:-}" "${2:-}"
 # Call this method when you want to panic (i.e. emit an 'ERROR' log, and exit uncleanly).
 # `dms_panic` methods should be preferred if your failure type is supported.
 trap "exit 1" SIGUSR1
-SCRIPT_PID="${$}"
+SCRIPT_PID=${$}
 function _shutdown
 {
   _log 'error' "${1:-_shutdown called without message}"

--- a/target/scripts/helpers/error.sh
+++ b/target/scripts/helpers/error.sh
@@ -76,7 +76,7 @@ function _dms_panic__general       { dms_panic 'general'       "${1:-}" "${2:-}"
 
 # Call this method when you want to panic (i.e. emit an 'ERROR' log, and exit uncleanly).
 # `dms_panic` methods should be preferred if your failure type is supported.
-trap "exit 1" 10
+trap "exit 1" SIGUSR1
 SCRIPT_PID="$$"
 function _shutdown
 {
@@ -84,6 +84,6 @@ function _shutdown
   _log 'error' 'Shutting down'
 
   sleep 1
-  kill 1                   # Graceful DMS shutdown.
-  kill -10 "${SCRIPT_PID}" # Stop start-mailserver.sh execution, even when _shutdown() is called from a subshell.
+  kill -SIGTERM 1               # Graceful DMS shutdown.
+  kill -SIGUSR1 "${SCRIPT_PID}" # Stop start-mailserver.sh execution, even when _shutdown() is called from a subshell.
 }

--- a/target/scripts/helpers/error.sh
+++ b/target/scripts/helpers/error.sh
@@ -84,6 +84,6 @@ function _shutdown
   _log 'error' 'Shutting down'
 
   sleep 1
-  kill -SIGTERM 1               # Graceful DMS shutdown.
+  kill -SIGTERM 1               # Trigger graceful DMS shutdown.
   kill -SIGUSR1 "${SCRIPT_PID}" # Stop start-mailserver.sh execution, even when _shutdown() is called from a subshell.
 }

--- a/target/scripts/helpers/error.sh
+++ b/target/scripts/helpers/error.sh
@@ -24,7 +24,7 @@ function dms_panic
 {
   local PANIC_TYPE=${1:-}
   local PANIC_INFO=${2:-}
-  local PANIC_SCOPE=${3-} # optional, must not be :- but just -
+  local PANIC_SCOPE=${3:-}
 
   local SHUTDOWN_MESSAGE
 

--- a/target/scripts/helpers/error.sh
+++ b/target/scripts/helpers/error.sh
@@ -77,7 +77,7 @@ function _dms_panic__general       { dms_panic 'general'       "${1:-}" "${2:-}"
 # Call this method when you want to panic (i.e. emit an 'ERROR' log, and exit uncleanly).
 # `dms_panic` methods should be preferred if your failure type is supported.
 trap "exit 1" SIGUSR1
-SCRIPT_PID="$$"
+SCRIPT_PID="${$}"
 function _shutdown
 {
   _log 'error' "${1:-_shutdown called without message}"

--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -92,13 +92,13 @@ function _replace_by_env_in_file
 {
   if [[ -z ${1+set} ]]
   then
-    _dms_panic__invalid_value 'first argument unset' 'utils.sh:_replace_by_env_in_file' 'immediate'
+    _dms_panic__invalid_value 'first argument unset' 'utils.sh:_replace_by_env_in_file'
   elif [[ -z ${2+set} ]]
   then
-    _dms_panic__invalid_value 'second argument unset' 'utils.sh:_replace_by_env_in_file' 'immediate'
+    _dms_panic__invalid_value 'second argument unset' 'utils.sh:_replace_by_env_in_file'
   elif [[ ! -f ${2} ]]
   then
-    _dms_panic__invalid_value "file '${2}' does not exist" 'utils.sh:_replace_by_env_in_file' 'immediate'
+    _dms_panic__invalid_value "file '${2}' does not exist" 'utils.sh:_replace_by_env_in_file'
   fi
 
   local ENV_PREFIX=${1} CONFIG_FILE=${2}

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -61,11 +61,11 @@ function _register_functions
       ;;
 
     ( 'OIDC' )
-      _dms_panic__fail_init 'OIDC user account provisioning - it is not yet implemented' '' 'immediate'
+      _dms_panic__fail_init 'OIDC user account provisioning - it is not yet implemented'
       ;;
 
     ( * )
-      _dms_panic__invalid_value "'${ACCOUNT_PROVISIONER}' is not a valid value for ACCOUNT_PROVISIONER" '' 'immediate'
+      _dms_panic__invalid_value "'${ACCOUNT_PROVISIONER}' is not a valid value for ACCOUNT_PROVISIONER"
       ;;
   esac
 

--- a/target/scripts/startup/check-stack.sh
+++ b/target/scripts/startup/check-stack.sh
@@ -38,7 +38,7 @@ function _check_hostname
   # HOSTNAME should be an FQDN (eg: hostname.domain)
   if ! grep -q -E '^(\S+[.]\S+)$' <<< "${HOSTNAME}"
   then
-    _dms_panic__general 'Setting hostname/domainname is required' '' 'immediate'
+    _dms_panic__general 'Setting hostname/domainname is required'
   fi
 }
 

--- a/target/scripts/startup/daemons-stack.sh
+++ b/target/scripts/startup/daemons-stack.sh
@@ -29,7 +29,7 @@ function _default_start_daemon
   if [[ ${?} -ne 0 ]]
   then
     _log 'error' "${RESULT}"
-    _dms_panic__fail_init "${1}" '' 'immediate'
+    _dms_panic__fail_init "${1}"
   fi
 }
 

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -89,7 +89,7 @@ function _setup_apply_fixes_after_configuration
   _log 'debug' 'Checking /var/mail permissions'
   if ! _chown_var_mail_if_necessary
   then
-    _dms_panic__general 'Failed to fix /var/mail permissions' '' 'immediate'
+    _dms_panic__general 'Failed to fix /var/mail permissions'
   fi
 
   _log 'debug' 'Removing files and directories from older versions'

--- a/target/scripts/startup/setup.d/dovecot.sh
+++ b/target/scripts/startup/setup.d/dovecot.sh
@@ -175,7 +175,7 @@ function _setup_dovecot_local_user
       fi
     done
 
-    _dms_panic__fail_init 'accounts provisioning because no accounts were provided - Dovecot could not be started' '' 'immediate'
+    _dms_panic__fail_init 'accounts provisioning because no accounts were provided - Dovecot could not be started'
   }
 
   __wait_until_an_account_is_added_or_shutdown
@@ -199,7 +199,7 @@ function _setup_dovecot_inet_protocols
     PROTOCOL='[::]' # IPv6 only
   else
     # Unknown value, panic.
-    _dms_panic__invalid_value 'DOVECOT_INET_PROTOCOLS' "${DOVECOT_INET_PROTOCOLS}" 'immediate'
+    _dms_panic__invalid_value 'DOVECOT_INET_PROTOCOLS' "${DOVECOT_INET_PROTOCOLS}"
   fi
 
   sedfile -i "s|^#listen =.*|listen = ${PROTOCOL}|g" /etc/dovecot/dovecot.conf

--- a/target/scripts/startup/setup.d/networking.sh
+++ b/target/scripts/startup/setup.d/networking.sh
@@ -22,7 +22,7 @@ function _setup_docker_permit
   if [[ -z ${CONTAINER_IP} ]]
   then
     _log 'error' 'Detecting the container IP address failed'
-    _dms_panic__misconfigured 'NETWORK_INTERFACE' 'Network Setup [docker_permit]' 'immediate'
+    _dms_panic__misconfigured 'NETWORK_INTERFACE' 'Network Setup [docker_permit]'
   fi
 
   while read -r IP


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->

> In case the user requested an immediate exit, he ensure he is not in a subshell

This PR makes the decision obsolete, if the function is called from a subshell or not.

Inspired from: https://cravencode.com/post/essentials/exit-shell-script-from-subshell/

History:

- https://github.com/docker-mailserver/docker-mailserver/pull/3155
- https://github.com/docker-mailserver/docker-mailserver/issues/3140
- https://github.com/docker-mailserver/docker-mailserver/issues/3133

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
