### PR TITLE
scripts: apply fixes to helpers when using `set -eE`

### DIFF
--- a/target/scripts/helpers/dns.sh
+++ b/target/scripts/helpers/dns.sh
@@ -41,7 +41,7 @@ function _obtain_hostname_and_domainname
   # of this variable or if a more deterministic approach with `cut` should be relied on.
   if [[ $(_get_label_count "${HOSTNAME}") -gt 2 ]]
   then
-    if [[ -n ${OVERRIDE_HOSTNAME} ]]
+    if [[ -n ${OVERRIDE_HOSTNAME:-} ]]
     then
       # Emulates the intended behaviour of `hostname -d`:
       # Assign the HOSTNAME value minus everything up to and including the first `.`

--- a/target/scripts/helpers/log.sh
+++ b/target/scripts/helpers/log.sh
@@ -123,9 +123,9 @@ function _get_log_level_or_default
   if [[ -n ${LOG_LEVEL+set} ]]
   then
     echo "${LOG_LEVEL}"
-  elif [[ -e /etc/dms-settings ]]
+  elif [[ -e /etc/dms-settings ]] && grep -q -E "^LOG_LEVEL='[a-z]+'" /etc/dms-settings
   then
-    grep "^LOG_LEVEL=" /etc/dms-settings | cut -d "'" -f 2
+    grep '^LOG_LEVEL=' /etc/dms-settings | cut -d "'" -f 2
   else
     echo 'info'
   fi

--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -16,7 +16,13 @@ function _get_valid_lines_from_file
 # and it will return its value stored in /etc/dms-settings
 function _get_dms_env_value
 {
-  grep "^${1}=" /etc/dms-settings | cut -d "'" -f 2
+  if [[ -f /etc/dms-settings ]]
+  then
+    grep "^${1}=" /etc/dms-settings | cut -d "'" -f 2
+  else
+    _log 'warn' "Call to '_get_dms_env_value' but '/etc/dms-settings' is not present"
+    return 1
+  fi
 }
 
 # TODO: `chown -R 5000:5000 /var/mail` has existed since the projects first commit.
@@ -33,6 +39,7 @@ function _chown_var_mail_if_necessary
     _log 'trace' 'Fixing /var/mail permissions'
     chown -R 5000:5000 /var/mail || return 1
   fi
+  return 0
 }
 
 function _require_n_parameters_or_print_usage
@@ -43,6 +50,7 @@ function _require_n_parameters_or_print_usage
 
   [[ ${1:-} == 'help' ]]  && { __usage ; exit 0 ; }
   [[ ${#} -lt ${COUNT} ]] && { __usage ; exit 1 ; }
+  return 0
 }
 
 # NOTE: Postfix commands that read `main.cf` will stall execution,
@@ -56,6 +64,7 @@ function _adjust_mtime_for_postfix_maincf
   then
     touch -d '2 seconds ago' /etc/postfix/main.cf
   fi
+  return 0
 }
 
 function _reload_postfix


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
For an upcoming PR, these changes are required, because the script that is using the helpers uses `set -eE`. This leads to situations where errors are not properly handled in our helpers (yet; I plan on changing that in the future).

<!-- Link the issue which will be fixed (if any) here: -->
Fixes issues of an upcoming PR that I do not want to include in the upcoming PR because I am a nice maintainer and I try my best to separate concerns with PRs :D 😆

The `return 0` statements at the end of some functions seem superflous, but they are not, because the previos command (even when run inside an `if`-clause) set the return value to non-zero, which is not what we want.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
