### PR TITLE
tests(fix): Run `pgrep` within the actual container

### DIFF
--- a/test/tests/parallel/set3/container_configuration/process_check_restart.bats
+++ b/test/tests/parallel/set3/container_configuration/process_check_restart.bats
@@ -120,9 +120,9 @@ ENV_PROCESS_LIST=(
 
   # By this point the fetchmail processes have been verified to exist and restart,
   # For FETCHMAIL_PARALLEL=1 coverage, match full commandline for COUNTER values:
-  pgrep --full 'fetchmail-1.rc'
+  _run_in_container pgrep --full 'fetchmail-1.rc'
   assert_success
-  pgrep --full 'fetchmail-2.rc'
+  _run_in_container pgrep --full 'fetchmail-2.rc'
   assert_success
 
   _should_stop_cleanly


### PR DESCRIPTION
# Description

This was missed during the original review of https://github.com/docker-mailserver/docker-mailserver/pull/3010

On a linux host, processes running within a container have been visible via commands like `pgrep`. This is does not appear to be the case with WSL2 + Docker Desktop (Windows), resulting in test failure.

The command should have been run from within the container regardless.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
