### PR TITLE
scripts: disallow alias = account

### DIFF
--- a/target/scripts/helpers/database/manage/postfix-accounts.sh
+++ b/target/scripts/helpers/database/manage/postfix-accounts.sh
@@ -76,7 +76,7 @@ function _account_should_not_exist_yet
   __account_already_exists && _exit_with_error "'${MAIL_ACCOUNT}' already exists"
   if [[ -f ${DATABASE_VIRTUAL} ]] && grep -q "^${MAIL_ACCOUNT}" "${DATABASE_VIRTUAL}"
   then
-    _exit_with_error "'${MAIL_ACCOUNT}' is already defined to be an alias"
+    _exit_with_error "'${MAIL_ACCOUNT}' is already defined as an alias"
   fi
 }
 

--- a/target/scripts/helpers/database/manage/postfix-accounts.sh
+++ b/target/scripts/helpers/database/manage/postfix-accounts.sh
@@ -74,6 +74,10 @@ function _arg_expect_mail_account
 function _account_should_not_exist_yet
 {
   __account_already_exists && _exit_with_error "'${MAIL_ACCOUNT}' already exists"
+  if grep -q "^${MAIL_ACCOUNT}" "${DATABASE_VIRTUAL}"
+  then
+    _exit_with_error "'${MAIL_ACCOUNT}' is already defined to be an alias"
+  fi
 }
 
 # Also used by delmailuser, setquota, delquota

--- a/target/scripts/helpers/database/manage/postfix-accounts.sh
+++ b/target/scripts/helpers/database/manage/postfix-accounts.sh
@@ -74,7 +74,7 @@ function _arg_expect_mail_account
 function _account_should_not_exist_yet
 {
   __account_already_exists && _exit_with_error "'${MAIL_ACCOUNT}' already exists"
-  if grep -q "^${MAIL_ACCOUNT}" "${DATABASE_VIRTUAL}"
+  if [[ -f ${DATABASE_VIRTUAL} ]] && grep -q "^${MAIL_ACCOUNT}" "${DATABASE_VIRTUAL}"
   then
     _exit_with_error "'${MAIL_ACCOUNT}' is already defined to be an alias"
   fi

--- a/target/scripts/helpers/database/manage/postfix-virtual.sh
+++ b/target/scripts/helpers/database/manage/postfix-virtual.sh
@@ -27,7 +27,7 @@ function _manage_virtual_aliases
     ( 'update' )
       if [[ -f ${DATABASE_ACCOUNTS} ]] && grep -q "^${MAIL_ALIAS}" "${DATABASE_ACCOUNTS}"
       then
-        _exit_with_error "'${MAIL_ALIAS}' is already defined to be an account"
+        _exit_with_error "'${MAIL_ALIAS}' is already defined as an account"
       fi
       _db_entry_add_or_append "${DATABASE_VIRTUAL}" "${MAIL_ALIAS}" "${RECIPIENT}"
       ;;

--- a/target/scripts/helpers/database/manage/postfix-virtual.sh
+++ b/target/scripts/helpers/database/manage/postfix-virtual.sh
@@ -25,7 +25,7 @@ function _manage_virtual_aliases
   case "${ACTION}" in
     # Associate RECIPIENT to MAIL_ALIAS:
     ( 'update' )
-      if grep -q "^${MAIL_ALIAS}" "${DATABASE_ACCOUNTS}"
+      if [[ -f ${DATABASE_ACCOUNTS} ]] && grep -q "^${MAIL_ALIAS}" "${DATABASE_ACCOUNTS}"
       then
         _exit_with_error "'${MAIL_ALIAS}' is already defined to be an account"
       fi

--- a/target/scripts/helpers/database/manage/postfix-virtual.sh
+++ b/target/scripts/helpers/database/manage/postfix-virtual.sh
@@ -25,6 +25,10 @@ function _manage_virtual_aliases
   case "${ACTION}" in
     # Associate RECIPIENT to MAIL_ALIAS:
     ( 'update' )
+      if grep -q "^${MAIL_ALIAS}" "${DATABASE_ACCOUNTS}"
+      then
+        _exit_with_error "'${MAIL_ALIAS}' is already defined to be an account"
+      fi
       _db_entry_add_or_append "${DATABASE_VIRTUAL}" "${MAIL_ALIAS}" "${RECIPIENT}"
       ;;
 


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
We do not support aliases that are accounts at the same time. This commit provides a guard that checks the condition.

@bibiak1 made us aware of the fact that we allow creating aliases as users (and vice versa). I think we do not support this, and at least to me, it does not make a lot of sense.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #3262
Closes #3259

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
