### PR TITLE
docs: Restore missing edit button

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -35,6 +35,8 @@ theme:
     - navigation.top
     - navigation.expand
     - navigation.instant
+    - content.action.edit
+    - content.action.view
     - content.code.annotate
   palette:
     # Light mode


### PR DESCRIPTION
# Description

>A "view source" button can be shown next to the "edit this page" button, both of which must now be explicitly enabled.

Source: https://squidfunk.github.io/mkdocs-material/upgrade/#contentaction


<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
