### PR TITLE
tests: TLS cipher suites - Update `testssl.sh` tag to `3.2`

### DIFF
--- a/test/tests/parallel/set2/tls_cipherlists.bats
+++ b/test/tests/parallel/set2/tls_cipherlists.bats
@@ -25,7 +25,7 @@ function setup_file() {
 
   # Pull `testssl.sh` image in advance to avoid it interfering with the `run` captured output.
   # Only interferes (potential test failure) with `assert_output` not `assert_success`?
-  docker pull drwetter/testssl.sh:3.1dev
+  docker pull drwetter/testssl.sh:3.2
 
   # Only used in `_should_support_expected_cipherlists()` to set a storage location for `testssl.sh` JSON output:
   # `${BATS_TMPDIR}` maps to `/tmp`: https://bats-core.readthedocs.io/en/v1.8.2/writing-tests.html#special-variables
@@ -166,7 +166,7 @@ function _collect_cipherlists() {
     --volume "${TLS_CONFIG_VOLUME}" \
     --volume "${RESULTS_PATH}:/output" \
     --workdir "/output" \
-    drwetter/testssl.sh:3.1dev "${TESTSSL_CMD[@]}"
+    drwetter/testssl.sh:3.2 "${TESTSSL_CMD[@]}"
 
   assert_success
 }


### PR DESCRIPTION
# Description

`3.1dev` branch has been [renamed to `3.2`](https://github.com/drwetter/testssl.sh/issues/2376). DockerHub has the [`3.2` tag published](https://hub.docker.com/r/drwetter/testssl.sh/tags).

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
