### PR TITLE
Docs: Drop mention of port 25 support for authenticated submission

### DIFF
--- a/docs/content/config/security/understanding-the-ports.md
+++ b/docs/content/config/security/understanding-the-ports.md
@@ -16,7 +16,7 @@ Prefer ports with Implicit [TLS][wikipedia-tls] ports, they're more secure than 
 | IMAP4                    | 143                      | 993             | Retrieval            | Yes                |
 
 1. A connection _may_ be secured over TLS when both ends support `STARTTLS`. On ports 110, 143 and 587, DMS will reject a connection that cannot be secured. Port 25 is [required][ref-port25-mandatory] to support insecure connections.
-2. Receives email, DMS additionally filters for spam and viruses. For submitting email to the server to be sent to third-parties, you should prefer the _submission_ ports (465, 587) - which require authentication. Unless a relay host is configured (eg: SendGrid), outgoing email will leave the server via port 25 (_thus outbound traffic must not be blocked by your provider or firewall_).
+2. Receives email, DMS additionally filters for spam and viruses. For submitting email to the server to be sent to third-parties, you need to use the _submission_ ports (465, 587) - which require authentication. Unless a relay host is configured (eg: SendGrid), outgoing email will leave the server via port 25 (_thus outbound traffic must not be blocked by your provider or firewall_).
 3. A _submission_ port since 2018 ([RFC 8314][rfc-8314]).
 
 ??? warning "Beware of outdated advice on port 465"

--- a/docs/content/config/security/understanding-the-ports.md
+++ b/docs/content/config/security/understanding-the-ports.md
@@ -16,7 +16,7 @@ Prefer ports with Implicit [TLS][wikipedia-tls] ports, they're more secure than 
 | IMAP4                    | 143                      | 993             | Retrieval            | Yes                |
 
 1. A connection _may_ be secured over TLS when both ends support `STARTTLS`. On ports 110, 143 and 587, DMS will reject a connection that cannot be secured. Port 25 is [required][ref-port25-mandatory] to support insecure connections.
-2. Receives email, DMS additionally filters for spam and viruses. For submitting email to the server to be sent to third-parties, you need to use the _submission_ ports (465, 587) - which require authentication. Unless a relay host is configured (eg: SendGrid), outgoing email will leave the server via port 25 (_thus outbound traffic must not be blocked by your provider or firewall_).
+2. Receives email, DMS additionally filters for spam and viruses. For submitting email to the server to be sent to third-parties, you should prefer the _submission_ ports (465, 587) - which require authentication. Unless a relay host is configured (eg: SendGrid), outgoing email will leave the server via port 25 (_thus outbound traffic must not be blocked by your provider or firewall_).
 3. A _submission_ port since 2018 ([RFC 8314][rfc-8314]).
 
 ??? warning "Beware of outdated advice on port 465"

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -143,7 +143,7 @@ imap port:          143 or 993 with STARTTLS/SSL (recommended)
 imap path prefix:   INBOX
 
 # SMTP
-smtp port:          25 or 587/465 with STARTTLS/SSL (recommended)
+smtp port:          587 or 465 with STARTTLS/SSL (recommended)
 username:           <user1@example.com>
 password:           <mypassword>
 ```


### PR DESCRIPTION
# Description

In the same spirit as #3464, this PR fixes a documentation issue (in the FAQ page, and in "Understanding the Ports"), about using port 25 for mail clients, which is unsupported since #3006.

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
