### PR TITLE
Rspamd: local network addition and user name mismatch

### DIFF
--- a/target/bin/rspamd-dkim
+++ b/target/bin/rspamd-dkim
@@ -216,6 +216,7 @@ try_fallback = false;
 use_domain = "header";
 use_redis = false; # don't change unless Redis also provides the DKIM keys
 use_esld = true;
+allow_username_mismatch = true;
 
 check_pubkey = true; # you want to use this in the beginning
 

--- a/target/rspamd/local.d/options.inc
+++ b/target/rspamd/local.d/options.inc
@@ -1,3 +1,3 @@
 pidfile = false;
 soft_reject_on_timeout = true;
-local_networks = "127.0.0.1/8, 10.0.0.0/8, 172.16.0.0/12";
+local_networks = "127.0.0.1/8, 10.0.0.0/8, 172.16.0.0/12 192.168.0.0/16";


### PR DESCRIPTION
# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->
Follow up of #3439; includes changes of #3452. Added `192.168.0.0/16` to local networks and enabled `allow_username_mismatch` (see <https://github.com/docker-mailserver/docker-mailserver/issues/3433#issuecomment-1650613426>).

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #3454 #3433 (again)

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
