### PR TITLE
Rspamd: adjust learning of ham

### DIFF
--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -353,7 +353,9 @@ Controls whether the [Rspamd Greylisting module][rspamd-greylisting-module] is e
 When enabled,
 
 1. the "[autolearning][rspamd-autolearn]" feature is turned on;
-2. the Bayes classifier will be trained when moving mails from or to the Junk folder (with the help of Sieve scripts).
+2. the Bayes classifier will be trained (with the help of Sieve scripts) when moving mails
+    1. from anywhere to the `Junk` folder (learning this email as spam);
+    2. from the `Junk` folder into the `INBOX` (learning this email as ham).
 
 !!! warning "Attention"
 

--- a/target/scripts/startup/setup.d/security/rspamd.sh
+++ b/target/scripts/startup/setup.d/security/rspamd.sh
@@ -222,13 +222,13 @@ function __rspamd__setup_learning
     sedfile -i -E '/^}/d' /etc/dovecot/conf.d/90-sieve.conf
     cat >>/etc/dovecot/conf.d/90-sieve.conf << EOF
 
-  # From elsewhere to Junk folder
+  # From anyhwere to Junk
   imapsieve_mailbox1_name = Junk
   imapsieve_mailbox1_causes = COPY
   imapsieve_mailbox1_before = file:${SIEVE_PIPE_BIN_DIR}/learn-spam.sieve
 
-  # From Junk folder to elsewhere
-  imapsieve_mailbox2_name = *
+  # From Junk to Inbox
+  imapsieve_mailbox2_name = INBOX
   imapsieve_mailbox2_from = Junk
   imapsieve_mailbox2_causes = COPY
   imapsieve_mailbox2_before = file:${SIEVE_PIPE_BIN_DIR}/learn-ham.sieve

--- a/test/test-files/nc_templates/rspamd_imap_move_to_inbox.txt
+++ b/test/test-files/nc_templates/rspamd_imap_move_to_inbox.txt
@@ -1,4 +1,4 @@
 A LOGIN user1@localhost.localdomain 123
 B SELECT Junk
-A UID MOVE 1:1 INBOX
-A4 LOGOUT
+A MOVE 1:1 INBOX
+A LOGOUT

--- a/test/test-files/nc_templates/rspamd_imap_move_to_junk.txt
+++ b/test/test-files/nc_templates/rspamd_imap_move_to_junk.txt
@@ -1,4 +1,4 @@
 A LOGIN user1@localhost.localdomain 123
 B SELECT INBOX
-A UID MOVE 1:1 Junk
-A4 LOGOUT
+A MOVE 1:1 Junk
+A LOGOUT


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
When moving a mail from the Junk folder to the Trash folder, the mail
previously classified as ham due to the wildcard match of `*`. Because
the syntax does not allow for negation, we can only change the behavior
in a way that mails are learned as ham when they are moved into `INBOX`
from `Junk`. This is reasonable though.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #3333

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update (not strictly)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
