### PR TITLE
Fix issue with concatenating $dmarc_milter and $dkim_milter in main.cf

### DIFF
--- a/target/scripts/startup/setup.d/dmarc_dkim_spf.sh
+++ b/target/scripts/startup/setup.d/dmarc_dkim_spf.sh
@@ -17,8 +17,8 @@ function _setup_opendkim() {
     postconf 'dkim_milter = inet:localhost:8891'
     # shellcheck disable=SC2016
     sed -i -E                                            \
-      -e 's|^(smtpd_milters =.*)\$dkim_milter(.*)|\1 \2 \$dkim_milter|g'     \
-      -e 's|^(non_smtpd_milters =.*)\$dkim_milter(.*)|\1 \2 \$dkim_milter|g' \
+      -e '/\$dkim_milter/! s|^(smtpd_milters =.*)|\1 \$dkim_milter|g'     \
+      -e '/\$dkim_milter/! s|^(non_smtpd_milters =.*)|\1 \$dkim_milter|g' \
       /etc/postfix/main.cf
 
     # check if any keys are available
@@ -64,7 +64,7 @@ function _setup_opendmarc() {
     postconf 'dmarc_milter = inet:localhost:8893'
     # Make sure to append the OpenDMARC milter _after_ the OpenDKIM milter!
     # shellcheck disable=SC2016
-    sed -i -E 's|^(smtpd_milters =.*)\$dmarc_milter(.*)|\1 \2 \$dmarc_milter|g' /etc/postfix/main.cf
+    sed -i -E '/\$dmarc_milter/! s|^(smtpd_milters =.*)|\1 \$dmarc_milter|g' /etc/postfix/main.cf
 
     sed -i \
       -e "s|^AuthservID.*$|AuthservID          ${HOSTNAME}|g" \

--- a/target/scripts/startup/setup.d/dmarc_dkim_spf.sh
+++ b/target/scripts/startup/setup.d/dmarc_dkim_spf.sh
@@ -17,8 +17,8 @@ function _setup_opendkim() {
     postconf 'dkim_milter = inet:localhost:8891'
     # shellcheck disable=SC2016
     sed -i -E                                            \
-      -e 's|^(smtpd_milters =.*)|\1 \$dkim_milter|g'     \
-      -e 's|^(non_smtpd_milters =.*)|\1 \$dkim_milter|g' \
+      -e 's|^(smtpd_milters =.*)\$dkim_milter(.*)|\1 \2 \$dkim_milter|g'     \
+      -e 's|^(non_smtpd_milters =.*)\$dkim_milter(.*)|\1 \2 \$dkim_milter|g' \
       /etc/postfix/main.cf
 
     # check if any keys are available
@@ -64,7 +64,7 @@ function _setup_opendmarc() {
     postconf 'dmarc_milter = inet:localhost:8893'
     # Make sure to append the OpenDMARC milter _after_ the OpenDKIM milter!
     # shellcheck disable=SC2016
-    sed -i -E 's|^(smtpd_milters =.*)|\1 \$dmarc_milter|g' /etc/postfix/main.cf
+    sed -i -E 's|^(smtpd_milters =.*)\$dmarc_milter(.*)|\1 \2 \$dmarc_milter|g' /etc/postfix/main.cf
 
     sed -i \
       -e "s|^AuthservID.*$|AuthservID          ${HOSTNAME}|g" \


### PR DESCRIPTION
Upon each start the  `smtpd_milters` and `non_smtpd_milters` would be extended with the following:
```
smtpd_milters =   $dmarc_milter $dkim_milter
non_smtpd_milters = $dkim_milter
```
In my case they became long enough that mail delivery stopped. I think this was because of the extra headers that are added by these steps. (which in turn would cause the mail to be dropped)

# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
