### PR TITLE
tests: LDAP - Improvements to LDIF test data

### DIFF
--- a/test/config/ldap/docker-openldap/bootstrap/ldif/01_mail-tree.ldif
+++ b/test/config/ldap/docker-openldap/bootstrap/ldif/01_mail-tree.ldif
@@ -1,11 +1,16 @@
-# The root object, all entries will branch off this one:
-dn: dc=localhost,dc=localdomain
+# The root object of the tree, all entries will branch off this one:
+dn: dc=example,dc=test
+# DN is formed from `example.test` DNS labels:
+# NOTE: This is just a common convention (not dependent on hostname or any external config)
 objectClass: dcObject
+# Must reference left most component:
+dc: example
+# It's required to use an `objectClass` that implements a "Structural Class":
 objectClass: organization
-dc: localhost
+# Value is purely descriptive, not important to tests:
 o: DMS Test
 
 # User accounts will belong to this subtree:
-dn: ou=people,dc=localhost,dc=localdomain
+dn: ou=users,dc=example,dc=test
 objectClass: organizationalUnit
-ou: people
+ou: users

--- a/test/config/ldap/docker-openldap/bootstrap/ldif/02_user-email.ldif
+++ b/test/config/ldap/docker-openldap/bootstrap/ldif/02_user-email.ldif
@@ -1,12 +1,11 @@
 # NOTE: A standard user account to test against
-dn: uniqueIdentifier=some.user,ou=people,dc=localhost,dc=localdomain
-objectClass: organizationalPerson
+dn: uid=some.user,ou=users,dc=example,dc=test
+objectClass: inetOrgPerson
 objectClass: PostfixBookMailAccount
-objectClass: extensibleObject
 cn: Some User
 givenName: Some
 surname: User
-uniqueIdentifier: some.user
+userID: some.user
 # Password is: secret
 userPassword: {SSHA}eLtqGpid+hkSVhxvsdTPztv4uapRofGx
 mail: some.user@localhost.localdomain

--- a/test/config/ldap/docker-openldap/bootstrap/ldif/03_user-email-other-primary-domain.ldif
+++ b/test/config/ldap/docker-openldap/bootstrap/ldif/03_user-email-other-primary-domain.ldif
@@ -1,13 +1,12 @@
 # NOTE: This user differs via the domain-part of their mail address
 # They also have their mail directory attributes using the primary domain, not their domain-part
-dn: uniqueIdentifier=some.other.user,ou=people,dc=localhost,dc=localdomain
-objectClass: organizationalPerson
+dn: uid=some.other.user,ou=users,dc=example,dc=test
+objectClass: inetOrgPerson
 objectClass: PostfixBookMailAccount
-objectClass: extensibleObject
 cn: Some Other User
 givenName: Some
 surname: Other User
-uniqueIdentifier: some.other.user
+userID: some.other.user
 # Password is: secret
 userPassword: {SSHA}eLtqGpid+hkSVhxvsdTPztv4uapRofGx
 mail: some.other.user@localhost.otherdomain

--- a/test/config/ldap/docker-openldap/bootstrap/ldif/04_user-email-different-uid.ldif
+++ b/test/config/ldap/docker-openldap/bootstrap/ldif/04_user-email-different-uid.ldif
@@ -1,13 +1,12 @@
 # NOTE: This user differs by local-part of mail address not matching their uniqueIdentifier attribute
 # They also do not have any alias or groups configured
-dn: uniqueIdentifier=some.user.id,ou=people,dc=localhost,dc=localdomain
-objectClass: organizationalPerson
+dn: uid=some.user.id,ou=users,dc=example,dc=test
+objectClass: inetOrgPerson
 objectClass: PostfixBookMailAccount
-objectClass: extensibleObject
 cn: Some User
 givenName: Some
 surname: User
-uniqueIdentifier: some.user.id
+userID: some.user.id
 # Password is: secret
 userPassword: {SSHA}eLtqGpid+hkSVhxvsdTPztv4uapRofGx
 mail: some.user.email@localhost.localdomain


### PR DESCRIPTION
# Description

Another iterative change for LDAP test.

I could stage these out in a multi-commit PR but I'm choosing to preserve some change history and provide smaller diff for review, before introducing a change for v13 (_outside of the tests, but will also affect this LDAP test going forward_).

No change to DMS beyond the LDAP test and it's test data.

---

### Changes:

- The `uniqueIdentifier` attribute is not appropriate and was relying on `objectClass: extensibleObject` as a workaround to allow it. A more appropriate attribute to use instead is `userID` (_short name: `uid`_).
- Removing `extensibleObject` now requires switching the user accounts to use `inetOrgPerson` class (_which inherits from `organizationalPerson`_). which allows the attributes `givenName`, `userID` and `mail` (_also provided via the `PostfixBookMailAccount` class_).
- The LDAP root object now uses `dc` attributes for `example.test` instead of `localhost.localdomain`. This has nothing to do with DMS or LDAP containers networking config, nor the users mail addresses.
- Users are now grouped under the organizational unit of `users` instead of `people`. Purely a naming change out of preference, no functional difference.

The LDAP test ENV has been updated to accommodate the above changes. An additional ENV override was required for SASLAuthd to switch an attribute set for `ldap_filter` in `/etc/saslauthd.conf` from the implicit default of `uniqueIdentifier` (_that we [set during startup as an ENV default](https://github.com/docker-mailserver/docker-mailserver/blob/43a122fe18abec5d7607e9659a890780930bb1ce/target/scripts/startup/variables-stack.sh#L169) for fallback_) to the `userID` attribute.

**Relevant history:**
- `uniqueIdentifier` was introduce into DMS via the original LDAP support PR #352 but lacks information on the choice (_that PR was another attempt building off from the work in_ #335 ). There is no mention of this attribute in LDAP docs for SASLAuthd, Dovecot, or Postfix.
- The change to using `userID` as part of the LDAP DN for users and thus the lookup query filters may have a slight impact on test-cases for LDAP spoofing (`SPOOF_PROTECTION=1`), as the `ldap-senders.cf` file (_contributed by_ #1902 ) has a `result_attribute` value of `mail, uid`, returning the `userID` attribute which now exists in the LDIF test data. However, those test cases need some rework anyway 😅 

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
