### PR TITLE
 scripts: add wrapper to update Postfix configuration safely (follow up)

### DIFF
--- a/target/scripts/helpers/postfix.sh
+++ b/target/scripts/helpers/postfix.sh
@@ -92,7 +92,7 @@ function _vhost_ldap_support() {
 # /etc/aliases is handled by `alias.sh` and uses `postalias` to update the Postfix alias database. No need for `postmap`.
 # http://www.postfix.org/postalias.1.html
 
-# Add an key with an value to Postfix's main configuration file
+# Add a key with a value to Postfix's main configuration file
 # or update an existing key. An already existing key can be updated
 # by either appending to the existing value (default) or by prepending.
 #

--- a/target/scripts/helpers/postfix.sh
+++ b/target/scripts/helpers/postfix.sh
@@ -114,10 +114,10 @@ function _add_to_or_update_postfix_main() {
 
     case "${ACTION}" in
       ('append')
-        SED_STRING="/${NEW_VALUE}/! s|^(${KEY}\s*=.*)|\1 ${NEW_VALUE}|g"
+        SED_STRING="/^${KEY}\s*=.*${NEW_VALUE}/! s|^(${KEY}\s*=.*)|\1 ${NEW_VALUE}|g"
         ;;
       ('prepend')
-        SED_STRING="/${NEW_VALUE}/! s|^(${KEY})\s*=\s*(.*)|\1 = ${NEW_VALUE} \2|g"
+        SED_STRING="/^${KEY}\s*=.*${NEW_VALUE}/! s|^(${KEY})\s*=\s*(.*)|\1 = ${NEW_VALUE} \2|g"
         ;;
       (*)
         _log 'error' "Action '${3}' in _add_to_or_update_postfix_main is unknown"

--- a/target/scripts/helpers/postfix.sh
+++ b/target/scripts/helpers/postfix.sh
@@ -98,7 +98,7 @@ function _vhost_ldap_support() {
 #
 # @param ${1} = key name in Postfix's main configuration file
 # @param ${2} = new value (appended or prepended)
-# @param ${3} = "append" (default) or "prepend" [OPTIONAL]
+# @param ${3} = action "append" (default) or "prepend" [OPTIONAL]
 function _add_to_or_update_postfix_main() {
   local KEY=${1:?Key name is required}
   local NEW_VALUE=${2:?New value is required}

--- a/target/scripts/helpers/postfix.sh
+++ b/target/scripts/helpers/postfix.sh
@@ -105,9 +105,8 @@ function _add_to_or_update_postfix_main() {
   local ACTION=${3:-append}
   local CURRENT_VALUE
 
-  _adjust_mtime_for_postfix_maincf
-
   # Get current value from /etc/postfix/main.cf
+  _adjust_mtime_for_postfix_maincf
   CURRENT_VALUE=$(postconf -h "${KEY}" 2>/dev/null)
 
   # If key does not exist or value is empty, add it - otherwise update with ACTION:

--- a/target/scripts/helpers/postfix.sh
+++ b/target/scripts/helpers/postfix.sh
@@ -114,7 +114,7 @@ function _add_to_or_update_postfix_main() {
     postconf "${KEY} = ${NEW_VALUE}"
   else
     # If $NEW_VALUE is already present --> nothing to do, skip.
-    if grep -qF " ${NEW_VALUE} " <<<" ${CURRENT_VALUE} "; then
+    if [[ " ${CURRENT_VALUE} " == *" ${NEW_VALUE} "* ]]; then
       return 0
     fi
 

--- a/target/scripts/helpers/postfix.sh
+++ b/target/scripts/helpers/postfix.sh
@@ -105,7 +105,7 @@ function _add_to_or_update_postfix_main() {
   local ACTION=${3:-append}
 
   # If entry does not exist, add it - otherwise update with ACTION:
-  if ! grep -q -E "^${KEY}\s+=" /etc/postfix/main.cf; then
+  if ! grep -q -E "^${KEY}\s*=" /etc/postfix/main.cf; then
     postconf "${KEY} = ${NEW_VALUE}"
   else
     KEY=$(_escape_for_sed "${KEY}")

--- a/target/scripts/helpers/postfix.sh
+++ b/target/scripts/helpers/postfix.sh
@@ -105,6 +105,8 @@ function _add_to_or_update_postfix_main() {
   local ACTION=${3:-append}
   local CURRENT_VALUE
 
+  _adjust_mtime_for_postfix_maincf
+
   # Get current value from /etc/postfix/main.cf
   CURRENT_VALUE=$(postconf -h "${KEY}" 2>/dev/null)
 

--- a/target/scripts/helpers/postfix.sh
+++ b/target/scripts/helpers/postfix.sh
@@ -113,7 +113,7 @@ function _add_to_or_update_postfix_main() {
     postconf "${KEY} = ${NEW_VALUE}"
   else
     # If $NEW_VALUE is already present --> nothing to do, skip.
-    if grep -qF " ${NEW_VALUE} " <<<" {$CURRENT_VALUE} "; then
+    if grep -qF " ${NEW_VALUE} " <<<" ${CURRENT_VALUE} "; then
       return 0
     fi
 

--- a/target/scripts/helpers/postfix.sh
+++ b/target/scripts/helpers/postfix.sh
@@ -114,10 +114,10 @@ function _add_to_or_update_postfix_main() {
 
     case "${ACTION}" in
       ('append')
-        SED_STRING="/${NEW_VALUE}/! s|^(${KEY} *=.*)|\1 ${NEW_VALUE}|g"
+        SED_STRING="/${NEW_VALUE}/! s|^(${KEY}\s*=.*)|\1 ${NEW_VALUE}|g"
         ;;
       ('prepend')
-        SED_STRING="/${NEW_VALUE}/! s|^(${KEY}) *= *(.*)|\1 = ${NEW_VALUE} \2|g"
+        SED_STRING="/${NEW_VALUE}/! s|^(${KEY})\s*=\s*(.*)|\1 = ${NEW_VALUE} \2|g"
         ;;
       (*)
         _log 'error' "Action '${3}' in _add_to_or_update_postfix_main is unknown"

--- a/target/scripts/helpers/postfix.sh
+++ b/target/scripts/helpers/postfix.sh
@@ -105,10 +105,10 @@ function _add_to_or_update_postfix_main() {
   local ACTION=${3:-append}
   local CURRENT_VALUE
 
-  # Get current value if present
+  # Get current value from /etc/postfix/main.cf
   CURRENT_VALUE=$(postconf -h "${KEY}" 2>/dev/null)
 
-  # If entry does not exist, add it - otherwise update with ACTION:
+  # If key does not exist or value is empty, add it - otherwise update with ACTION:
   if [[ -z ${CURRENT_VALUE} ]]; then
     postconf "${KEY} = ${NEW_VALUE}"
   else

--- a/target/scripts/helpers/postfix.sh
+++ b/target/scripts/helpers/postfix.sh
@@ -105,7 +105,7 @@ function _add_to_or_update_postfix_main() {
   local ACTION=${3:-append}
 
   # If entry does not exist, add it - otherwise update with ACTION:
-  if ! grep -q -E "^${KEY}" /etc/postfix/main.cf; then
+  if ! grep -q -E "^${KEY}\s+=" /etc/postfix/main.cf; then
     postconf "${KEY} = ${NEW_VALUE}"
   else
     KEY=$(_escape_for_sed "${KEY}")

--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -4,6 +4,7 @@ function _escape() {
   echo "${1//./\\.}"
 }
 
+# TODO: Not in use currently. Maybe in the future: https://github.com/docker-mailserver/docker-mailserver/pull/3484/files#r1299410851
 # Replaces a string so that it can be used inside
 # `sed` safely.
 #


### PR DESCRIPTION
# Description

While working on improving the function `_add_to_or_update_postfix_main()`, I noticed a problem we had before in other occasions.

`SED_STRING="/${NEW_VALUE}/!`

This is not really fail safe, when `$NEW_VALUE` is a substring of an existing value.

Now I simplified the whole function, by replacing `sed` with `postconf`.

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #3484

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
