### PR TITLE
fix: Open-DKIM key generation broken

### DIFF
--- a/target/bin/open-dkim
+++ b/target/bin/open-dkim
@@ -3,9 +3,12 @@
 # shellcheck source=../scripts/helpers/index.sh
 source /usr/local/bin/helpers/index.sh
 
-if [[ -f /etc/dms-settings ]] && [[ $(_get_dms_env_value 'ENABLE_OPENDKIM') -ne 1 ]]; then
-  /usr/local/bin/rspamd-dkim "${@}"
-  exit
+if [[ -f /etc/dms-settings ]] && [[ $(_get_dms_env_value 'ENABLE_RSPAMD') -eq 1 ]]; then
+  if [[ $(_get_dms_env_value 'ENABLE_OPENDKIM') -eq 1 ]]; then
+    log 'error' "You enabled Rspamd and OpenDKIM - OpenDKIM will be implicitly used for DKIM keys"
+  else
+    /usr/local/bin/rspamd-dkim "${@}"
+    exit
 fi
 
 KEYSIZE=2048

--- a/target/bin/open-dkim
+++ b/target/bin/open-dkim
@@ -3,7 +3,7 @@
 # shellcheck source=../scripts/helpers/index.sh
 source /usr/local/bin/helpers/index.sh
 
-if [[ -f /etc/dms-settings ]] && [[ $(_get_dms_env_value 'ENABLE_RSPAMD') -eq 1 ]]; then
+if [[ -f /etc/dms-settings ]] && [[ $(_get_dms_env_value 'ENABLE_OPENDKIM') -ne 1 ]]; then
   /usr/local/bin/rspamd-dkim "${@}"
   exit
 fi

--- a/target/bin/open-dkim
+++ b/target/bin/open-dkim
@@ -9,6 +9,7 @@ if [[ -f /etc/dms-settings ]] && [[ $(_get_dms_env_value 'ENABLE_RSPAMD') -eq 1 
   else
     /usr/local/bin/rspamd-dkim "${@}"
     exit
+  fi
 fi
 
 KEYSIZE=2048


### PR DESCRIPTION
With `ENABLE_OPENDKIM=1` and `ENABLE_RSPAMD=1` it's currently not possible to create DKIM Keys

# Description

<!-- Include a summary of the change.
     Please also include relevant motivation and context. -->

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #

## Type of change

<!-- Delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
