### PR TITLE
chore: Add debug group (`packages.sh`) + more resilient rspamd setup

### DIFF
--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -43,10 +43,6 @@ function _install_postfix() {
 function _install_packages() {
   _log 'debug' 'Installing all packages now'
 
-  declare -a ANTI_VIRUS_SPAM_PACKAGES
-  declare -a CODECS_PACKAGES MISCELLANEOUS_PACKAGES
-  declare -a POSTFIX_PACKAGES MAIL_PROGRAMS_PACKAGES
-
   ANTI_VIRUS_SPAM_PACKAGES=(
     amavisd-new clamav clamav-daemon
     pyzor razor spamassassin
@@ -62,14 +58,13 @@ function _install_packages() {
   )
 
   MISCELLANEOUS_PACKAGES=(
-    apt-transport-https bind9-dnsutils binutils bsd-mailx
+    apt-transport-https binutils bsd-mailx
     ca-certificates curl dbconfig-no-thanks
-    dumb-init ed gnupg iproute2 iputils-ping
-    libdate-manip-perl libldap-common
-    libmail-spf-perl libnet-dns-perl
-    locales logwatch netcat-openbsd
-    nftables rsyslog supervisor
-    uuid whois
+    dumb-init gnupg libdate-manip-perl
+    libldap-common libmail-spf-perl
+    libnet-dns-perl locales logwatch
+    netcat-openbsd nftables rsyslog
+    supervisor uuid whois
   )
 
   POSTFIX_PACKAGES=(
@@ -82,12 +77,17 @@ function _install_packages() {
     opendmarc libsasl2-modules sasl2-bin
   )
 
+  DEBUG_PACKAGES=(
+    bind9-dnsutils iproute2 iputils-ping most nano
+  )
+
   apt-get "${QUIET}" --no-install-recommends install \
     "${ANTI_VIRUS_SPAM_PACKAGES[@]}" \
     "${CODECS_PACKAGES[@]}" \
     "${MISCELLANEOUS_PACKAGES[@]}" \
     "${POSTFIX_PACKAGES[@]}" \
-    "${MAIL_PROGRAMS_PACKAGES[@]}"
+    "${MAIL_PROGRAMS_PACKAGES[@]}" \
+    "${DEBUG_PACKAGES[@]}"
 }
 
 function _install_dovecot() {
@@ -206,6 +206,9 @@ function _post_installation_steps() {
   _log 'debug' 'Running post-installation steps (cleanup)'
   apt-get "${QUIET}" clean
   rm -rf /var/lib/apt/lists/*
+
+  _log 'debug' "Linking 'less' to 'most'"
+  ln -sf "$(command -v most)" /usr/local/bin/less
 
   _log 'info' 'Finished installing packages'
 }

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -78,7 +78,7 @@ function _install_packages() {
   )
 
   DEBUG_PACKAGES=(
-    bind9-dnsutils iproute2 iputils-ping most nano
+    bind9-dnsutils iproute2 iputils-ping less nano
   )
 
   apt-get "${QUIET}" --no-install-recommends install \

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -60,7 +60,7 @@ function _install_packages() {
   MISCELLANEOUS_PACKAGES=(
     apt-transport-https binutils bsd-mailx
     ca-certificates curl dbconfig-no-thanks
-    dumb-init gnupg libdate-manip-perl
+    dumb-init gnupg iproute2 libdate-manip-perl
     libldap-common libmail-spf-perl
     libnet-dns-perl locales logwatch
     netcat-openbsd nftables rsyslog
@@ -77,8 +77,10 @@ function _install_packages() {
     opendmarc libsasl2-modules sasl2-bin
   )
 
+  # `bind9-dnsutils` provides the `dig` command
+  # `iputils-ping` provides the `ping` command
   DEBUG_PACKAGES=(
-    bind9-dnsutils iproute2 iputils-ping less nano
+    bind9-dnsutils iputils-ping less nano
   )
 
   apt-get "${QUIET}" --no-install-recommends install \

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -207,9 +207,6 @@ function _post_installation_steps() {
   apt-get "${QUIET}" clean
   rm -rf /var/lib/apt/lists/*
 
-  _log 'debug' "Linking 'less' to 'most'"
-  ln -sf "$(command -v most)" /usr/local/bin/less
-
   _log 'info' 'Finished installing packages'
 }
 

--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -127,9 +127,17 @@ function _replace_by_env_in_file() {
 function _env_var_expect_zero_or_one() {
   local ENV_VAR_NAME=${1:?ENV var name must be provided to _env_var_expect_zero_or_one}
 
-  [[ ${!ENV_VAR_NAME} =~ ^(0|1)$ ]] && return 0
-  _log 'warn' "The value of '${ENV_VAR_NAME}' is not zero or one ('${!ENV_VAR_NAME}'), but was expected to be"
-  return 1
+  if [[ ! -v ${ENV_VAR_NAME} ]]; then
+    _log 'warn' "'${ENV_VAR_NAME}' is not set, but was expected to be"
+    return 1
+  fi
+
+  if [[ ! ${!ENV_VAR_NAME} =~ ^(0|1)$ ]]; then
+    _log 'warn' "The value of '${ENV_VAR_NAME}' (= '${!ENV_VAR_NAME}') is not 0 or 1, but was expected to be"
+    return 1
+  fi
+
+  return 0
 }
 
 # Check if an environment variable's value is an integer.

--- a/target/scripts/startup/setup.d/security/rspamd.sh
+++ b/target/scripts/startup/setup.d/security/rspamd.sh
@@ -80,7 +80,7 @@ function __rspamd__run_early_setup_and_checks() {
     if rmdir "${RSPAMD_OVERRIDE_D}" 2>/dev/null; then
       ln -s "${RSPAMD_DMS_OVERRIDE_D}" "${RSPAMD_OVERRIDE_D}"
     else
-      __rspamd__log 'warn' "Could not remove '${RSPAMD_OVERRIDE_D}' (not empty? not a directory?; did you restart properly?) - not linking '${RSPAMD_DMS_OVERRIDE_D}'"
+      __rspamd__log 'warn' "Could not remove '${RSPAMD_OVERRIDE_D}' (not empty?; not a directory?; did you restart properly?) - not linking '${RSPAMD_DMS_OVERRIDE_D}'"
     fi
   fi
 

--- a/target/scripts/startup/setup.d/security/rspamd.sh
+++ b/target/scripts/startup/setup.d/security/rspamd.sh
@@ -184,7 +184,7 @@ function __rspamd__setup_default_modules() {
     metric_exporter
   )
 
-  readonly DISABLE_MODULES
+  readonly -a DISABLE_MODULES
   local MODULE
   for MODULE in "${DISABLE_MODULES[@]}"; do
     __rspamd__helper__enable_disable_module "${MODULE}" 'false'

--- a/target/scripts/startup/setup.d/security/rspamd.sh
+++ b/target/scripts/startup/setup.d/security/rspamd.sh
@@ -42,6 +42,8 @@ function __rspamd__helper__enable_disable_module() {
   local LOCAL_OR_OVERRIDE=${3:-local}
   local MESSAGE='Enabling'
 
+  readonly MODULE ENABLE_MODULE LOCAL_OR_OVERRIDE
+
   if [[ ! ${ENABLE_MODULE} =~ ^(true|false)$ ]]; then
     __rspamd__log 'warn' "__rspamd__helper__enable_disable_module got non-boolean argument for deciding whether module should be enabled or not"
     return 1
@@ -63,10 +65,12 @@ EOF
 function __rspamd__run_early_setup_and_checks() {
   # Note: Variables not marked with `local` are
   # used in other functions as well.
-  RSPAMD_LOCAL_D='/etc/rspamd/local.d'
-  RSPAMD_OVERRIDE_D='/etc/rspamd/override.d'
-  RSPAMD_DMS_D='/tmp/docker-mailserver/rspamd'
+  readonly RSPAMD_LOCAL_D='/etc/rspamd/local.d'
+  readonly RSPAMD_OVERRIDE_D='/etc/rspamd/override.d'
+  readonly RSPAMD_DMS_D='/tmp/docker-mailserver/rspamd'
+
   local RSPAMD_DMS_OVERRIDE_D="${RSPAMD_DMS_D}/override.d/"
+  readonly RSPAMD_DMS_OVERRIDE_D
 
   mkdir -p /var/lib/rspamd/
   : >/var/lib/rspamd/stats.ucl
@@ -180,6 +184,7 @@ function __rspamd__setup_default_modules() {
     metric_exporter
   )
 
+  readonly DISABLE_MODULES
   local MODULE
   for MODULE in "${DISABLE_MODULES[@]}"; do
     __rspamd__helper__enable_disable_module "${MODULE}" 'false'
@@ -196,6 +201,7 @@ function __rspamd__setup_learning() {
     __rspamd__log 'debug' 'Setting up intelligent learning of spam and ham'
 
     local SIEVE_PIPE_BIN_DIR='/usr/lib/dovecot/sieve-pipe'
+    readonly SIEVE_PIPE_BIN_DIR
     ln -s "$(type -f -P rspamc)" "${SIEVE_PIPE_BIN_DIR}/rspamc"
 
     sedfile -i -E 's|(mail_plugins =.*)|\1 imap_sieve|' /etc/dovecot/conf.d/20-imap.conf
@@ -249,6 +255,7 @@ function __rspamd__setup_greylisting() {
 # succeeds.
 function __rspamd__setup_hfilter_group() {
   local MODULE_FILE="${RSPAMD_LOCAL_D}/hfilter_group.conf"
+  readonly MODULE_FILE
   if _env_var_expect_zero_or_one 'RSPAMD_HFILTER' && [[ ${RSPAMD_HFILTER} -eq 1 ]]; then
     __rspamd__log 'debug' 'Hfilter (group) module is enabled'
     # Check if we received a number first
@@ -269,6 +276,7 @@ function __rspamd__setup_hfilter_group() {
 
 function __rspamd__setup_check_authenticated() {
   local MODULE_FILE="${RSPAMD_LOCAL_D}/settings.conf"
+  readonly MODULE_FILE
   if _env_var_expect_zero_or_one 'RSPAMD_CHECK_AUTHENTICATED' \
   && [[ ${RSPAMD_CHECK_AUTHENTICATED} -eq 0 ]]
   then
@@ -305,8 +313,10 @@ function __rspamd__handle_user_modules_adjustments() {
     local VALUE=${4:?Value belonging to an option must be provided}
     # remove possible whitespace at the end (e.g., in case ${ARGUMENT3} is empty)
     VALUE=${VALUE% }
-
     local FILE="${RSPAMD_OVERRIDE_D}/${MODULE_FILE}"
+
+    readonly MODULE_FILE MODULE_LOG_NAME OPTION VALUE FILE
+
     [[ -f ${FILE} ]] || touch "${FILE}"
 
     if grep -q -E "${OPTION}.*=.*" "${FILE}"; then
@@ -320,6 +330,7 @@ function __rspamd__handle_user_modules_adjustments() {
 
   local RSPAMD_CUSTOM_COMMANDS_FILE="${RSPAMD_DMS_D}/custom-commands.conf"
   local RSPAMD_CUSTOM_COMMANDS_FILE_OLD="${RSPAMD_DMS_D}-modules.conf"
+  readonly RSPAMD_CUSTOM_COMMANDS_FILE RSPAMD_CUSTOM_COMMANDS_FILE_OLD
 
   # We check for usage of the previous location of the commands file.
   # This can be removed after the release of v14.0.0.
@@ -332,6 +343,7 @@ function __rspamd__handle_user_modules_adjustments() {
   if [[ -f "${RSPAMD_CUSTOM_COMMANDS_FILE}" ]]; then
     __rspamd__log 'debug' "Found file '${RSPAMD_CUSTOM_COMMANDS_FILE}' - parsing and applying it"
 
+    local COMMAND ARGUMENT1 ARGUMENT2 ARGUMENT3
     while read -r COMMAND ARGUMENT1 ARGUMENT2 ARGUMENT3; do
       case "${COMMAND}" in
         ('disable-module')

--- a/test/tests/parallel/set3/scripts/helper_functions.bats
+++ b/test/tests/parallel/set3/scripts/helper_functions.bats
@@ -35,7 +35,11 @@ SOURCE_BASE_PATH="${REPOSITORY_ROOT:?Expected REPOSITORY_ROOT to be set}/target/
 
   run _env_var_expect_zero_or_one TWO
   assert_failure
-  assert_output --partial "The value of 'TWO' is not zero or one ('2'), but was expected to be"
+  assert_output --partial "The value of 'TWO' (= '2') is not 0 or 1, but was expected to be"
+
+  run _env_var_expect_zero_or_one UNSET
+  assert_failure
+  assert_output --partial "'UNSET' is not set, but was expected to be"
 
   run _env_var_expect_zero_or_one
   assert_failure


### PR DESCRIPTION
# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->

This PR does 2 things (and I was too lazy to provide two different PRs for these small changes):

1. Adjust `packages.sh` to install `most` and `nano` and remove `ed`, adding a dedicated set up packages for debugging (first commit)
2. Adjust the Rspamd setup script to make it even more robust (commit 2 and 4)

<!-- Link the issue which will be fixed (if any) here: -->
Follow up of #3576

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
