### PR TITLE
refactor: Helper function `_replace_by_env_in_file()`

### DIFF
--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -130,7 +130,7 @@ function _replace_by_env_in_file() {
     ESCAPED_KEY=$(_escape_for_sed "${KEY,,}")
     ESCAPED_VALUE=$(_escape_for_sed "${VALUE}")
     _log 'trace' "Setting value of '${KEY}' in '${CONFIG_FILE}' to '${VALUE}'"
-    sed -i -E "s#^(${ESCAPED_KEY}[[:space:]]*${KV_DELIMITER}[[:space:]]*).*#\1${ESCAPED_VALUE}#g" "${CONFIG_FILE}"
+    sedfile -i -E "s#^(${ESCAPED_KEY}[[:space:]]*${KV_DELIMITER}[[:space:]]*).*#\1${ESCAPED_VALUE}#gi" "${CONFIG_FILE}"
   done < <(env | grep "^${ENV_PREFIX}")
 }
 

--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -129,9 +129,8 @@ function _replace_by_env_in_file() {
     KEY=${KEY#"${ENV_PREFIX}"} # strip prefix
     ESCAPED_KEY=$(_escape_for_sed "${KEY,,}")
     ESCAPED_VALUE=$(_escape_for_sed "${VALUE}")
-    [[ -n ${ESCAPED_VALUE} ]] && ESCAPED_VALUE=" ${ESCAPED_VALUE}"
     _log 'trace' "Setting value of '${KEY}' in '${CONFIG_FILE}' to '${VALUE}'"
-    sed -i -E "s#^${ESCAPED_KEY}[[:space:]]*${KV_DELIMITER}.*#${ESCAPED_KEY} ${KV_DELIMITER}${ESCAPED_VALUE}#g" "${CONFIG_FILE}"
+    sed -i -E "s#^(${ESCAPED_KEY}[[:space:]]*${KV_DELIMITER}[[:space:]]*).*#\1${ESCAPED_VALUE}#g" "${CONFIG_FILE}"
   done < <(env | grep "^${ENV_PREFIX}")
 }
 

--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -4,14 +4,30 @@ function _escape() {
   echo "${1//./\\.}"
 }
 
-# TODO: Not in use currently. Maybe in the future: https://github.com/docker-mailserver/docker-mailserver/pull/3484/files#r1299410851
-# Replaces a string so that it can be used inside
-# `sed` safely.
+# Replaces a string so that it can be used inside the `sed` regex segment safely.
+# WARNING: Only for use with `sed -E` / `sed -r` due to escaping additional tokens,
+# which are valid tokens when escaped in basic regex mode.
 #
 # @param ${1} = string to escape
 # @output     = prints the escaped string
 function _escape_for_sed() {
-  sed -E 's/[]\/$*.^[]/\\&/g' <<< "${1:?String to escape for sed is required}"
+  # Escapes all special tokens:
+  # - `/` should represent the sed delimiter (caution when using sed with a non-default delimiter).
+  # - `]` should be the first char, while `.` must not be the 2nd.
+  # - Within the `[ ... ]` scope, no escaping is needed regardless of basic vs extended regexp mode.
+  local REGEX_BASIC='][/\$*.^'
+  # In this mode (`-E` / `-r`), these tokens no longer require a preceding `\`, so must also be escaped:
+  local REGEX_EXTENDED='|?)(}{+'
+  # The replacement segment is compatible but most tokens do not require escaping.
+  # `&` is a token for this segment, and is compatible with escaping in the regex segment:
+  local TOKEN_REPLACEMENT='&'
+  local REGEX_SEGMENT="${REGEX_BASIC}${REGEX_EXTENDED}${TOKEN_REPLACEMENT}"
+
+  # Output: `\\` prepends a `\` to a token matched by the regex segment (`&`)
+  local PREPEND_ESCAPE='\\&'
+
+  # Full sed expression: sed -E 's/[][/\$*.^|?)(}{+&]/\\&/g'
+  sed -E "s/[${REGEX_SEGMENT}]/${PREPEND_ESCAPE}/g" <<< "${1:?String to escape for sed is required}"
 }
 
 # Returns input after filtering out lines that are:
@@ -78,8 +94,9 @@ function _reload_postfix() {
 # calling this function.
 #
 # @option --shutdown-on-error = shutdown in case an error is detected
-# @param ${1} = prefix for environment variables
-# @param ${2} = file in which substitutions should take place
+# @param ${1} = Prefix for selecting environment variables
+# @param ${2} = File in which substitutions should take place
+# @param ${3} = The key/value assignment operator used (default: `=`) [OPTIONAL]
 #
 # ## Example
 #
@@ -87,7 +104,7 @@ function _reload_postfix() {
 # you can set the environment variable `POSTFIX_README_DIRECTORY='/new/dir/'`
 # (`POSTFIX_` is an arbitrary prefix, you can choose the one you like),
 # and then call this function:
-# `_replace_by_env_in_file 'POSTFIX_' 'PATH TO POSTFIX's main.cf>`
+# `_replace_by_env_in_file 'POSTFIX_' '/etc/postfix/main.cf`
 #
 # ## Panics
 #
@@ -105,15 +122,16 @@ function _replace_by_env_in_file() {
   fi
 
   local ENV_PREFIX=${1} CONFIG_FILE=${2}
+  local KV_DELIMITER=${3:-'='}
   local ESCAPED_VALUE ESCAPED_KEY
 
-  while IFS='=' read -r KEY VALUE; do
+  while IFS="${KV_DELIMITER}" read -r KEY VALUE; do
     KEY=${KEY#"${ENV_PREFIX}"} # strip prefix
-    ESCAPED_KEY=$(sed -E 's#([\=\&\|\$\.\*\/\[\\^]|\])#\\\1#g' <<< "${KEY,,}")
-    ESCAPED_VALUE=$(sed -E 's#([\=\&\|\$\.\*\/\[\\^]|\])#\\\1#g' <<< "${VALUE}")
+    ESCAPED_KEY=$(_escape_for_sed "${KEY,,}")
+    ESCAPED_VALUE=$(_escape_for_sed "${VALUE}")
     [[ -n ${ESCAPED_VALUE} ]] && ESCAPED_VALUE=" ${ESCAPED_VALUE}"
     _log 'trace' "Setting value of '${KEY}' in '${CONFIG_FILE}' to '${VALUE}'"
-    sed -i -E "s#^${ESCAPED_KEY}[[:space:]]*=.*#${ESCAPED_KEY} =${ESCAPED_VALUE}#g" "${CONFIG_FILE}"
+    sed -i -E "s#^${ESCAPED_KEY}[[:space:]]*${KV_DELIMITER}.*#${ESCAPED_KEY} ${KV_DELIMITER}${ESCAPED_VALUE}#g" "${CONFIG_FILE}"
   done < <(env | grep "^${ENV_PREFIX}")
 }
 


### PR DESCRIPTION
# Description

Some refactoring improvements and fixes to the escaping support:

-  `_replace_by_env_in_file()`:
   - Minor change to add support for usage with `saslauthd.conf` which differs with `:` for it's key/value delimiter.
   - Also adopts using the`_escape_for_sed()` helper function, instead of the inline sed pattern (_which for some reason escaped a `=`? but not actual regex tokens `(` + `)`, thus buggy if ever matching on input with those tokens_).
   - Since the value is used regardless in the final `sed` expression, no need to prepend white-space, and we can additionally preserve the white-space between key and value of the source input while being more DRY.
- `_escape_for_sed()`:
  - This was not escaping for `(` + `)` (_or even `|`_), which is required for proper escaping support when using `sed -E` / `sed -r` with this helper function. It does now.
  - Additionally added escaping support for the `&` _replacement segment_ token, which seems ok to escape in the _regexp segment_ too (_even though it has no meaning there_). Increased verbosity to better grok pattern matching expression (_easier when broken down, vs all in a single line_), clarified an escaping concern with the `sed` segment delimiter (_since the project is not consistent there_).

**NOTE:** Tests will fail, this PR can be rebased upon https://github.com/docker-mailserver/docker-mailserver/pull/3524 which for the `mail_with_ldap.bats` test at least should pass then, other tests can be updated here after that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
