### PR TITLE
chore: Change `setup config dkim` default key size to `2048` (`open-dkim`)

### DIFF
--- a/docs/content/config/best-practices/dkim_dmarc_spf.md
+++ b/docs/content/config/best-practices/dkim_dmarc_spf.md
@@ -40,6 +40,22 @@ You should have:
 - At least one [email account setup][docs-accounts-add]
 - Attached a [volume for config][docs-volumes-config] to persist the generated files to local storage
 
+!!! example "Creating DKIM Keys"
+
+    DKIM keys can be generated with good defaults by running:
+
+    ```bash
+    docker exec -it <CONTAINER NAME> setup config dkim
+    ```
+
+    If you need to generate your keys with different settings, check the `help` output for supported config options and examples:
+
+    ```bash
+    docker exec -it <CONTAINER NAME> setup config dkim help
+    ```
+
+    As described by the help output, you may need to use the `domain` option explicitly when you're using LDAP or Rspamd.
+
 !!! warning "RSA Key Sizes >= 4096 Bit"
 
     According to [RFC 8301][rfc-8301], keys are preferably between 1024 and 2048 bits. Keys of size 4096-bit or larger may not be compatible to all systems your mail is intended for.
@@ -52,17 +68,7 @@ DKIM is currently supported by either OpenDKIM or Rspamd:
 
     OpenDKIM is currently [enabled by default][docs-env-opendkim].
 
-    The command `docker exec <CONTAINER NAME> setup config dkim help` will provide details of supported config options, along with some examples.
-
-    !!! example "Creating a DKIM key"
-
-        Generate the DKIM files with:
-
-        ```sh
-        docker exec -it <CONTAINER NAME> setup config dkim
-        ```
-
-        Your new DKIM key(s) and OpenDKIM config files have been added to `/tmp/docker-mailserver/opendkim/`.
+    Your new DKIM key(s) and OpenDKIM config files have been added to `/tmp/docker-mailserver/opendkim/`.
 
     ??? note "LDAP accounts need to specify mail domains explicitly"
 
@@ -98,22 +104,6 @@ DKIM is currently supported by either OpenDKIM or Rspamd:
 
     1. [Verifying DKIM signatures from inbound mail][rspamd-docs-dkim-checks] is enabled by default.
     2. [Signing outbound mail with your DKIM key][rspamd-docs-dkim-signing] needs additional setup (key + dns + config).
-
-    !!! example "Creating DKIM Keys"
-
-        You can simply run
-
-        ```bash
-        docker exec -it <CONTAINER NAME> setup config dkim help
-        ```
-
-        which provides you with an overview of what the script can do. Just running
-
-        ```bash
-        docker exec -it <CONTAINER NAME> setup config dkim
-        ```
-
-        will execute the helper script with default parameters.
 
     ??? warning "Using Multiple Domains"
 

--- a/docs/content/config/best-practices/dkim_dmarc_spf.md
+++ b/docs/content/config/best-practices/dkim_dmarc_spf.md
@@ -42,7 +42,7 @@ You should have:
 
 !!! warning "RSA Key Sizes >= 4096 Bit"
 
-    Keys of 4096 bits could be denied by some mail servers. According to [RFC 6376][rfc-6376], keys are [preferably between 512 and 2048 bits][github-issue-dkimlength].
+    Keys of size 4096-bit could be denied by some mail servers. According to [RFC 6376][rfc-6376], keys are [preferably between 512 and 2048 bits][github-issue-dkimlength] (_**NOTE:** 512-bit is considered insecure_).
 
 DKIM is currently supported by either OpenDKIM or Rspamd:
 
@@ -50,14 +50,14 @@ DKIM is currently supported by either OpenDKIM or Rspamd:
 
     OpenDKIM is currently [enabled by default][docs-env-opendkim].
 
-    The command `docker exec <CONTAINER NAME> setup config dkim help` details supported config options, along with some examples.
+    The command `docker exec <CONTAINER NAME> setup config dkim help` will provide details of supported config options, along with some examples.
 
     !!! example "Creating a DKIM key"
 
         Generate the DKIM files with:
 
         ```sh
-        docker exec -ti <CONTAINER NAME> setup config dkim
+        docker exec -it <CONTAINER NAME> setup config dkim
         ```
 
         Your new DKIM key(s) and OpenDKIM config files have been added to `/tmp/docker-mailserver/opendkim/`.
@@ -67,22 +67,24 @@ DKIM is currently supported by either OpenDKIM or Rspamd:
         The command is unable to infer the domains from LDAP user accounts, you must specify them:
 
         ```sh
-        setup config dkim domain 'example.com,example.io'
+        setup config dkim domain 'example.com,another-example.com'
         ```
 
-    ??? tip "Changing the key size"
+    ??? info "Changing the key size"
 
-        The private key presently defaults to RSA-4096. To create an RSA 2048-bit key run:
+        The keypair generated for using with DKIM presently defaults to RSA-2048. This is a good size but you can lower the security to `1024-bit`, or increase it to `4096-bit` (_discouraged as that is excessive_).
+        
+        To generate a key with different size (_for RSA 1024-bit_) run:
 
         ```sh
-        setup config dkim keysize 2048
+        setup config dkim keysize 1024
         ```
 
     !!! info "Restart required"
 
         After restarting DMS, outgoing mail will now be signed with your new DKIM key(s) :tada:
 
-        You'll need to repeat this process if you add any new domains.
+        **NOTE:** You'll need to repeat this process if you add any new domains.
 
 === "Rspamd"
 
@@ -98,20 +100,22 @@ DKIM is currently supported by either OpenDKIM or Rspamd:
         You can simply run
 
         ```bash
-        docker exec -ti <CONTAINER NAME> setup config dkim help
+        docker exec -it <CONTAINER NAME> setup config dkim help
         ```
 
         which provides you with an overview of what the script can do. Just running
 
         ```bash
-        docker exec -ti <CONTAINER NAME> setup config dkim
+        docker exec -it <CONTAINER NAME> setup config dkim
         ```
 
         will execute the helper script with default parameters.
 
     ??? warning "Using Multiple Domains"
 
-        Unlike the current script for OpenDKIM, the Rspamd script will **not** create keys for all domains DMS is managing, but only for the one it assumes to be the main domain (derived from DMS' domain name). Moreover, the default `dkim_signing.conf` configuration file that DMS ships will also only contain one domain. If you have multiple domains, you need to run the command `docker exec -ti <CONTAINER NAME> setup config dkim domain <DOMAIN>` multiple times to create all the keys for all domains, and then provide a custom `dkim_signing.conf` (for which an example is shown below).
+        Unlike the current script for OpenDKIM, the Rspamd script will **not** create keys for all domains DMS is managing, but only for the one it assumes to be the main domain (_derived from the FQDN assigned to DMS, minus any subdomain_). Moreover, the default `dkim_signing.conf` configuration file that DMS ships will also only contain one domain.
+
+        If you have multiple domains, you need to run the command `docker exec -it <CONTAINER NAME> setup config dkim domain <DOMAIN>` multiple times to create all the keys for all domains, and then provide a custom `dkim_signing.conf` (for which an example is shown below).
 
     !!! info "About the Helper Script"
 
@@ -121,7 +125,9 @@ DKIM is currently supported by either OpenDKIM or Rspamd:
 
         ---
 
-        In case you have not already provided a default DKIM signing configuration, the script will create one and write it to `/etc/rspamd/override.d/dkim_signing.conf`. If this file already exist, it will not be overwritten. When you're already using [the `rspamd/override.d/` directory][docs-rspamd-override-d], the file is created inside your volume and therefore persisted correctly. If you are not using `rspamd/override.d/`, you will need to persist the file yourself (otherwise it is lost on container restart).
+        In case you have not already provided a default DKIM signing configuration, the script will create one and write it to `/etc/rspamd/override.d/dkim_signing.conf`. If this file already exists, it will not be overwritten.
+
+        When you're already using [the `rspamd/override.d/` directory][docs-rspamd-config-dropin], the file is created inside your volume and therefore persisted correctly. If you are not using `rspamd/override.d/`, you will need to persist the file yourself (otherwise it is lost on container restart).
 
         An example of what a default configuration file for DKIM signing looks like can be found by expanding the example below.
 
@@ -190,8 +196,6 @@ DKIM is currently supported by either OpenDKIM or Rspamd:
 
         If there is a mismatch, a warning will be emitted to the Rspamd log `/var/log/supervisor/rspamd.log`.
 
-    [docs-rspamd-override-d]: ../security/rspamd.md#manually
-
 ### DNS Record { #dkim-dns }
 
 When mail signed with your DKIM key is sent from your mail server, the receiver needs to check a DNS `TXT` record to verify the DKIM signature is trustworthy.
@@ -221,11 +225,13 @@ When mail signed with your DKIM key is sent from your mail server, the receiver 
 
 ??? info "`<selector>.txt` - Formatting the `TXT` record value correctly"
 
-    This file was generated for use within a [DNS zone file][dns::wikipedia-zonefile]. DNS `TXT` records values that are longer than 255 characters need to be split into multiple parts. This is why the public key has multiple parts wrapped within double-quotes between `(` and `)`.
+    This file was generated for use within a [DNS zone file][dns::wikipedia-zonefile]. The file name uses the DKIM selector it was generated with (default DKIM selector is `mail`, which creates `mail.txt`_).
 
-    A DNS web-interface may handle this internally instead, while [others may not, but expect the input as a single line][dns::webui-dkim]_). You'll need to manually format the value as described below.
+    For your DNS setup, DKIM support needs to create a `TXT` record to store the public key for mail clients to use. `TXT` records with values that are longer than 255 characters need to be split into multiple parts. This is why the generated `<selector>.txt` file (_containing your public key for use with DKIM_) has multiple value parts wrapped within double-quotes between `(` and `)`.
 
-    Your DNS record file (eg: `mail.txt`) should look similar to this:
+    A DNS web-interface may handle this separation internally instead, and [could expect the value provided all as a single line][dns::webui-dkim] instead of split. When that is required, you'll need to manually format the value as described below.
+
+    Your generated DNS record file (`<selector>.txt`) should look similar to this:
 
     ```txt
     mail._domainkey IN TXT ( "v=DKIM1; k=rsa; "
@@ -243,7 +249,7 @@ When mail signed with your DKIM key is sent from your mail server, the receiver 
     To test that your new DKIM record is correct, query it with the `dig` command. The `TXT` value response should be a single line split into multiple parts wrapped in double-quotes:
 
     ```console
-    $ dig +short TXT dkim-rsa._domainkey.example.com
+    $ dig +short TXT mail._domainkey.example.com
     "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqQMMqhb1S52Rg7VFS3EC6JQIMxNDdiBmOKZvY5fiVtD3Z+yd9ZV+V8e4IARVoMXWcJWSR6xkloitzfrRtJRwOYvmrcgugOalkmM0V4Gy/2aXeamuiBuUc4esDQEI3egmtAsHcVY1XCoYfs+9VqoHEq3vdr3UQ8zP/l+FP5UfcaJFCK/ZllqcO2P1GjIDVSHLdPpRHbMP/tU1a9mNZ5QMZBJ/JuJK/s+2bp8gpxKn8rh1akSQjlynlV9NI+7J3CC7CUf3bGvoXIrb37C/lpJehS39" "KNtcGdaRufKauSfqx/7SxA0zyZC+r13f7ASbMaQFzm+/RRusTqozY/p/MsWx8QIDAQAB"
     ```
 
@@ -328,7 +334,6 @@ volumes:
 [docs-env-opendkim]: ../environment.md#enable_opendkim
 [docs-env-rspamd]: ../environment.md#enable_rspamd
 [docs-rspamd-config-dropin]: ../security/rspamd.md#manually
-[docs-rspamd-config-declarative]: ../security/rspamd.md#with-the-help-of-a-custom-file
 [cloudflare-dkim-dmarc-spf]: https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/
 [rfc-6376]: https://tools.ietf.org/html/rfc6376
 [github-issue-dkimlength]: https://github.com/docker-mailserver/docker-mailserver/issues/1854

--- a/docs/content/config/best-practices/dkim_dmarc_spf.md
+++ b/docs/content/config/best-practices/dkim_dmarc_spf.md
@@ -62,9 +62,11 @@ DKIM is currently supported by either OpenDKIM or Rspamd:
 
         Your new DKIM key(s) and OpenDKIM config files have been added to `/tmp/docker-mailserver/opendkim/`.
 
-    ??? note "LDAP accounts need to specify domains explicitly"
+    ??? note "LDAP accounts need to specify mail domains explicitly"
 
-        The command is unable to infer the domains from LDAP user accounts, you must specify them:
+        `setup config dkim` only makes an assumption of the primary mail domain from the FQDN assigned to DMS. When the DMS FQDN is `mail.example.com` or `example.com`, by default this command will generate DKIM keys for `example.com` as the primary domain for your users mail accounts to be using (`hello@example.com`).
+
+        Otherwise, the commands defaults (_when DMS is configured with `ACCOUNT_PROVISIONER=LDAP`_) are not able to source the extra mail domains known by your LDAP provider. If you need to support additional mail domains, then you must explicitly specify them by using the `domain` option:
 
         ```sh
         setup config dkim domain 'example.com,another-example.com'

--- a/docs/content/config/best-practices/dkim_dmarc_spf.md
+++ b/docs/content/config/best-practices/dkim_dmarc_spf.md
@@ -42,7 +42,9 @@ You should have:
 
 !!! warning "RSA Key Sizes >= 4096 Bit"
 
-    Keys of size 4096-bit could be denied by some mail servers. According to [RFC 6376][rfc-6376], keys are [preferably between 512 and 2048 bits][github-issue-dkimlength] (_**NOTE:** 512-bit is considered insecure_).
+    According to [RFC 8301][rfc-8301], keys are preferably between 1024 and 2048 bits. Keys of size 4096-bit or larger may not be compatible to all systems your mail is intended for.
+
+    You [should not need a key length beyond 2048-bit][github-issue-dkimlength]. If 2048-bit does not meet your security needs, you may want to instead consider adopting key rotation or switching from RSA to ECC keys for DKIM.
 
 DKIM is currently supported by either OpenDKIM or Rspamd:
 
@@ -337,8 +339,8 @@ volumes:
 [docs-env-rspamd]: ../environment.md#enable_rspamd
 [docs-rspamd-config-dropin]: ../security/rspamd.md#manually
 [cloudflare-dkim-dmarc-spf]: https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/
-[rfc-6376]: https://tools.ietf.org/html/rfc6376
-[github-issue-dkimlength]: https://github.com/docker-mailserver/docker-mailserver/issues/1854
+[rfc-8301]: https://datatracker.ietf.org/doc/html/rfc8301#section-3.2
+[github-issue-dkimlength]: https://github.com/docker-mailserver/docker-mailserver/issues/1854#issuecomment-806280929
 [rspamd-docs-dkim-checks]: https://www.rspamd.com/doc/modules/dkim.html
 [rspamd-docs-dkim-signing]: https://www.rspamd.com/doc/modules/dkim_signing.html
 [dns::example-webui]: https://www.vultr.com/docs/introduction-to-vultr-dns/

--- a/target/bin/open-dkim
+++ b/target/bin/open-dkim
@@ -16,13 +16,14 @@ function __usage() {
   printf '%s' "${PURPLE}OPEN-DKIM${RED}(${YELLOW}8${RED})
 
 ${ORANGE}NAME${RESET}
-    open-dkim - configure DomainKeys Identified Mail (DKIM)
+    open-dkim - Configure DKIM (DomainKeys Identified Mail)
 
 ${ORANGE}SYNOPSIS${RESET}
     ./setup.sh config dkim [ OPTIONS${RED}...${RESET} ]
 
 ${ORANGE}DESCRIPTION${RESET}
-    Configures DKIM keys. OPTIONS can be used to configure a more complex setup.
+    Creates and configures DKIM keys. OPTIONS can be used when needing to avoid defaults.
+    By default creates keys for domains sourced from your configured 'ACCOUNT_PROVISIONER'.
     LDAP setups require these options.
 
 ${ORANGE}OPTIONS${RESET}
@@ -30,23 +31,19 @@ ${ORANGE}OPTIONS${RESET}
         help       Print the usage information.
 
     ${BLUE}Configuration adjustments${RESET}
-        keysize    Set the size of the keys to be generated (default: 2048). Possible are: 1024, 2048 and 4096.
-        selector   Set a manual selector (default is 'mail') for the key. (${LCYAN}ATTENTION${RESET}: NOT IMPLEMENTED YET!)
-        domain     Provide the domain(s) for which keys are to be generated.
+        keysize    Set the size of the keys to be generated (default: 2048). Possible values: 1024, 2048 and 4096.
+        selector   Set a manual selector (default: mail) for the key. (${LCYAN}ATTENTION${RESET}: NOT IMPLEMENTED YET!)
+        domain     Provide the domain(s) for which to generate keys for.
 
 ${ORANGE}EXAMPLES${RESET}
-    ${LWHITE}./setup.sh config dkim keysize 2048${RESET}
-        Creates keys of length 2048 bit in a default setup where domains are obtained from
-        your accounts.
+    ${LWHITE}./setup.sh config dkim keysize 4096${RESET}
+        Creates keys with their length increased to a size of 4096-bit.
 
-    ${LWHITE}./setup.sh config dkim keysize 2048 selector 2021-dkim${RESET}
-        Creates keys of length 2048 bit in a default setup where domains are obtained from
-        your accounts. The DKIM selector used is '2021-dkim'.
+    ${LWHITE}./setup.sh config dkim keysize 1024 selector 2023-dkim${RESET}
+        Creates 1024-bit sized keys, and changes the DKIM selector to '2023-dkim'.
 
-    ${LWHITE}./setup.sh config dkim keysize 2048 selector 2021-dkim domain 'whoami.com,whoareyou.org'${RESET}
-        Appropriate for an LDAP setup. Creates keys of length 2048 bit in a default setup
-        where domains are obtained from your accounts. The DKIM selector used is '2021-dkim'.
-        The domains for which DKIM keys are generated are 'whoami.com' and 'whoareyou.org'.
+    ${LWHITE}./setup.sh config dkim domain 'example.com,another-example.com'${RESET}
+        Only generates DKIM keys for the specified domains: 'example.com' and 'another-example.com'.
 
 ${ORANGE}EXIT STATUS${RESET}
     Exit status is 0 if command was successful. If wrong arguments are provided or arguments contain

--- a/target/bin/open-dkim
+++ b/target/bin/open-dkim
@@ -8,7 +8,7 @@ if [[ -f /etc/dms-settings ]] && [[ $(_get_dms_env_value 'ENABLE_RSPAMD') -eq 1 
   exit
 fi
 
-KEYSIZE=4096
+KEYSIZE=2048
 SELECTOR=mail
 DOMAINS=
 
@@ -30,7 +30,7 @@ ${ORANGE}OPTIONS${RESET}
         help       Print the usage information.
 
     ${BLUE}Configuration adjustments${RESET}
-        keysize    Set the size of the keys to be generated. Possible are 1024, 2048 and 4096 (default).
+        keysize    Set the size of the keys to be generated (default: 2048). Possible are: 1024, 2048 and 4096.
         selector   Set a manual selector (default is 'mail') for the key. (${LCYAN}ATTENTION${RESET}: NOT IMPLEMENTED YET!)
         domain     Provide the domain(s) for which keys are to be generated.
 

--- a/target/bin/open-dkim
+++ b/target/bin/open-dkim
@@ -19,30 +19,36 @@ ${ORANGE}NAME${RESET}
     open-dkim - Configure DKIM (DomainKeys Identified Mail)
 
 ${ORANGE}SYNOPSIS${RESET}
-    ./setup.sh config dkim [ OPTIONS${RED}...${RESET} ]
+    setup config dkim [ OPTIONS${RED}...${RESET} ]
 
 ${ORANGE}DESCRIPTION${RESET}
-    Creates and configures DKIM keys. OPTIONS can be used when needing to avoid defaults.
-    By default creates keys for domains sourced from your configured 'ACCOUNT_PROVISIONER'.
-    LDAP setups require these options.
+    Creates DKIM keys and configures them within DMS for OpenDKIM.
+    OPTIONS can be used when your requirements are not met by the defaults.
+    When not using 'ACCOUNT_PROVISIONER=FILE' (default), you may need to explicitly
+    use the 'domain' option to generate DKIM keys for your mail account domains.
 
 ${ORANGE}OPTIONS${RESET}
     ${BLUE}Generic Program Information${RESET}
-        help       Print the usage information.
+        help      Print the usage information.
 
     ${BLUE}Configuration adjustments${RESET}
-        keysize    Set the size of the keys to be generated (default: 2048). Possible values: 1024, 2048 and 4096.
-        selector   Set a manual selector (default: mail) for the key. (${LCYAN}ATTENTION${RESET}: NOT IMPLEMENTED YET!)
-        domain     Provide the domain(s) for which to generate keys for.
+        keysize   Set the size of the keys to be generated.
+                  Possible values: 1024, 2048 and 4096
+                  Default: 2048
+        selector  Set a manual selector for the key.
+                  Default: mail
+        domain    Provide the domain(s) for which to generate keys for.
+                  Default: The FQDN assigned to DMS, excluding any subdomain.
+                           'ACCOUNT_PROVISIONER=FILE' also sources domains from mail accounts.
 
 ${ORANGE}EXAMPLES${RESET}
-    ${LWHITE}./setup.sh config dkim keysize 4096${RESET}
+    ${LWHITE}setup config dkim keysize 4096${RESET}
         Creates keys with their length increased to a size of 4096-bit.
 
-    ${LWHITE}./setup.sh config dkim keysize 1024 selector 2023-dkim${RESET}
+    ${LWHITE}setup config dkim keysize 1024 selector 2023-dkim${RESET}
         Creates 1024-bit sized keys, and changes the DKIM selector to '2023-dkim'.
 
-    ${LWHITE}./setup.sh config dkim domain 'example.com,another-example.com'${RESET}
+    ${LWHITE}setup config dkim domain 'example.com,another-example.com'${RESET}
         Only generates DKIM keys for the specified domains: 'example.com' and 'another-example.com'.
 
 ${ORANGE}EXIT STATUS${RESET}

--- a/target/bin/rspamd-dkim
+++ b/target/bin/rspamd-dkim
@@ -16,14 +16,14 @@ function __usage() {
   echo -e "${PURPLE}RSPAMD-DKIM${RED}(${YELLOW}8${RED})
 
 ${ORANGE}NAME${RESET}
-    rspamd-dkim - Configure DomainKeys Identified Mail (DKIM) via Rspamd
+    rspamd-dkim - Configure DKIM (DomainKeys Identified Mail)
 
 ${ORANGE}SYNOPSIS${RESET}
     setup config dkim [ OPTIONS${RED}...${RESET} ]
 
 ${ORANGE}DESCRIPTION${RESET}
-    This script aids in creating DKIM signing keys. The keys are created and managed by Rspamd.
-    OPTIONS can be used to configure a more complex setup.
+    Creates DKIM keys and configures them within DMS for Rspamd.
+    OPTIONS can be used when your requirements are not met by the defaults.
 
 ${ORANGE}OPTIONS${RESET}
     ${BLUE}Generic Program Information${RESET}
@@ -32,30 +32,27 @@ ${ORANGE}OPTIONS${RESET}
         help      Print the usage information.
 
     ${BLUE}Configuration adjustments${RESET}
-        keytype   Set the type of key you want to use
+        keytype   Set the type of key you want to use.
                   Possible values: rsa, ed25519
                   Default: rsa
-        keysize   Set the size of the keys to be generated
+        keysize   Set the size of the keys to be generated.
                   Possible values: 1024, 2048 and 4096
                   Default: 2048
                   Only applies when using keytype=rsa
-        selector  Set a manual selector for the key
+        selector  Set a manual selector for the key.
                   Default: mail
-        domain    Provide the domain for which keys are to be generated
-                  Default: primary domain name of DMS
+        domain    Provide the domain for which to generate keys for.
+                  Default: The FQDN assigned to DMS, excluding any subdomain.
 
 ${ORANGE}EXAMPLES${RESET}
-    ${LWHITE}setup config dkim keysize 2048${RESET}
-        Creates keys of length 2048 bit in a default setup where domains are obtained from
-        your accounts.
+    ${LWHITE}setup config dkim keysize 4096${RESET}
+        Creates keys with their length increased to a size of 4096-bit.
 
-    ${LWHITE}setup config dkim keysize 512 selector 2023-dkim${RESET}
-        Creates keys of length 512 bit in a default setup where domains are obtained from
-        your accounts. The DKIM selector used is '2023-dkim'.
+    ${LWHITE}setup config dkim keysize 1024 selector 2023-dkim${RESET}
+        Creates 1024-bit sized keys, and changes the DKIM selector to '2023-dkim'.
 
-    ${LWHITE}setup config dkim keysize 1024 selector 2023-dkim domain whoami.com${RESET}
-        Creates keys of length 1024 bit in a default setup where domains are obtained from your accounts.
-        The DKIM selector used is '2023-dkim'. The domain for which DKIM keys are generated is whoami.com.
+    ${LWHITE}setup config dkim domain example.com${RESET}
+        Generate the DKIM key for a different domain (example.com).
 
 ${ORANGE}EXIT STATUS${RESET}
     Exit status is 0 if command was successful. If wrong arguments are provided or arguments contain

--- a/test/tests/parallel/set1/spam_virus/rspamd_dkim.bats
+++ b/test/tests/parallel/set1/spam_virus/rspamd_dkim.bats
@@ -49,7 +49,7 @@ function teardown_file() { _default_teardown ; }
   _run_in_container setup config dkim help
   __log_is_free_of_warnings_and_errors
   assert_output --partial 'Showing usage message now'
-  assert_output --partial 'rspamd-dkim - Configure DomainKeys Identified Mail (DKIM) via Rspamd'
+  assert_output --partial 'rspamd-dkim - Configure DKIM (DomainKeys Identified Mail)'
 }
 
 @test 'default signing config is created if it does not exist and not overwritten' {
@@ -143,7 +143,7 @@ function teardown_file() { _default_teardown ; }
 }
 
 @test "argument 'keysize' is applied correctly for RSA keys" {
-  for KEYSIZE in 512 1024 2048 4096; do
+  for KEYSIZE in 1024 2048 4096; do
     __create_key 'rsa' 'mail' "${DOMAIN_NAME}" "${KEYSIZE}"
     assert_success
     __log_is_free_of_warnings_and_errors

--- a/test/tests/parallel/set3/scripts/setup_cli.bats
+++ b/test/tests/parallel/set3/scripts/setup_cli.bats
@@ -237,7 +237,7 @@ function teardown_file() { _default_teardown ; }
 @test "config dkim (help correctly displayed)" {
   run ./setup.sh -c "${CONTAINER_NAME}" config dkim help
   assert_success
-  assert_line --index 3 --partial "    open-dkim - configure DomainKeys Identified Mail (DKIM)"
+  assert_line --index 3 --partial "open-dkim - Configure DKIM (DomainKeys Identified Mail)"
 }
 
 # debug

--- a/test/tests/serial/open_dkim.bats
+++ b/test/tests/serial/open_dkim.bats
@@ -113,14 +113,14 @@ function teardown() { _default_teardown ; }
   __init_container_without_waiting '/tmp/docker-mailserver'
 
   # generate first key (with a custom selector)
-  __should_generate_dkim_key 4 '2048' 'domain1.tld' 'mailer'
+  __should_generate_dkim_key 4 '1024' 'domain1.tld' 'mailer'
   __assert_outputs_common_dkim_logs
   # generate two additional keys different to the previous one
-  __should_generate_dkim_key 2 '2048' 'domain2.tld,domain3.tld'
+  __should_generate_dkim_key 2 '1024' 'domain2.tld,domain3.tld'
   __assert_logged_dkim_creation 'domain2.tld'
   __assert_logged_dkim_creation 'domain3.tld'
   # generate an additional key whilst providing already existing domains
-  __should_generate_dkim_key 1 '2048' 'domain3.tld,domain4.tld'
+  __should_generate_dkim_key 1 '1024' 'domain3.tld,domain4.tld'
   __assert_logged_dkim_creation 'domain4.tld'
 
   __should_have_tables_trustedhosts_for_domain
@@ -197,7 +197,7 @@ function __should_support_creating_key_of_size() {
   __assert_logged_dkim_creation 'localhost.localdomain'
   __assert_logged_dkim_creation 'otherdomain.tld'
 
-  __should_have_expected_files "${EXPECTED_KEYSIZE:-4096}"
+  __should_have_expected_files "${EXPECTED_KEYSIZE:-2048}"
   _run_in_container rm -r /tmp/docker-mailserver/opendkim
 }
 


### PR DESCRIPTION
# Description

I originally raised this change as desired back in a [March 2021 discussion](https://github.com/docker-mailserver/docker-mailserver/issues/1854#issuecomment-800679841) (_and again by me recently in [April 2023](https://github.com/docker-mailserver/docker-mailserver/pull/3231#pullrequestreview-1377342412) and [Aug 2023](https://github.com/docker-mailserver/docker-mailserver/issues/3491#issuecomment-1685412235)_), detailing why we should be set the default to 2048 (_revert rather, as the change from `2048` to `4096` wasn't justified well but got through review_).

Additional history for how the default became 4096 is detailed in:
- https://github.com/docker-mailserver/docker-mailserver/pull/2620 (June 2022)
- https://github.com/docker-mailserver/docker-mailserver/pull/3060 (Feb 2023)

I finally got around to tackling it 🎉 and improved the related DKIM docs and help command output while at it.

The DKIM UX and docs could probably do with some more improvements, but I mostly wanted to address the bad default of `4096-bit` default key size. Potentially a breaking change if users rely on implicit defaults with automated config/deployment scripts.

---

### Extra reference from RFC documents

Our docs reference RFC 6376, and I'll update that to reflect changes from RFC 8301 as noted below, and cited in the original March 2021 discussion referenced to motivate this change in DMS.

[RFC 8301 `3.2` Key Sizes](https://datatracker.ietf.org/doc/html/rfc8301#section-3.2) (Jan 2018, **Updates:** RFC 6376):

> _Selecting appropriate key sizes is a trade-off between cost, performance, and risk.  Since short RSA keys more easily succumb to off-line attacks:_
> - _Signers MUST use RSA keys of at least 1024 bits for all keys._
> - _Signers SHOULD use RSA keys of at least 2048 bits._
> - _Verifiers MUST be able to validate signatures with keys ranging from 1024 bits to 4096 bits, and they MAY be able to validate signatures with larger keys_
> - _Verifiers MUST NOT consider signatures using RSA keys of less than 1024 bits as valid signatures._

Compared to [RFC 6376 `3.3.3` Key Sizes](https://datatracker.ietf.org/doc/html/rfc6376#section-3.3.3) (Sep 2011), the 1024-bit requirement for signers changed from long-lived keys to ALL keys, and that the verifiers minimum range for validation was raised to 1024-bit from 512-bit.

It additionally notes key size choice should be influenced by:

> - _The practical constraint that large (e.g. 4096-bit) keys might not fit within a 512-byte DNS UDP response packet._
> - _The security constraint that keys smaller than 1024 bits are subject to off-line attacks._
> - _Larger keys impose higher CPU costs to verify and sign email._
> - _Keys can be replaced on a regular basis; thus, their lifetime can be relatively short._
> - _The security goals of this specification are modest compared to typical goals of other systems that employ digital signatures._

1024-bit should be fine, especially with key rotation and the lower impact to security when compromised vs private keys for other security purposes. 2048-bit should place more of our audience at ease, where those that prefer the perks of smaller key sizes are advised to adopt ECC keys (_supported with rspamd, along with RSA fallback_).

---

**NOTE:** Each commit has a message detailing changes, may provide extra context for review or easier to follow diffs.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update (DONE)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] New and existing unit tests pass locally with my changes
