### PR TITLE
ci: Revise PR template (Change checklist into a comment)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,9 @@
 # Description
 
-<!-- Include a summary of the change.
-     Please also include relevant motivation and context. -->
+<!--
+  Include a summary of the change.
+  Please also include relevant motivation and context.
+-->
 
 <!-- Link the issue which will be fixed (if any) here: -->
 Fixes #
@@ -14,13 +16,12 @@ Fixes #
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Improvement (non-breaking change that does improve existing functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
 
-## Checklist:
-
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
-- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
+<!-- Before submitting consider this checklist:
+- My code follows the style guidelines of this project
+- I have performed a self-review of my own code
+- I have commented my code, particularly in hard-to-understand areas
+- I have updated any relevant documentation (under `docs/`) to reflect my changes
+- New and existing unit tests pass locally with my changes
+- If necessary I have added tests that prove my fix is effective or that my feature works
+-->


### PR DESCRIPTION
# Description

The checklist isn't too important to render, it is primarily to benefit the contributor as a reminder.

Keep it for that purpose, but treated as comment instead?

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)
