### PR TITLE
fix: DB helper should properly filter entries

### DIFF
--- a/target/scripts/helpers/database/db.sh
+++ b/target/scripts/helpers/database/db.sh
@@ -132,11 +132,11 @@ function __db_list_already_contains_value
 {
   # Avoids accidentally matching a substring (case-insensitive acceptable):
   # 1. Extract the current value of the entry (`\1`),
-  # 2. If a value list, split into separate lines (`\n`+`g`) at V_DELIMITER,
+  # 2. Value list support: Split values into separate lines (`\n`+`g`) at V_DELIMITER,
   # 3. Check each line for an exact match of the target VALUE
-  sed -e "s/^${KEY_LOOKUP}\(.*\)/\1/" \
-      -e "s/${V_DELIMITER}/\n/g"      \
-      "${DATABASE}" | grep -qi "^${_VALUE_}$"
+  sed -ne "s/^${KEY_LOOKUP}\+\(.*\)/\1/p" "${DATABASE}" \
+    | sed -e "s/${V_DELIMITER}/\n/g" \
+    | grep -qi "^${_VALUE_}$"
 }
 
 


### PR DESCRIPTION
# Description

Previously it was assumed the sed operation was applying the sed expressions as a sequence, but it did not seem to filter entries being looked up correctly. Instead any line that matched either sed expression pattern was output (_value without matching key, values split by the delimiter_), then grep would match any of that causing false-positives.

Resolved by piping the first sed expression into the next.

Fixes: https://github.com/docker-mailserver/docker-mailserver/issues/3358

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
