### PR TITLE
scripts: fix setting `SRS_EXCLUDE_DOMAINS` during startup

### DIFF
--- a/target/scripts/startup/setup.d/postfix.sh
+++ b/target/scripts/startup/setup.d/postfix.sh
@@ -170,8 +170,8 @@ function _setup_SRS
 
   if [[ -n ${SRS_EXCLUDE_DOMAINS} ]]
   then
-    sed -i \
-      "s/^#\?(SRS_EXCLUDE_DOMAINS=).*$/\1=${SRS_EXCLUDE_DOMAINS}/g" \
+    sedfile -i -E \
+      "s|^#?(SRS_EXCLUDE_DOMAINS=).*|\1${SRS_EXCLUDE_DOMAINS}|" \
       /etc/default/postsrsd
   fi
 }


### PR DESCRIPTION
# Description

``mailserver  | sed: -e expression #1, char 302: invalid reference \1 on `s' command's RHS``

The sed command has a syntax error preventing a reference from being created. There's also an errant "=" that would output.

This fixes the issue and allows SRS_EXCLUDE_DOMAINS to be set in the postsrsd configuration.

## Type of change

<!-- Delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
