### PR TITLE
refactor: `logrotate` setup + rspamd log path + tests log helper fallback path

### DIFF
--- a/docs/content/config/security/rspamd.md
+++ b/docs/content/config/security/rspamd.md
@@ -69,6 +69,10 @@ DMS does not supply custom values for DNS servers to Rspamd. If you need to use 
 
     This setting is enabled to not allow spam to proceed just because DNS requests did not succeed. It could deny legitimate e-mails to pass though too in case your DNS setup is incorrect or not functioning properly.
 
+### Logs
+
+You can find the Rspamd logs at `/var/log/mail/rspamd.log`, and the corresponding logs for [Redis](#persistence-with-redis), if it is enabled, at `/var/log/supervisor/rspamd-redis.log`. We recommend inspecting these logs (with `docker exec -ti <CONTAINER NAME> cat /var/log/mail/rspamd.log`) in case Rspamd does not work as expected.
+
 ### Modules
 
 You can find a list of all Rspamd modules [on their website][rspamd-docs-modules].

--- a/docs/content/config/security/rspamd.md
+++ b/docs/content/config/security/rspamd.md
@@ -71,7 +71,7 @@ DMS does not supply custom values for DNS servers to Rspamd. If you need to use 
 
 ### Logs
 
-You can find the Rspamd logs at `/var/log/mail/rspamd.log`, and the corresponding logs for [Redis](#persistence-with-redis), if it is enabled, at `/var/log/supervisor/rspamd-redis.log`. We recommend inspecting these logs (with `docker exec -ti <CONTAINER NAME> cat /var/log/mail/rspamd.log`) in case Rspamd does not work as expected.
+You can find the Rspamd logs at `/var/log/mail/rspamd.log`, and the corresponding logs for [Redis](#persistence-with-redis), if it is enabled, at `/var/log/supervisor/rspamd-redis.log`. We recommend inspecting these logs (with `docker exec -it <CONTAINER NAME> cat /var/log/mail/rspamd.log`) in case Rspamd does not work as expected.
 
 ### Modules
 

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -91,7 +91,6 @@ function _register_functions() {
   _register_setup_function '_setup_dovecot_hostname'
 
   _register_setup_function '_setup_postfix_early'
-  _register_setup_function '_setup_logrotate'
   _register_setup_function '_setup_fetchmail'
   _register_setup_function '_setup_fetchmail_parallel'
 
@@ -106,6 +105,7 @@ function _register_functions() {
   fi
 
   _register_setup_function '_setup_postfix_late'
+  _register_setup_function '_setup_logrotate'
   _register_setup_function '_setup_mail_summary'
   _register_setup_function '_setup_logwatch'
 

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -82,10 +82,8 @@ function _register_functions() {
   _register_setup_function '_setup_opendmarc' # must come after `_setup_opendkim`
   _register_setup_function '_setup_policyd_spf'
 
-  _register_setup_function '_setup_logrotate'
-
   _register_setup_function '_setup_security_stack'
-  _register_setup_function '_setup_rspamd' # must come after _setup_logrotate
+  _register_setup_function '_setup_rspamd'
 
   _register_setup_function '_setup_ssl'
   _register_setup_function '_setup_docker_permit'
@@ -93,6 +91,7 @@ function _register_functions() {
   _register_setup_function '_setup_dovecot_hostname'
 
   _register_setup_function '_setup_postfix_early'
+  _register_setup_function '_setup_logrotate'
   _register_setup_function '_setup_fetchmail'
   _register_setup_function '_setup_fetchmail_parallel'
 

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -82,8 +82,10 @@ function _register_functions() {
   _register_setup_function '_setup_opendmarc' # must come after `_setup_opendkim`
   _register_setup_function '_setup_policyd_spf'
 
+  _register_setup_function '_setup_logrotate'
+
   _register_setup_function '_setup_security_stack'
-  _register_setup_function '_setup_rspamd'
+  _register_setup_function '_setup_rspamd' # must come after _setup_logrotate
 
   _register_setup_function '_setup_ssl'
   _register_setup_function '_setup_docker_permit'
@@ -105,7 +107,6 @@ function _register_functions() {
   fi
 
   _register_setup_function '_setup_postfix_late'
-  _register_setup_function '_setup_logrotate'
   _register_setup_function '_setup_mail_summary'
   _register_setup_function '_setup_logwatch'
 

--- a/target/scripts/startup/setup.d/log.sh
+++ b/target/scripts/startup/setup.d/log.sh
@@ -13,7 +13,7 @@ function _setup_logs_general() {
 function _setup_logrotate() {
   _log 'debug' 'Setting up logrotate'
 
-  if [[ ${LOGROTATE_INTERVAL} =~ ^(dai|week|month)ly$ ]]; then
+  if [[ ${LOGROTATE_INTERVAL} =~ ^(daily|weekly|monthly)$ ]]; then
     _log 'trace' "Logrotate interval set to ${LOGROTATE_INTERVAL}"
   else
     _log 'warn' "Value '${LOGROTATE_INTERVAL}' for LOGROTATE_INTERVAL is invalid - falling back to default"

--- a/target/scripts/startup/setup.d/log.sh
+++ b/target/scripts/startup/setup.d/log.sh
@@ -16,10 +16,7 @@ function _setup_logrotate() {
   if [[ ${LOGROTATE_INTERVAL} =~ ^(daily|weekly|monthly)$ ]]; then
     _log 'trace' "Logrotate interval set to ${LOGROTATE_INTERVAL}"
   else
-    _log 'warn' "Value '${LOGROTATE_INTERVAL}' for LOGROTATE_INTERVAL is invalid - falling back to default"
-    export LOGROTATE_INTERVAL='weekly'
-    # shellcheck disable=SC2034
-    VARS[LOGROTATE_INTERVAL]='weekly'
+    _dms_panic__invalid_value 'LOGROTATE_INTERVAL' 'Setup -> Logrotate'
   fi
 
   cat >/etc/logrotate.d/maillog << EOF

--- a/target/scripts/startup/setup.d/security/rspamd.sh
+++ b/target/scripts/startup/setup.d/security/rspamd.sh
@@ -102,6 +102,7 @@ function __rspamd__run_early_setup_and_checks() {
   fi
 }
 
+# Keep in sync with `target/scripts/startup/setup.d/log.sh:_setup_logrotate()`
 function __rspamd__setup_logfile() {
   cat >/etc/logrotate.d/rspamd << EOF
 /var/log/mail/rspamd.log

--- a/target/scripts/startup/setup.d/security/rspamd.sh
+++ b/target/scripts/startup/setup.d/security/rspamd.sh
@@ -7,6 +7,7 @@ function _setup_rspamd() {
     __rspamd__log 'trace' '----------  Setup started  ----------'
 
     __rspamd__run_early_setup_and_checks      # must run first
+    __rspamd__setup_logfile
     __rspamd__setup_redis
     __rspamd__setup_postfix
     __rspamd__setup_clamav
@@ -99,6 +100,19 @@ function __rspamd__run_early_setup_and_checks() {
   if [[ ${ENABLE_POSTGREY} -eq 1 ]] && [[ ${RSPAMD_GREYLISTING} -eq 1 ]]; then
     __rspamd__log 'warn' 'Running Postgrey & Rspamd at the same time is discouraged - we recommend Rspamd for greylisting'
   fi
+}
+
+function __rspamd__setup_logfile() {
+  cat >/etc/logrotate.d/rspamd << EOF
+/var/log/mail/rspamd.log
+{
+  compress
+  copytruncate
+  delaycompress
+  rotate 4
+  ${LOGROTATE_INTERVAL}
+}
+EOF
 }
 
 # Sets up Redis. In case the user does not use a dedicated Redis instance, we

--- a/target/supervisor/conf.d/supervisor-app.conf
+++ b/target/supervisor/conf.d/supervisor-app.conf
@@ -101,8 +101,8 @@ startsecs=0
 stopwaitsecs=55
 autostart=false
 autorestart=true
-stdout_logfile=/var/log/supervisor/%(program_name)s.log
-stderr_logfile=/var/log/supervisor/%(program_name)s.log
+stdout_logfile=/var/log/mail/%(program_name)s.log
+stderr_logfile=/var/log/mail/%(program_name)s.log
 command=/usr/bin/rspamd --no-fork --user=_rspamd --group=_rspamd
 
 [program:rspamd-redis]

--- a/test/helper/common.bash
+++ b/test/helper/common.bash
@@ -431,6 +431,7 @@ function _filter_service_log() {
   local CONTAINER_NAME=$(__handle_container_name "${3:-}")
   local FILE="/var/log/supervisor/${SERVICE}.log"
 
+  # Fallback to alternative log location:
   [[ -f ${FILE} ]] || FILE="/var/log/mail/${SERVICE}.log"
   _run_in_container grep -E "${STRING}" "${FILE}"
 }

--- a/test/helper/common.bash
+++ b/test/helper/common.bash
@@ -429,8 +429,10 @@ function _filter_service_log() {
   local SERVICE=${1:?Service name must be provided}
   local STRING=${2:?String to match must be provided}
   local CONTAINER_NAME=$(__handle_container_name "${3:-}")
+  local FILE="/var/log/supervisor/${SERVICE}.log"
 
-  _run_in_container grep -E "${STRING}" "/var/log/supervisor/${SERVICE}.log"
+  [[ -f ${FILE} ]] || FILE="/var/log/mail/${SERVICE}.log"
+  _run_in_container grep -E "${STRING}" "${FILE}"
 }
 
 # Like `_filter_service_log` but asserts that the string was found.


### PR DESCRIPTION
# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->

~~In order to allow users to more easily go through log files, I added `most` to the set of packages we install. This adds +122kB in size, which I think is negligible.~~

~~Moreover, I added a section to the Rspamd documentation about where to find the corresponding log files.~~

I adjusted this PR to only include changes to logrotate and to the Rspamd log. In detail, I improved `_setup_logrotate` by simplifying it and making it more readable. Moreover, I adjusted the Rspamd log file location and added a logrotate config for the Rspamd log file.

I will provide a follow-up PR that includes changes about adding and removing packages, as discussed [here](https://github.com/docker-mailserver/docker-mailserver/pull/3576#discussion_r1353455195).

<!-- Link the issue which will be fixed (if any) here: -->
Associated: #3570

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)
- [x] This change is a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
