### PR TITLE
scripts: improve `CLAMAV_MESSAGE_SIZE_LIMIT` usage

### DIFF
--- a/target/rspamd/local.d/antivirus.conf
+++ b/target/rspamd/local.d/antivirus.conf
@@ -10,4 +10,5 @@ ClamAV {
     scan_mime_parts = false;
     symbol = "CLAM_VIRUS";
     log_clean = true;
+    max_size = 25000000;
 }

--- a/target/scripts/startup/setup.d/security/misc.sh
+++ b/target/scripts/startup/setup.d/security/misc.sh
@@ -188,7 +188,7 @@ function __setup__security__clamav
       _log 'trace' "Setting ClamAV message scan size limit to '${CLAMAV_MESSAGE_SIZE_LIMIT}'"
 
       # do a short sanity checks; ClamAV stops scanning at more that 4GB file size
-      if [[ $(numfmt --from=si "${CLAMAV_MESSAGE_SIZE_LIMIT}") > $(numfmt --from=si 4G) ]]
+      if [[ $(numfmt --from=si "${CLAMAV_MESSAGE_SIZE_LIMIT}") -gt $(numfmt --from=si 4G) ]]
       then
         _log 'warn' "You set 'CLAMAV_MESSAGE_SIZE_LIMIT' to a value larger than 4 Gigabyte which ClamAV does not support - you should correct your configuration"
       fi

--- a/target/scripts/startup/setup.d/security/misc.sh
+++ b/target/scripts/startup/setup.d/security/misc.sh
@@ -186,8 +186,18 @@ function __setup__security__clamav
     if [[ ${CLAMAV_MESSAGE_SIZE_LIMIT} != '25M' ]]
     then
       _log 'trace' "Setting ClamAV message scan size limit to '${CLAMAV_MESSAGE_SIZE_LIMIT}'"
-      sedfile -i \
-        "s/^MaxFileSize.*/MaxFileSize ${CLAMAV_MESSAGE_SIZE_LIMIT}/" \
+
+      # do a short sanity checks; ClamAV stops scanning at more that 4GB file size
+      if [[ $(numfmt --from=si "${CLAMAV_MESSAGE_SIZE_LIMIT}") > $(numfmt --from=si 4G) ]]
+      then
+        _log 'warn' "You set 'CLAMAV_MESSAGE_SIZE_LIMIT' to a value larger than 4 Gigabyte which ClamAV does not support - you should correct your configuration"
+      fi
+
+      sedfile -i -E \
+        "s|^(MaxFileSize).*|\1 ${CLAMAV_MESSAGE_SIZE_LIMIT}|" \
+        /etc/clamav/clamd.conf
+      sedfile -i -E \
+        "s|^(MaxScanSize).*|\1 ${CLAMAV_MESSAGE_SIZE_LIMIT}|" \
         /etc/clamav/clamd.conf
     fi
   else

--- a/target/scripts/startup/setup.d/security/rspamd.sh
+++ b/target/scripts/startup/setup.d/security/rspamd.sh
@@ -164,6 +164,14 @@ function __rspamd__setup_clamav
     sedfile -i -E 's|^(enabled).*|\1 = true;|g' "${RSPAMD_LOCAL_D}/antivirus.conf"
     # Rspamd uses ClamAV's UNIX socket, and to be able to read it, it must be in the same group
     usermod -a -G clamav _rspamd
+
+    if [[ ${CLAMAV_MESSAGE_SIZE_LIMIT} != '25M' ]]
+    then
+      local SIZE_IN_BYTES
+      SIZE_IN_BYTES=$(numfmt --from=si "${CLAMAV_MESSAGE_SIZE_LIMIT}")
+      __rspamd__log 'trace' "Adjusting maximum size for ClamAV to ${SIZE_IN_BYTES} bytes (${CLAMAV_MESSAGE_SIZE_LIMIT})"
+      sedfile -i -E "s|(.*max_size =).*|\1 ${SIZE_IN_BYTES};|" "${RSPAMD_LOCAL_D}/antivirus.conf"
+    fi
   else
     __rspamd__log 'debug' 'Rspamd will not use ClamAV (which has not been enabled)'
   fi

--- a/test/tests/parallel/set1/spam_virus/rspamd_full.bats
+++ b/test/tests/parallel/set1/spam_virus/rspamd_full.bats
@@ -20,6 +20,7 @@ function setup_file() {
     --env ENABLE_OPENDMARC=0
     --env ENABLE_POLICYD_SPF=0
     --env ENABLE_POSTGREY=0
+    --env CLAMAV_MESSAGE_SIZE_LIMIT=42M
     --env PERMIT_DOCKER=host
     --env LOG_LEVEL=trace
     --env MOVE_SPAM_TO_JUNK=1
@@ -78,6 +79,7 @@ function teardown_file() { _default_teardown ; }
   run docker logs "${CONTAINER_NAME}"
   assert_success
   assert_line --partial 'Enabling ClamAV integration'
+  assert_line --partial 'Adjusting maximum size for ClamAV to 42000000 bytes (42M)'
   assert_line --partial 'Setting up intelligent learning of spam and ham'
   assert_line --partial 'Enabling greylisting'
   assert_line --partial 'Hfilter (group) module is enabled'
@@ -94,6 +96,11 @@ function teardown_file() { _default_teardown ; }
   _service_log_should_contain_string 'rspamd' 'lua module spamassassin is disabled in the configuration'
   _service_log_should_contain_string 'rspamd' 'lua module url_redirector is disabled in the configuration'
   _service_log_should_contain_string 'rspamd' 'lua module metric_exporter is disabled in the configuration'
+}
+
+@test 'antivirus maximum size was adjusted' {
+  _run_in_container grep 'max_size = 42000000' /etc/rspamd/local.d/antivirus.conf
+  assert_success
 }
 
 @test 'normal mail passes fine' {

--- a/test/tests/parallel/set1/spam_virus/rspamd_partly.bats
+++ b/test/tests/parallel/set1/spam_virus/rspamd_partly.bats
@@ -57,6 +57,11 @@ function teardown_file() { _default_teardown ; }
   assert_line --partial 'Disabling Hfilter (group) module'
 }
 
+@test 'antivirus maximum size was not adjusted unnecessarily' {
+  _run_in_container grep 'max_size = 25000000' /etc/rspamd/local.d/antivirus.conf
+  assert_success
+}
+
 @test 'learning is properly disabled' {
   for FILE in learn-{ham,spam}.{sieve,svbin}
   do


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

Addes sanity check for ClamAV size & adjusted MaxScanSize. The second part is of special importance! See <https://askubuntu.com/a/1448525>, which explains that the maximum scan size is important as well. We previously just set the maximum file size, which actually is pretty insecure as we silently not scan mile bigger than `MaxScanSize`. This is corrected now.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
