### PR TITLE
ci: `question.yml` - Clarify that the issue tracker is not for personal support

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,18 +1,10 @@
 name: Other
-description: Miscellaneous questions and reports
+description: Miscellaneous questions and reports for the project (not support)
 title: 'other: '
 labels:
   - meta/help wanted
 
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Markdown formatting can be used in almost all text fields. The description will tell you if this is not the case for a specific field.
-
-        Be as precise as possible, and if in doubt, it's best to add more information that too few.
-
-        ---
   - type: dropdown
     id: subject
     attributes:
@@ -21,8 +13,7 @@ body:
         - I would like to contribute to the project
         - I would like to configure a not documented mail server use case
         - I would like some feedback concerning a use case
-        - I have questions about TLS/SSL/STARTTLS/OpenSSL
-        - Other
+        - Something else that requires developers attention
     validations:
       required: true
   - type: textarea
@@ -31,3 +22,9 @@ body:
       label: Description
     validations:
       required: true
+    value: |
+      <!---
+      Please do not use this form to bypass doing a proper bug report.
+      The issue is tracker is anything relevant to the project itself, not individual support queries.
+      If you don't want to fill out a bug report, please ask support questions at our community discussions page: https://github.com/orgs/docker-mailserver/discussions
+      -->

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -25,6 +25,6 @@ body:
     value: |
       <!---
       Please do not use this form to bypass doing a proper bug report.
-      The issue is tracker is anything relevant to the project itself, not individual support queries.
+      The issue tracker is for anything relevant to the project itself, not individual support queries.
       If you don't want to fill out a bug report, please ask support questions at our community discussions page: https://github.com/orgs/docker-mailserver/discussions
       -->


### PR DESCRIPTION
# Description

Recently there has been low effort reports (_bypassing the dedicated form_) through this alternative free-form field, which is intended for addressing other concerns related to the project - **not troubleshooting user problems**.

When a user does not want to put the effort in of a full bug report (_and following our debug docs tips that it refers them to_), they should be using the Github Discussions page which provides the same free-form input, but should not require attention of project devs (contributors / maintainers).

---

The markdown rendered field above the "Description" input field didn't seem too relevant for this template. I've opted for a markdown comment (so it won't render if kept) into the input field with hopes that'll be more visible to the readers attention.

I'm usually more lenient with this kind of thing, but I'd still like to discourage it, especially when it's from enabling non-default features for the sake of it without sharing any notion of efforts made to troubleshoot with the information available to them without raising a bug report.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)
