### PR TITLE
chore: Adapt `ENABLE_LDAP=1` to `ACCOUNT_PROVISIONER=LDAP`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. The format 
 
 > **Note**: Changes and additions listed here are contained in the `:edge` image tag. These changes may not be as stable as released changes.
 
+### Breaking
+
+- The environment variable `ENABLE_LDAP=1` has been changed to `ACCOUNT_PROVISIONER=LDAP`.
+
 ### Added
 
 - New environment variable `MARK_SPAM_AS_READ`. When set to `1`, marks incoming junk as "read" to avoid unwanted notification of junk as new mail ([#3489](https://github.com/docker-mailserver/docker-mailserver/pull/3489))
@@ -210,7 +214,11 @@ Notable changes are:
 
 ### Summary
 
-This release features a lot of small and medium-sized changes, many related to how the image is build and tested during CI. The build now requires Docker Buildkit as the ClamAV Signatures are added via `COPY --link ...` during build-time. Moreover, the build is now multi-stage. `ENABLE_LDAP` is now deprecated.
+This release features a lot of small and medium-sized changes, many related to how the image is build and tested during CI. The build now multi-stage based and requires Docker Buildkit, as the ClamAV Signatures are added via `COPY --link ...` during build-time.
+
+### Deprecated
+
+- The environment variable `ENABLE_LDAP` is deprecated and will be removed in [13.0.0]. Use `ACCOUNT_PROVISIONER=LDAP` now.
 
 ### Added
 
@@ -236,10 +244,6 @@ This release features a lot of small and medium-sized changes, many related to h
 - **scripts**: improve `helpers/log.sh`
 - **build**: adjust build arguments
 - **build**: enhance build process
-
-### Deprecated
-
-- The environment variable `ENABLE_LDAP` is deprecated and will be removed in [13.0.0]. Use `ACCOUNT_PROVISIONER=LDAP` now.
 
 ### Removed
 

--- a/docs/content/config/advanced/auth-ldap.md
+++ b/docs/content/config/advanced/auth-ldap.md
@@ -34,7 +34,6 @@ Those variables contain the LDAP lookup filters for postfix, using `%s` as the p
     A really simple `LDAP_QUERY_FILTER` configuration, using only the _user filter_ and allowing only `admin@*` to spoof any sender addresses.
 
     ```yaml
-    - ENABLE_LDAP=1 # with the :edge tag, use ACCOUNT_PROVISIONER
     - LDAP_START_TLS=yes
     - ACCOUNT_PROVISIONER=LDAP
     - LDAP_SERVER_HOST=ldap.example.org
@@ -215,7 +214,6 @@ The changes on the configurations necessary to work with Active Directory (**onl
           - ENABLE_POSTGREY=1
 
           # >>> Postfix LDAP Integration
-          - ENABLE_LDAP=1 # with the :edge tag, use ACCOUNT_PROVISIONER
           - ACCOUNT_PROVISIONER=LDAP
           - LDAP_SERVER_HOST=ldap.example.org
           - LDAP_BIND_DN=cn=admin,ou=users,dc=example,dc=org
@@ -284,7 +282,6 @@ The changes on the configurations necessary to work with Active Directory (**onl
           # <<< SASL Authentication
 
           # >>> Postfix Ldap Integration
-          - ENABLE_LDAP=1 # with the :edge tag, use ACCOUNT_PROVISIONER
           - ACCOUNT_PROVISIONER=LDAP
           - LDAP_SERVER_HOST=<yourLdapContainer/yourLdapServer>
           - LDAP_SEARCH_BASE=dc=mydomain,dc=loc

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -49,7 +49,7 @@ User provisioning via OIDC is planned for the future, see [this tracking issue](
 - OIDC => use OIDC authentication (**not yet implemented**)
 - FILE => use local files (this is used as the default)
 
-A second container for the ldap service is necessary (e.g. [docker-openldap](https://github.com/osixia/docker-openldap))
+A second container for the ldap service is necessary (e.g. [`bitnami/openldap`](https://hub.docker.com/r/bitnami/openldap/)).
 
 ##### PERMIT_DOCKER
 
@@ -584,9 +584,7 @@ Enable or disable `getmail`.
 
 #### LDAP
 
-##### ENABLE_LDAP
 
-Deprecated. See [`ACCOUNT_PROVISIONER`](#account_provisioner).
 
 ##### LDAP_START_TLS
 

--- a/docs/content/examples/use-cases/forward-only-mailserver-with-ldap-authentication.md
+++ b/docs/content/examples/use-cases/forward-only-mailserver-with-ldap-authentication.md
@@ -30,7 +30,6 @@ We can create aliases with `./setup.sh`, like this:
 If you want to send emails from outside the mail server you have to authenticate somehow (with a username and password). One way of doing it is described in [this discussion][github-issue-1247]. However if there are many user accounts, it is better to use authentication with LDAP. The settings for this on `mailserver.env` are:
 
 ```env
-ENABLE_LDAP=1 # with the :edge tag, use ACCOUNT_PROVISIONER
 ACCOUNT_PROVISIONER=LDAP
 LDAP_START_TLS=yes
 LDAP_SERVER_HOST=ldap.example.org

--- a/mailserver.env
+++ b/mailserver.env
@@ -405,12 +405,7 @@ GETMAIL_POLL=5
 # --- LDAP Section ------------------------------
 # -----------------------------------------------
 
-# A second container for the ldap service is necessary (i.e. https://github.com/osixia/docker-openldap)
-
-# with the :edge tag, use ACCOUNT_PROVISIONER=LDAP
-# empty => LDAP authentication is disabled
-# 1 => LDAP authentication is enabled
-ENABLE_LDAP=
+# A second container for the ldap service is necessary (i.e. https://hub.docker.com/r/bitnami/openldap/)
 
 # empty => no
 # yes => LDAP over TLS enabled for Postfix

--- a/target/scripts/startup/variables-stack.sh
+++ b/target/scripts/startup/variables-stack.sh
@@ -14,8 +14,7 @@ function _early_variables_setup() {
 # completely with a single version.
 function __environment_variables_backwards_compatibility() {
   if [[ ${ENABLE_LDAP:-0} -eq 1 ]]; then
-    _log 'warn' "'ENABLE_LDAP=1' is deprecated (and will be removed in v13.0.0) => use 'ACCOUNT_PROVISIONER=LDAP' instead"
-    ACCOUNT_PROVISIONER='LDAP'
+    _log 'error' "'ENABLE_LDAP=1' has been changed to 'ACCOUNT_PROVISIONER=LDAP' since DMS v13"
   fi
 
   # TODO this can be uncommented in a PR handling the HOSTNAME/DOMAINNAME issue


### PR DESCRIPTION
# Description

Before we forget and release v13 😅 

- Deprecation startup script check is kept for `ENABLE_LDAP=1` but adjusted to emit an error instead. It can be dropped in a future release. Just a precaution for those who mistakenly update (_possibly via automation_) without checking the release notes, an error log is somewhat helpful, although it could alternatively panic?
- Docs updated to remove the `ENABLE_LDAP=1` usage
- ENV docs updated to reference a maintained LDAP image.
- Changelog includes the breaking change, and slight revision to prior release mention of deprecation.
