### PR TITLE
chore: Discourage `latest` in bug report version field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: 🐋 DMS Version
       description: On which version (image tag) did you encounter this bug?
-      placeholder: v12.1.0
+      placeholder: v12.1.0 (do not put "latest")
     validations:
       required: true
   - type: input


### PR DESCRIPTION
# Description

Some users are reporting bugs with the `latest` tag instead of the actual DMS version, discourage this.
