### PR TITLE
docs: improve Rspamd docs about DKIM signing of multiple domains

### DIFF
--- a/docs/content/config/best-practices/dkim_dmarc_spf.md
+++ b/docs/content/config/best-practices/dkim_dmarc_spf.md
@@ -109,6 +109,10 @@ DKIM is currently supported by either OpenDKIM or Rspamd:
 
         will execute the helper script with default parameters.
 
+    ??? warning "Using Multiple Domains"
+
+        Unlike the current script for OpenDKIM, the Rspamd script will **not** create keys for all domains DMS is managing, but only for the one it assumes to be the main domain (derived from DMS' domain name). Moreover, the default `dkim_signing.conf` configuration file that DMS ships will also only contain one domain. If you have multiple domains, you need to run the command `docker exec -ti <CONTAINER NAME> setup config dkim domain <DOMAIN>` multiple times to create all the keys for all domains, and then provide a custom `dkim_signing.conf` (for which an example is shown below).
+
     !!! info "About the Helper Script"
 
         The script will persist the keys in `/tmp/docker-mailserver/rspamd/dkim/`. Hence, if you are already using the default volume mounts, the keys are persisted in a volume. The script also restarts Rspamd directly, so changes take effect without restarting DMS.
@@ -148,24 +152,16 @@ DKIM is currently supported by either OpenDKIM or Rspamd:
 
         As shown next:
 
-        - You can add more domains into the `domain { ... }` section.
-        - A domain can also be configured with multiple selectors and keys within a `selectors [ ... ]` array.
+        - You can add more domains into the `domain { ... }` section (in the following example: `example.com` and `example.org`).
+        - A domain can also be configured with multiple selectors and keys within a `selectors [ ... ]` array (in the following example, this is done for `example.org`).
 
         ```cf
         # ...
 
         domain {
             example.com {
-                selectors [
-                    {
-                        path = "/tmp/docker-mailserver/rspamd/dkim/example.com/rsa.private";
-                        selector = "dkim-rsa";
-                    },
-                    {
-                        path = /tmp/docker-mailserver/rspamd/example.com/ed25519.private";
-                        selector = "dkim-ed25519";
-                    }
-                ]
+                path = /tmp/docker-mailserver/rspamd/example.com/ed25519.private";
+                selector = "dkim-ed25519";
             }
             example.org {
                 selectors [

--- a/target/scripts/startup/setup.d/security/rspamd.sh
+++ b/target/scripts/startup/setup.d/security/rspamd.sh
@@ -78,11 +78,11 @@ function __rspamd__run_early_setup_and_checks
   if [[ -d ${RSPAMD_DMS_OVERRIDE_D} ]]
   then
     __rspamd__log 'debug' "Found directory '${RSPAMD_DMS_OVERRIDE_D}' - linking it to '${RSPAMD_OVERRIDE_D}'"
-    if rmdir "${RSPAMD_OVERRIDE_D}"
+    if rmdir "${RSPAMD_OVERRIDE_D}" 2>/dev/null
     then
       ln -s "${RSPAMD_DMS_OVERRIDE_D}" "${RSPAMD_OVERRIDE_D}"
     else
-      __rspamd__log 'warn' "Could not remove '${RSPAMD_OVERRIDE_D}' (not empty?) - not linking '${RSPAMD_DMS_OVERRIDE_D}'"
+      __rspamd__log 'warn' "Could not remove '${RSPAMD_OVERRIDE_D}' (not empty,not a directory?) - not linking '${RSPAMD_DMS_OVERRIDE_D}'"
     fi
   fi
 

--- a/target/scripts/startup/setup.d/security/rspamd.sh
+++ b/target/scripts/startup/setup.d/security/rspamd.sh
@@ -82,7 +82,7 @@ function __rspamd__run_early_setup_and_checks
     then
       ln -s "${RSPAMD_DMS_OVERRIDE_D}" "${RSPAMD_OVERRIDE_D}"
     else
-      __rspamd__log 'warn' "Could not remove '${RSPAMD_OVERRIDE_D}' (not empty,not a directory?) - not linking '${RSPAMD_DMS_OVERRIDE_D}'"
+      __rspamd__log 'warn' "Could not remove '${RSPAMD_OVERRIDE_D}' (not empty? not a directory?; did you restart properly?) - not linking '${RSPAMD_DMS_OVERRIDE_D}'"
     fi
   fi
 


### PR DESCRIPTION
See #3326 & #3328

# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
Improves docs on Rspamd's DKIM script usage for multiple domains. Also mutes the output of `rmdir` and only shows the error afterwards (see #3328).


<!-- Link the issue which will be fixed (if any) here: -->
Fixes #3326

## Type of change

<!-- Delete options that are not relevant. -->

- [x] This change is a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code