### PR TITLE
config: adjust `antivirus.conf` for Rspamd

### DIFF
--- a/target/rspamd/local.d/actions.conf
+++ b/target/rspamd/local.d/actions.conf
@@ -1,3 +1,9 @@
 # documentation: https://rspamd.com/doc/configuration/metrics.html#actions
+# and            https://rspamd.com/doc/configuration/metrics.html
+
+#greylist = 4;
+#add_header = 6;
+#rewrite_subject = 7;
+#reject = 15;
 
 subject = "***SPAM*** %s"

--- a/target/rspamd/local.d/antivirus.conf
+++ b/target/rspamd/local.d/antivirus.conf
@@ -11,4 +11,6 @@ ClamAV {
     symbol = "CLAM_VIRUS";
     log_clean = true;
     max_size = 25000000;
+    timeout = 10;
+    retransmits = 2;
 }


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
See #3320. Adds (really not well documented) parameters to Rspamd configuration so ClamAV will not complain anymore because of short scan times.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #3320

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
