### PR TITLE
ci: Simplify GH bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: File a bug report
+description: Submit a bug report to help us improve
 title: 'bug report: '
 labels:
   - kind/bug/report
@@ -9,7 +9,7 @@ body:
   - type: checkboxes
     id: preliminary-checks
     attributes:
-      label: Preliminary Checks
+      label: 📝 Preliminary Checks
       description: Please read these carefully.
       options:
         - label: I checked that all ports are open and not blocked by my ISP / hosting provider.
@@ -19,39 +19,20 @@ body:
         - label: I searched the issue tracker but was unable to find my issue.
           required: true
         - label: |
-            I read
-
-              - the [extended documentation in general](https://docker-mailserver.github.io/docker-mailserver/latest/) but found nothing to resolve the issue;
-              - the [documentation on debugging](https://docker-mailserver.github.io/docker-mailserver/latest/config/debugging/), tried the proposed steps to debug the problem, but was still unable to resolve the issue;
-              - this project's [Code of Conduct](https://github.com/docker-mailserver/docker-mailserver/blob/master/CODE_OF_CONDUCT.md) and I agree;
-              - the [documentation about filing a bug report](https://docker-mailserver.github.io/docker-mailserver/latest/contributing/issues-and-pull-requests/#filing-a-bug-report).
+            I have read:
+              - The [extended documentation in general](https://docker-mailserver.github.io/docker-mailserver/latest/) but found nothing to resolve the issue;
+              - The [documentation on debugging](https://docker-mailserver.github.io/docker-mailserver/latest/config/debugging/), tried the proposed steps to debug the problem, but was still unable to resolve the issue;
+              - This project's [Code of Conduct](https://github.com/docker-mailserver/docker-mailserver/blob/master/CODE_OF_CONDUCT.md) and I agree;
+              - The [documentation about filing a bug report](https://docker-mailserver.github.io/docker-mailserver/latest/contributing/issues-and-pull-requests/#filing-a-bug-report).
           required: true
-  - type: dropdown
+  - type: input
     id: operating-system
     attributes:
-      label: What operating system is the host running?
-      options:
-        - Linux
-        - macOS (not officially supported)
-        - Windows (unsupported)
-        - Other (unsupported)
-    validations:
-      required: true
-  - type: input
-    id: operating-system-version
-    attributes:
-      label: Which operating system version?
-      placeholder: Debian 11 (Bullseye)
-    validations:
-      required: true
-  - type: dropdown
-    id: isa
-    attributes:
-      label: What computer architecture is the host running?
-      options:
-        - AMD64 (x86_64)
-        - ARM64 (AArch64)
-        - Other (unsupported)
+      label: 💻 Operating System and Architecture
+      description: |
+        Which OS is your docker host running on?
+        **NOTE:** Windows and macOS have limited support.
+      placeholder: Debian 11 (Bullseye) x86_64, Fedora 38 ARM64
     validations:
       required: true
   - type: dropdown
@@ -63,67 +44,51 @@ body:
         - Docker Compose
         - Podman (not officially supported)
         - Kubernetes (not officially supported)
-        - Other (unsupported)
     validations:
       required: true
   - type: input
     id: mailserver-version
     attributes:
-      label: DMS version
+      label: 🐋 DMS Version
       description: On which version (image tag) did you encounter this bug?
       placeholder: v12.1.0
     validations:
       required: true
   - type: textarea
-    id: when-does-it-occur
+    id: what-happened
     attributes:
-      label: What happened and when does this occur?
-      description: >
-        Tell us what happened.
-        **It would also help immensely if you can share precise steps on how to reproduce the issue!** :heart:
-        Use [fenced code blocks](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks) when pasting lots of text!
-      placeholder: Although `LOG_LEVEL=debug` is set, I see no debug output.
+      label: 👀 What Happened?
+      description: How did this differ from your expectations?
+      placeholder: Although `LOG_LEVEL=debug` is set, the logs are missing debug output.
     validations:
       required: true
   - type: textarea
-    id: what-did-you-expect-to-happen
+    id: steps-to-reproduce
     attributes:
-      label: What did you expect to happen?
-      description: Tell us what you expected.
-      placeholder: I expected to see debug messages.
-    validations:
-      required: true
+      label: 👟 Reproduction Steps
+      description: |
+        How did you trigger this bug? Please walk us through it step by step.
+        Please use [fenced code blocks](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks) when pasting lots of text!
+      placeholder: The easier it is for us to reproduce your issue, the sooner we can help resolve it 😉
   - type: textarea
     id: container-configuration-files
     attributes:
       label: Container configuration files
-      description: >
+      description: |
         Show us the file that you use to run DMS (and possibly other related services).
-        This is most likely your `compose.yaml` file, but you can also show us your equivalent `docker run` command, if applicable. If you are using Kubernetes, you can also put your manifest files here.
-        This filed is formatted as YAML.
+        - This field is formatted as YAML.
+        - This is most likely your `compose.yaml` file, but you can also show us your equivalent `docker run` command, if applicable.
+        - If you are using Kubernetes, you can also put your manifest files here.
       render: yml
   - type: textarea
     id: relevant-log-output
     attributes:
       label: Relevant log output
-      description: Show us relevant log output here. You can enable debug output by setting the environment variable `LOG_LEVEL` to `debug` or `trace`. This field's contents are interpreted as pure text.
+      description: |
+        Show us relevant log output here.
+        - This field expects only plain text (_rendered as a fenced code block_).
+        - You can enable debug output by setting the environment variable `LOG_LEVEL` to `debug` or `trace`.
       render: Text
-  - type: checkboxes
-    id: experience
-    attributes:
-      label: What level of experience do you have with containers, mail servers, and using a terminal?
-      description: >
-        **You are not obliged to answer this question**.
-        We do encourage answering though as it provides context to better assist you.
-        Less experienced users tend to make common mistakes, which is ok; by letting us know we can spot those more easily. If you are experienced, we can skip basic questions and save time.
-
-      options:
-        - label: I am inexperienced with containers
-        - label: I am rather experienced with containers
-        - label: I am inexperienced with mail servers
-        - label: I am rather experienced with mail servers
-        - label: I am uncomfortable with using a terminal (CLI)
-        - label: I am rather comfortable with using a terminal (CLI)
   - type: input
     id: form-improvements
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,41 +19,12 @@ body:
         - label: I searched the issue tracker but was unable to find my issue.
           required: true
         - label: |
-            I have read:
+            I have read:  
               - The [extended documentation in general](https://docker-mailserver.github.io/docker-mailserver/latest/) but found nothing to resolve the issue;
               - The [documentation on debugging](https://docker-mailserver.github.io/docker-mailserver/latest/config/debugging/), tried the proposed steps to debug the problem, but was still unable to resolve the issue;
               - This project's [Code of Conduct](https://github.com/docker-mailserver/docker-mailserver/blob/master/CODE_OF_CONDUCT.md) and I agree;
               - The [documentation about filing a bug report](https://docker-mailserver.github.io/docker-mailserver/latest/contributing/issues-and-pull-requests/#filing-a-bug-report).
           required: true
-  - type: input
-    id: operating-system
-    attributes:
-      label: 💻 Operating System and Architecture
-      description: |
-        Which OS is your docker host running on?
-        **NOTE:** Windows and macOS have limited support.
-      placeholder: Debian 11 (Bullseye) x86_64, Fedora 38 ARM64
-    validations:
-      required: true
-  - type: dropdown
-    id: container-orchestrator
-    attributes:
-      label: What container orchestration tool are you using?
-      options:
-        - Docker
-        - Docker Compose
-        - Podman (not officially supported)
-        - Kubernetes (not officially supported)
-    validations:
-      required: true
-  - type: input
-    id: mailserver-version
-    attributes:
-      label: 🐋 DMS Version
-      description: On which version (image tag) did you encounter this bug?
-      placeholder: v12.1.0
-    validations:
-      required: true
   - type: textarea
     id: what-happened
     attributes:
@@ -70,10 +41,28 @@ body:
         How did you trigger this bug? Please walk us through it step by step.
         Please use [fenced code blocks](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks) when pasting lots of text!
       placeholder: The easier it is for us to reproduce your issue, the sooner we can help resolve it 😉
+  - type: input
+    id: mailserver-version
+    attributes:
+      label: 🐋 DMS Version
+      description: On which version (image tag) did you encounter this bug?
+      placeholder: v12.1.0
+    validations:
+      required: true
+  - type: input
+    id: operating-system
+    attributes:
+      label: 💻 Operating System and Architecture
+      description: |
+        Which OS is your docker host running on?
+        **NOTE:** Windows and macOS have limited support.
+      placeholder: Debian 11 (Bullseye) x86_64, Fedora 38 ARM64
+    validations:
+      required: true
   - type: textarea
     id: container-configuration-files
     attributes:
-      label: Container configuration files
+      label: ⚙️ Container configuration files
       description: |
         Show us the file that you use to run DMS (and possibly other related services).
         - This field is formatted as YAML.
@@ -83,7 +72,7 @@ body:
   - type: textarea
     id: relevant-log-output
     attributes:
-      label: Relevant log output
+      label: 📜 Relevant log output
       description: |
         Show us relevant log output here.
         - This field expects only plain text (_rendered as a fenced code block_).


### PR DESCRIPTION
# Description

Simplify the bug report form further by dropping / merging form sections. Partially inspired [`uptime-kuma`](https://github.com/louislam/uptime-kuma) report.

---

Presently the bug report form seems to have plenty of redundant content that maintainers don't leverage as context for responding or triaging any differently. They were originally intended to save us time but I don't recall that happening, sometimes information by the reporter was still communicated at a later stage.

In my experience, it's just additional noise for us and minor friction to the reporter. When the debug docs page is improved, we can probably simplify the "Preliminary Checks" section too (_or migrate common gotchas to still be visible on the bug report page as markdown comment placeholder in the "What Happened?" section_).

**Changes by Commits:**
1. - Minor revisions and formatting changes (_multi-line pipe operator, emoji, fix typos, etc_).
    - Collapsed OS + Arch into single input field (_not much benefit from the two additional dropdown items_).
    - Description/reproduction and expectation sections revised (_expectation intent is typically inferred by the issue description, while detailed reproduction steps can belong a separate optional section_).
    - Removed platform dropdown (_Windows and macOS are mentioned in description as unsupported_).
   - Removed experience checkboxes (_context doesn't really change responses_).
2. - Removed the orchestrator dropdown (_we don't seem to use this information, it's just noise_)
   - Relocate the DMS version + OS/Arch sections to come after the Reproduction steps.
