### PR TITLE
docs: fix path to rspamd.log

### DIFF
--- a/docs/content/config/best-practices/dkim_dmarc_spf.md
+++ b/docs/content/config/best-practices/dkim_dmarc_spf.md
@@ -202,7 +202,7 @@ DKIM is currently supported by either OpenDKIM or Rspamd:
 
         When `check_pubkey = true;` is set, Rspamd will query the DNS record for each DKIM selector, verifying each public key matches the private key configured.
 
-        If there is a mismatch, a warning will be emitted to the Rspamd log `/var/log/supervisor/rspamd.log`.
+        If there is a mismatch, a warning will be emitted to the Rspamd log `/var/log/mail/rspamd.log`.
 
 ### DNS Record { #dkim-dns }
 
@@ -265,7 +265,7 @@ When mail signed with your DKIM key is sent from your mail server, the receiver 
 
 [MxToolbox has a DKIM Verifier][mxtoolbox-dkim-verifier] that you can use to check your DKIM DNS record(s).
 
-When using Rspamd, we recommend you turn on `check_pubkey = true;` in `dkim_signing.conf`. Rspamd will then check whether your private key matches your public key, and you can check possible mismatches by looking at `/var/log/supervisor/rspamd.log`.
+When using Rspamd, we recommend you turn on `check_pubkey = true;` in `dkim_signing.conf`. Rspamd will then check whether your private key matches your public key, and you can check possible mismatches by looking at `/var/log/mail/rspamd.log`.
 
 ## DMARC
 


### PR DESCRIPTION
# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->

fix the remaining /var/log/supervisor/rspamd.log to also point the user to /var/log/mail/rspamd.log

Discovered this when i had to replace the log path in our local tests (using docker-mailserver with enabled rspamd to check if our mails conform to those non RFC rules). It seems this was missed in 894978ddd751f0d09e9f68e1a3de13926e17d432

<!-- Link the issue which will be fixed (if any) here: -->

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Info @wt-io-it