### PR TITLE
Add support for extracting certs from Caddy v2 data

### DIFF
--- a/docs/content/config/security/ssl.md
+++ b/docs/content/config/security/ssl.md
@@ -501,7 +501,7 @@ services:
       caddy.local_certs: # Remove this label when going to production
 
   dms:
-    image: registry.nuiton.org/codelutin/admsys/swarm-stack/docker-mailserver:with_caddy_support
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest
     hostname: mail.example.com
     ports:
       - "25:25"
@@ -509,6 +509,7 @@ services:
       - caddy_data:/caddy_data
     environment:
       SSL_TYPE: letsencrypt
+      SSL_DOMAIN: mail.example.com # Ensure this is exactly the same as the domain you pass to Caddy
       LOG_LEVEL: trace
     labels:
       caddy_0: mail.example.com


### PR DESCRIPTION
# Description

This PR adds support for  extracting certificates from Caddy v2 data, as this is already supported for Traefik's `acme.json`. 
## Type of change

<!-- Delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
