### PR TITLE
rspamd: add 192.168.0.0/16 to local_networks

### DIFF
--- a/target/rspamd/local.d/options.inc
+++ b/target/rspamd/local.d/options.inc
@@ -1,3 +1,3 @@
 pidfile = false;
 soft_reject_on_timeout = true;
-local_networks = "127.0.0.1/8, 10.0.0.0/8, 172.16.0.0/12";
+local_networks = "127.0.0.1/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16";


### PR DESCRIPTION
# Description

following https://github.com/docker-mailserver/docker-mailserver/pull/3439

add missing 192.168.0.0/16 to local networks for rspamd.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Info @wt-io-it