### PR TITLE
ci: Fix `question.yml` template - `value` should be an attribute

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -18,13 +18,13 @@ body:
       required: true
   - type: textarea
     id: description
-    attributes:
-      label: Description
     validations:
       required: true
-    value: |
-      <!---
-      Please do not use this form to bypass doing a proper bug report.
-      The issue tracker is for anything relevant to the project itself, not individual support queries.
-      If you don't want to fill out a bug report, please ask support questions at our community discussions page: https://github.com/orgs/docker-mailserver/discussions
-      -->
+    attributes:
+      label: Description
+      value: |
+        <!---
+        Please do not use this form to bypass doing a proper bug report.
+        The issue tracker is for anything relevant to the project itself, not individual support queries.
+        If you don't want to fill out a bug report, please ask support questions at our community discussions page: https://github.com/orgs/docker-mailserver/discussions
+        -->


### PR DESCRIPTION
# Description

The [recent change to this template](https://github.com/docker-mailserver/docker-mailserver/pull/3498) was invalid, as `value` should have been nested under the `attributes` object.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
