### PR TITLE
Don't register _setup_spam_to_junk() when SMTP_ONLY=1

### DIFF
--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -95,7 +95,7 @@ function _register_functions() {
   # needs to come after _setup_postfix_early
   _register_setup_function '_setup_spoof_protection'
 
-_register_setup_function '_setup_getmail'
+  _register_setup_function '_setup_getmail'
 
   if [[ ${ENABLE_SRS} -eq 1  ]]; then
     _register_setup_function '_setup_SRS'

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -47,6 +47,7 @@ function _register_functions() {
     _register_setup_function '_setup_dovecot_sieve'
     _register_setup_function '_setup_dovecot_dhparam'
     _register_setup_function '_setup_dovecot_quota'
+    _register_setup_function '_setup_spam_to_junk'
   fi
 
   case "${ACCOUNT_PROVISIONER}" in
@@ -80,7 +81,6 @@ function _register_functions() {
   _register_setup_function '_setup_policyd_spf'
 
   _register_setup_function '_setup_security_stack'
-  _register_setup_function '_setup_spam_to_junk'
   _register_setup_function '_setup_rspamd'
 
   _register_setup_function '_setup_ssl'


### PR DESCRIPTION
# Description

When running DMS with `SMTP_ONLY=1` and `MOVE_SPAM_TO_JUNK=1` (default), the following errors occur:

```
mailserver  | [   INF   ]  Welcome to docker-mailserver 12.1.0
mailserver  | [   INF   ]  Checking configuration
mailserver  | [   INF   ]  Configuring mail server
mailserver  | /usr/local/bin/setup.d/security/misc.sh: line 255: /usr/lib/dovecot/sieve-global/after/spam_to_junk.sieve: No such file or directory
mailserver  | error: script not found.
mailserver  | sievec: Fatal: failed to compile sieve script '/usr/lib/dovecot/sieve-global/after/spam_to_junk.sieve'
mailserver  | chown: cannot access '/usr/lib/dovecot/sieve-global/after/spam_to_junk.sieve': No such file or directory
mailserver  | chown: cannot access '/usr/lib/dovecot/sieve-global/after/spam_to_junk.svbin': No such file or directory
mailserver  | [ WARNING ]  !! INSECURE !! SSL configured with plain text access - DO NOT USE FOR PRODUCTION DEPLOYMENT
mailserver  | [   INF   ]  Starting daemons
mailserver  | [   INF   ]  mail.example.com is up and running
```

This PR provides a fix for that.

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
