### PR TITLE
docs: fix ipv6 example for Compose

### DIFF
--- a/docs/content/config/advanced/ipv6.md
+++ b/docs/content/config/advanced/ipv6.md
@@ -92,7 +92,9 @@ Next, configure a network with an IPv6 subnet for your container with any of the
             networks:
               dms-ipv6:
                 enable_ipv6: true
-                subnet: fd00:cafe:face:feed::/64
+                ipam:
+                  config:
+                    - subnet: fd00:cafe:face:feed::/64
             ```
 
             ??? tip "Override the implicit `default` network"


### PR DESCRIPTION
# Description
Fix the example for Docker Compose to configure an IPv6 network.

This was unfortunately slightly incorrect due to a mistake in the official Docker docs being propagated, which has been fixed upstream with docker/docs#18119.

The subnet must be specified as part of `ipam.config`.

Refer to the official Compose Spec for more details:
 * https://docs.docker.com/compose/compose-file/06-networks/#ipam

## Type of change
- [x] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
