### PR TITLE
Fail2Ban: fix regression introduced in #3269

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,6 +144,7 @@ EOF
 COPY target/fail2ban/jail.local /etc/fail2ban/jail.local
 COPY target/fail2ban/fail2ban.d/fixes.local /etc/fail2ban/fail2ban.d/fixes.local
 RUN <<EOF
+  mkdir -p /var/log/mail
   ln -s  /var/log/mail/mail.log     /var/log/mail.log
   ln -sf /var/log/mail/fail2ban.log /var/log/fail2ban.log
   # disable sshd jail
@@ -193,7 +194,6 @@ EOF
 
 RUN <<EOF
   sedfile -i -r "/^#?compress/c\compress\ncopytruncate" /etc/logrotate.conf
-  mkdir /var/log/mail
   chown syslog:root /var/log/mail
   touch /var/log/mail/clamav.log
   chown -R clamav:root /var/log/mail/clamav.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,6 @@ EOF
 COPY target/fail2ban/jail.local /etc/fail2ban/jail.local
 COPY target/fail2ban/fail2ban.d/fixes.local /etc/fail2ban/fail2ban.d/fixes.local
 RUN <<EOF
-  mkdir -p /var/log/mail
   ln -s  /var/log/mail/mail.log     /var/log/mail.log
   ln -sf /var/log/mail/fail2ban.log /var/log/fail2ban.log
   # disable sshd jail
@@ -194,8 +193,9 @@ EOF
 
 RUN <<EOF
   sedfile -i -r "/^#?compress/c\compress\ncopytruncate" /etc/logrotate.conf
+  mkdir /var/log/mail
   chown syslog:root /var/log/mail
-  touch /var/log/mail/clamav.log
+  touch /var/log/mail/{clamav,fail2ban}.log
   chown -R clamav:root /var/log/mail/clamav.log
   touch /var/log/mail/freshclam.log
   chown -R clamav:root /var/log/mail/freshclam.log


### PR DESCRIPTION
# Description

Fail2Ban would not start because the new link as dangling. This is now corrected. At least my setup, which has a recidive jail, did not start properly.

Fixes:

```console
root@mail:/# /usr/bin/fail2ban-server -xf start
2023-05-13 17:02:01,445 fail2ban.jailreader     [2631]: WARNING File /var/log/fail2ban.log is a dangling link, thus cannot be monitored
2023-05-13 17:02:01,446 fail2ban                [2631]: ERROR   Failed during configuration: Have not found any log file for recidive jail
2023-05-13 17:02:01,446 fail2ban                [2631]: ERROR   Async configuration of server failed
```

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
