### PR TITLE
scripts: remove superfluous `EOF` in `dmarc_dkim_spf.sh`

### DIFF
--- a/target/scripts/startup/setup.d/dmarc_dkim_spf.sh
+++ b/target/scripts/startup/setup.d/dmarc_dkim_spf.sh
@@ -103,7 +103,7 @@ EOF
     /etc/postfix/main.cf
   # SPF policy settings
   postconf 'policyd-spf_time_limit = 3600'
-EOF
+
   else
     _log 'debug' 'Disabling policyd-spf'
   fi


### PR DESCRIPTION
# Description

Our CI test logs have lots of:
```
/usr/local/bin/setup.d/dmarc_dkim_spf.sh: line 106: EOF: command not found
```

<!-- Link the issue which will be fixed (if any) here: -->
Also discussed in https://github.com/docker-mailserver/docker-mailserver/pull/3263/files#r1167336949 and fixed in #3261


## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
  >Note checks only complete with #3267 in place
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
  >Note checks only complete with #3267 in place

Info @wt-io-it
