### PR TITLE
feat(setup): Add `fail2ban` sub-command `status <JAIL>`

### DIFF
--- a/docs/content/config/security/fail2ban.md
+++ b/docs/content/config/security/fail2ban.md
@@ -58,6 +58,12 @@ setup fail2ban
 
 the script will show all banned IP addresses.
 
+To get Fail2ban's more detailed `status` view, run
+
+```bash
+setup fail2ban status
+```
+
 ### Managing Bans
 
 You can manage F2B with the `setup` script. The usage looks like this:

--- a/docs/content/config/security/fail2ban.md
+++ b/docs/content/config/security/fail2ban.md
@@ -58,7 +58,7 @@ setup fail2ban
 
 the script will show all banned IP addresses.
 
-To get Fail2ban's more detailed `status` view, run
+To get a more detailed `status` view, run
 
 ```bash
 setup fail2ban status

--- a/target/bin/fail2ban
+++ b/target/bin/fail2ban
@@ -6,6 +6,7 @@ source /usr/local/bin/helpers/index.sh
 function __usage() {
   echo "Usage: ./setup.sh fail2ban [<ban|unban> <IP>]"
   echo "       ./setup.sh fail2ban log"
+  echo "       ./setup.sh fail2ban status"
 }
 
 fail2ban-client ping &>/dev/null || _exit_with_error "Fail2ban not running"
@@ -70,6 +71,13 @@ else
 
     ( 'log' )
       cat /var/log/mail/fail2ban.log
+      ;;
+
+    ( 'status' )
+      for JAIL in "${JAILS[@]}"; do
+        RESULT=$(fail2ban-client status "${JAIL}" 2>&1)
+        echo -e "$RESULT\n"
+      done
       ;;
 
     ( * )

--- a/target/bin/fail2ban
+++ b/target/bin/fail2ban
@@ -75,8 +75,7 @@ else
 
     ( 'status' )
       for JAIL in "${JAILS[@]}"; do
-        RESULT=$(fail2ban-client status "${JAIL}" 2>&1)
-        echo -e "$RESULT\n"
+        printf '%s\n\n' "$(fail2ban-client status "${JAIL}" 2>&1)"
       done
       ;;
 

--- a/target/bin/setup
+++ b/target/bin/setup
@@ -60,6 +60,7 @@ ${RED}[${ORANGE}SUB${RED}]${ORANGE}COMMANDS${RESET}
         setup fail2ban ${CYAN}ban${RESET} <IP>
         setup fail2ban ${CYAN}unban${RESET} <IP>
         setup fail2ban ${CYAN}log${RESET}
+        setup fail2ban ${CYAN}status${RESET}
 
     ${LBLUE}COMMAND${RESET} debug ${RED}:=${RESET}
         setup debug ${CYAN}fetchmail${RESET}


### PR DESCRIPTION
# Description

This PR adds a new option to the `setup.sh fail2ban` script to show a more detailed view on the status of all fail2ban jails using fail2ban's native `status <jail>` command. Effectively, the options just runs exactly that command for all jails already existing in the `JAILS` variable and outputs the result.
I wanted to have an option between just running the setup `fail2ban` sub-command without options that just returns the banned IPs and getting all details using `setup fail2ban log`. 
This might be a bit redundant to other options, but since it is a small change that breaks nothing, I figured I could move it back here, since its usage is probably very intuitive to any fail2ban user.

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [X] If necessary I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
