### PR TITLE
ClamAV: add a warning for the internal message size limit

### DIFF
--- a/target/scripts/startup/setup.d/security/misc.sh
+++ b/target/scripts/startup/setup.d/security/misc.sh
@@ -187,10 +187,16 @@ function __setup__security__clamav
     then
       _log 'trace' "Setting ClamAV message scan size limit to '${CLAMAV_MESSAGE_SIZE_LIMIT}'"
 
-      # do a short sanity checks; ClamAV stops scanning at more that 4GB file size
-      if [[ $(numfmt --from=si "${CLAMAV_MESSAGE_SIZE_LIMIT}") -gt $(numfmt --from=si 4G) ]]
+      # do a short sanity check: ClamAV does not support setting a maximum size greater than 4000M (at all)
+      if [[ $(numfmt --from=si "${CLAMAV_MESSAGE_SIZE_LIMIT}") -gt $(numfmt --from=si 4000M) ]]
       then
-        _log 'warn' "You set 'CLAMAV_MESSAGE_SIZE_LIMIT' to a value larger than 4 Gigabyte which ClamAV does not support - you should correct your configuration"
+        _log 'warn' "You set 'CLAMAV_MESSAGE_SIZE_LIMIT' to a value larger than 4 Gigabyte, but the maximum value is 4000M for this value - you should correct your configuration"
+      fi
+      # For more details, see
+      # https://github.com/docker-mailserver/docker-mailserver/pull/3341
+      if [[ $(numfmt --from=si "${CLAMAV_MESSAGE_SIZE_LIMIT}") -ge $(numfmt --from=iec 2G) ]]
+      then
+        _log 'warn' "You set 'CLAMAV_MESSAGE_SIZE_LIMIT' to a value larger than 2 GiBiByte but ClamAV does not scan files larger or equal to 2GiBiByte"
       fi
 
       sedfile -i -E \


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
ClamAV stops scanning files larger than or equal to 2GiB add a warning for that.


When checking the 4000M limit for CLAMAV_MESSAGE_SIZE_LIMIT in https://github.com/docker-mailserver/docker-mailserver/pull/3332#discussion_r1193388669 i discovered that ClamAV stops scanning at a much lower limit.


<!-- Link the issue which will be fixed (if any) here: -->
Fixes #

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Info @wt-io-it