### PR TITLE
Dovecot: make home dir distinct from mail dir

### DIFF
--- a/target/dovecot/10-mail.conf
+++ b/target/dovecot/10-mail.conf
@@ -27,6 +27,7 @@
 #
 # <doc/wiki/MailLocation.txt>
 #
+mail_home = /var/mail/%d/%n/home
 mail_location = maildir:/var/mail/%d/%n
 
 # If you need to set multiple mailbox locations or want to change default

--- a/target/dovecot/10-mail.conf
+++ b/target/dovecot/10-mail.conf
@@ -27,7 +27,7 @@
 #
 # <doc/wiki/MailLocation.txt>
 #
-mail_home = /var/mail/%d/%n/home
+mail_home = /var/mail/%d/%n/home/
 mail_location = maildir:/var/mail/%d/%n
 
 # If you need to set multiple mailbox locations or want to change default

--- a/target/dovecot/auth-master.inc
+++ b/target/dovecot/auth-master.inc
@@ -6,4 +6,3 @@ passdb {
   result_success = continue
   #auth_bind = yes
 }
-

--- a/target/dovecot/auth-passwdfile.inc
+++ b/target/dovecot/auth-passwdfile.inc
@@ -15,5 +15,5 @@ passdb {
 userdb {
   driver = passwd-file
   args = username_format=%u /etc/dovecot/userdb
-  default_fields = uid=docker gid=docker home=/var/mail/%d/%u/home
+  default_fields = uid=docker gid=docker home=/var/mail/%d/%u/home/
 }

--- a/target/dovecot/auth-passwdfile.inc
+++ b/target/dovecot/auth-passwdfile.inc
@@ -15,5 +15,5 @@ passdb {
 userdb {
   driver = passwd-file
   args = username_format=%u /etc/dovecot/userdb
-  default_fields = uid=docker gid=docker home=/var/mail/%d/%u
+  default_fields = uid=docker gid=docker home=/var/mail/%d/%u/home
 }

--- a/target/scripts/helpers/accounts.sh
+++ b/target/scripts/helpers/accounts.sh
@@ -77,7 +77,7 @@ function _create_accounts
 
       # Dovecot's userdb has the following format
       # user:password:uid:gid:(gecos):home:(shell):extra_fields
-      DOVECOT_USERDB_LINE="${LOGIN}:${PASS}:5000:5000::/var/mail/${DOMAIN}/${USER}::${USER_ATTRIBUTES}"
+      DOVECOT_USERDB_LINE="${LOGIN}:${PASS}:5000:5000::/var/mail/${DOMAIN}/${USER}/home::${USER_ATTRIBUTES}"
       if grep -qF "${DOVECOT_USERDB_LINE}" "${DOVECOT_USERDB_FILE}"
       then
         _log 'warn' "Login '${LOGIN}' will not be added to '${DOVECOT_USERDB_FILE}' twice"
@@ -85,12 +85,12 @@ function _create_accounts
         echo "${DOVECOT_USERDB_LINE}" >>"${DOVECOT_USERDB_FILE}"
       fi
 
-      mkdir -p "/var/mail/${DOMAIN}/${USER}"
+      mkdir -p "/var/mail/${DOMAIN}/${USER}/home"
 
       # copy user provided sieve file, if present
       if [[ -e "/tmp/docker-mailserver/${LOGIN}.dovecot.sieve" ]]
       then
-        cp "/tmp/docker-mailserver/${LOGIN}.dovecot.sieve" "/var/mail/${DOMAIN}/${USER}/.dovecot.sieve"
+        cp "/tmp/docker-mailserver/${LOGIN}.dovecot.sieve" "/var/mail/${DOMAIN}/${USER}/home/.dovecot.sieve"
       fi
     done < <(_get_valid_lines_from_file "${DATABASE_ACCOUNTS}")
 

--- a/target/scripts/startup/setup.d/dovecot.sh
+++ b/target/scripts/startup/setup.d/dovecot.sh
@@ -24,10 +24,10 @@ function _setup_dovecot
 
     ( 'sdbox' | 'mdbox' )
       _log 'trace' "Dovecot ${DOVECOT_MAILBOX_FORMAT} format configured"
-      sed -i -e \
-        "s|^mail_location = .*$|mail_location = ${DOVECOT_MAILBOX_FORMAT}:\/var\/mail\/%d\/%n|g" \
+      sedfile -i -E "s|^(mail_home =).*|\1 /var/mail/%d/%n|" /etc/dovecot/conf.d/10-mail.conf
+      sedfile -i -E \
+        "s|^(mail_location =).*|\1 ${DOVECOT_MAILBOX_FORMAT}:/var/mail/%d/%n|" \
         /etc/dovecot/conf.d/10-mail.conf
-
       _log 'trace' 'Enabling cron job for dbox purge'
       mv /etc/cron.d/dovecot-purge.disabled /etc/cron.d/dovecot-purge
       chmod 644 /etc/cron.d/dovecot-purge
@@ -35,7 +35,6 @@ function _setup_dovecot
 
     ( * )
       _log 'trace' 'Dovecot default format (maildir) configured'
-      sed -i -e 's|^mail_location = .*$|mail_location = maildir:\/var\/mail\/%d\/%n|g' /etc/dovecot/conf.d/10-mail.conf
       ;;
 
   esac

--- a/test/tests/parallel/set1/dovecot/dovecot_sieve.bats
+++ b/test/tests/parallel/set1/dovecot/dovecot_sieve.bats
@@ -17,9 +17,9 @@ function setup_file() {
     --env ENABLE_MANAGESIEVE=1
     # Required for mail delivery via nc:
     --env PERMIT_DOCKER=container
-    # Mount into mail dir for user1 to treat as a user-sieve:
+    # Mount into home dir for user1 to treat as a user-sieve:
     # NOTE: Cannot use ':ro', 'start-mailserver.sh' attempts to 'chown -R' /var/mail:
-    --volume "${TEST_TMP_CONFIG}/dovecot.sieve:/var/mail/localhost.localdomain/user1/.dovecot.sieve"
+    --volume "${TEST_TMP_CONFIG}/dovecot.sieve:/var/mail/localhost.localdomain/user1/home/.dovecot.sieve"
   )
   _common_container_setup 'CONTAINER_ARGS_ENV_CUSTOM'
 


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

Funnily enough, strictly speaking this is not actually a breaking change. The Sieve scripts are already moved by us from `/tmp/docker-mailserver` to the correct location on startup, and the same goes for the Dovecot userdb file. But that is irrelevant, as the next version we are going to release is a major.. I woudl definitely mention it separately on the release page and in the changelog.

I consider this PR as high priority, as <<https://doc.dovecot.org/configuration_manual/home_directories_for_virtual_users/> points out: "Home directory shouldn’t be the same as mail directory with mbox or Maildir formats (but with dbox/obox it’s fine). It’s possible to do that, but you might run into trouble with it sooner or later."

I took care that mdbox/sdbox formats are untouched.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #3296

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
