### PR TITLE
rspamd: fix DKIM signing for inbound emails

### DIFF
--- a/target/bin/rspamd-dkim
+++ b/target/bin/rspamd-dkim
@@ -210,10 +210,11 @@ function _setup_default_signing_conf() {
 enabled = true;
 
 sign_authenticated = true;
-sign_local = true;
+sign_local = false;
+try_fallback = false;
 
 use_domain = "header";
-use_redis = false;   # don't change unless Redis also provides the DKIM keys
+use_redis = false; # don't change unless Redis also provides the DKIM keys
 use_esld = true;
 
 check_pubkey = true; # you want to use this in the beginning

--- a/target/rspamd/local.d/options.inc
+++ b/target/rspamd/local.d/options.inc
@@ -1,2 +1,3 @@
 pidfile = false;
 soft_reject_on_timeout = true;
+local_networks = "127.0.0.1/8, 10.0.0.0/8, 172.16.0.0/12";


### PR DESCRIPTION
# Description

See <https://github.com/docker-mailserver/docker-mailserver/issues/3433#issuecomment-1646532264>.

Inbound emails should not be signed by Rspamd. Moreover, messages delivered from local addresses should not be signed either for the reasons mentioned in the comment above.

CC @Codelica

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #3433

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
