### PR TITLE
Fix sieve setup

### DIFF
--- a/target/scripts/startup/setup.d/security/misc.sh
+++ b/target/scripts/startup/setup.d/security/misc.sh
@@ -252,6 +252,7 @@ function __setup__security__amavis() {
 function _setup_spam_to_junk() {
   if [[ ${MOVE_SPAM_TO_JUNK} -eq 1 ]]; then
     _log 'debug' 'Spam emails will be moved to the Junk folder'
+    mkdir -p /usr/lib/dovecot/sieve-global/after/
     cat >/usr/lib/dovecot/sieve-global/after/spam_to_junk.sieve << EOF
 require ["fileinto","mailbox"];
 


### PR DESCRIPTION
# Description

## Type of change

Bug fix

## Details

Without this one-line patch, version 1.2.0 gives me:

```
mailserver  | [   INF   ]  Welcome to docker-mailserver 12.1.0
mailserver  | [   INF   ]  Checking configuration
mailserver  | [   INF   ]  Configuring mail server
mailserver  | /usr/local/bin/setup.d/security/misc.sh: line 273: /usr/lib/dovecot/sieve-global/after/spam_to_junk.sieve: No such file or directory
mailserver  | error: script not found.
mailserver  | sievec: Fatal: failed to compile sieve script '/usr/lib/dovecot/sieve-global/after/spam_to_junk.sieve'
mailserver  | chown: cannot access '/usr/lib/dovecot/sieve-global/after/spam_to_junk.sieve': No such file or directory
mailserver  | chown: cannot access '/usr/lib/dovecot/sieve-global/after/spam_to_junk.svbin': No such file or directory
```

