### PR TITLE
bugfix: change Rspamd DKIM default config location

### DIFF
--- a/target/bin/rspamd-dkim
+++ b/target/bin/rspamd-dkim
@@ -168,8 +168,8 @@ function _preflight_checks() {
   # 2. ${RSPAMD_OVERRIDE_D} has contents already
   #
   # If 1. is true, then we're good since DMS' default setup linked the directory already and we will save
-  # a persisted location in every case. If 1. is false, 2. should be false as well since by the default,
-  # ${RSPAMD_OVERRIDE_D} has not contents - we're good as well. What should logically never happen is
+  # a persisted location in every case. If 1. is false, 2. should be false as well since by default,
+  # ${RSPAMD_OVERRIDE_D} has no contents - we're good as well. What should logically never happen is
   # that 1. is false but 2. is true; this case is caught nevertheless and a warning is emitted.
   if [[ ! -h "${RSPAMD_OVERRIDE_D}" ]]; then
     if rmdir "${RSPAMD_OVERRIDE_D}" &>/dev/null; then

--- a/target/bin/rspamd-dkim
+++ b/target/bin/rspamd-dkim
@@ -154,11 +154,30 @@ function _preflight_checks() {
   # in other functions (after this function was called).
   # Also keep in sync with: target/scripts/startup/setup.d/security/rspamd.sh:__rspamd__run_early_setup_and_checks
   local RSPAMD_DMS_D='/tmp/docker-mailserver/rspamd'
-  RSPAMD_DMS_DKIM_D="${RSPAMD_DMS_D}/dkim"
-  RSPAMD_DMS_OVERRIDE_D="${RSPAMD_DMS_D}/override.d"
+  local RSPAMD_OVERRIDE_D='/etc/rspamd/override.d'
+  readonly RSPAMD_DMS_DKIM_D="${RSPAMD_DMS_D}/dkim"
+  readonly RSPAMD_DMS_OVERRIDE_D="${RSPAMD_DMS_D}/override.d"
 
   mkdir -p "${RSPAMD_DMS_DKIM_D}" "${RSPAMD_DMS_OVERRIDE_D}"
   chown _rspamd:_rspamd "${RSPAMD_DMS_DKIM_D}"
+
+  # Mimmick target/scripts/startup/setup.d/security/rspamd.sh:__rspamd__run_early_setup_and_checks where
+  # ${RSPAMD_OVERRIDE_D} is linked to ${RSPAMD_DMS_OVERRIDE_D}, but not if
+  #
+  # 1. ${RSPAMD_OVERRIDE_D} has already been linked to ${RSPAMD_DMS_OVERRIDE_D}
+  # 2. ${RSPAMD_OVERRIDE_D} has contents already
+  #
+  # If 1. is true, then we're good since DMS' default setup linked the directory already and we will save
+  # a persisted location in every case. If 1. is false, 2. should be false as well since by the default,
+  # ${RSPAMD_OVERRIDE_D} has not contents - we're good as well. What should logically never happen is
+  # that 1. is false but 2. is true; this case is caught nevertheless and a warning is emitted.
+  if [[ ! -h "${RSPAMD_OVERRIDE_D}" ]]; then
+    if rmdir "${RSPAMD_OVERRIDE_D}" &>/dev/null; then
+      ln -s "${RSPAMD_DMS_OVERRIDE_D}" "${RSPAMD_OVERRIDE_D}"
+    else
+      _log 'warn' "Could not link '${RSPAMD_OVERRIDE_D}' to '${RSPAMD_DMS_OVERRIDE_D}' (as '${RSPAMD_OVERRIDE_D}' does not appear to be empty, which is unexpected) - you will need to restart DMS for changes to take effect"
+    fi
+  fi
 }
 
 function _create_keys() {

--- a/target/bin/rspamd-dkim
+++ b/target/bin/rspamd-dkim
@@ -138,24 +138,36 @@ function _parse_arguments() {
     shift 2
   done
 
+  return 0
+}
+
+function _preflight_checks() {
   if [[ ${KEYTYPE} == 'ed25519' ]] && [[ ${KEYSIZE} -ne 2048 ]]; then
     _exit_with_error "Chosen keytype does not accept the 'keysize' argument"
   fi
 
-  return 0
+  if [[ ! -d /tmp/docker-mailserver ]]; then
+    _log 'warn' "The directory '/tmp/docker-mailserver' does not seem to be mounted by a volume - the Rspamd (DKIM) configuration will not be persisted"
+  fi
+
+  # Note: Variables not marked with `local` are used
+  # in other functions (after this function was called).
+  # Also keep in sync with: target/scripts/startup/setup.d/security/rspamd.sh:__rspamd__run_early_setup_and_checks
+  local RSPAMD_DMS_D='/tmp/docker-mailserver/rspamd'
+  RSPAMD_DMS_DKIM_D="${RSPAMD_DMS_D}/dkim"
+  RSPAMD_DMS_OVERRIDE_D="${RSPAMD_DMS_D}/override.d"
+
+  mkdir -p "${RSPAMD_DMS_DKIM_D}" "${RSPAMD_DMS_OVERRIDE_D}"
+  chown _rspamd:_rspamd "${RSPAMD_DMS_DKIM_D}"
 }
 
 function _create_keys() {
-  # Note: Variables not marked with `local` are used
-  # in other functions (after this function was called).
-  BASE_DIR='/tmp/docker-mailserver/rspamd/dkim'
-
   if [[ ${KEYTYPE} == 'rsa' ]]; then
-    local BASE_FILE_NAME="${BASE_DIR}/${KEYTYPE}-${KEYSIZE}-${SELECTOR}-${DOMAIN}"
+    local BASE_FILE_NAME="${RSPAMD_DMS_DKIM_D}/${KEYTYPE}-${KEYSIZE}-${SELECTOR}-${DOMAIN}"
     KEYTYPE_OPTIONS=('-b' "${KEYSIZE}")
     _log 'info' "Creating DKIM keys of type '${KEYTYPE}' and length '${KEYSIZE}' with selector '${SELECTOR}' for domain '${DOMAIN}'"
   else
-    local BASE_FILE_NAME="${BASE_DIR}/${KEYTYPE}-${SELECTOR}-${DOMAIN}"
+    local BASE_FILE_NAME="${RSPAMD_DMS_DKIM_D}/${KEYTYPE}-${SELECTOR}-${DOMAIN}"
     KEYTYPE_OPTIONS=('-t' "${KEYTYPE}")
     _log 'info' "Creating DKIM keys of type '${KEYTYPE}' with selector '${SELECTOR}' for domain '${DOMAIN}'"
   fi
@@ -163,9 +175,6 @@ function _create_keys() {
   PUBLIC_KEY_FILE="${BASE_FILE_NAME}.public.txt"
   PUBLIC_KEY_DNS_FILE="${BASE_FILE_NAME}.public.dns.txt"
   PRIVATE_KEY_FILE="${BASE_FILE_NAME}.private.txt"
-
-  mkdir -p "${BASE_DIR}"
-  chown _rspamd:_rspamd "${BASE_DIR}"
 
   # shellcheck disable=SC2310
   if __do_as_rspamd_user rspamadm \
@@ -186,8 +195,8 @@ function _create_keys() {
 
 function _check_permissions() {
   # shellcheck disable=SC2310
-  if ! __do_as_rspamd_user ls "${BASE_DIR}" >/dev/null; then
-    _log 'warn' "The Rspamd user ('_rspamd') seems to be unable to list files in the keys directory ('${BASE_DIR}') - Rspamd may experience permission errors later"
+  if ! __do_as_rspamd_user ls "${RSPAMD_DMS_DKIM_D}" >/dev/null; then
+    _log 'warn' "The Rspamd user ('_rspamd') seems to be unable to list files in the keys directory ('${RSPAMD_DMS_DKIM_D}') - Rspamd may experience permission errors later"
   elif ! __do_as_rspamd_user cat "${PRIVATE_KEY_FILE}" >/dev/null; then
     _log 'warn' "The Rspamd user ('_rspamd') seems to be unable to read the private key file - Rspamd may experience permission errors later"
   else
@@ -196,11 +205,11 @@ function _check_permissions() {
 }
 
 function _setup_default_signing_conf() {
-  local DEFAULT_CONFIG_FILE='/etc/rspamd/override.d/dkim_signing.conf'
+  local DEFAULT_CONFIG_FILE="${RSPAMD_DMS_OVERRIDE_D}/dkim_signing.conf"
   if [[ -f ${DEFAULT_CONFIG_FILE} ]]; then
     _log 'debug' "'${DEFAULT_CONFIG_FILE}' exists, not supplying a default"
   else
-    _log 'info' "Supplying a default configuration ('${DEFAULT_CONFIG_FILE}')"
+    _log 'info' "Supplying a default configuration (to '${DEFAULT_CONFIG_FILE}')"
     cat >"${DEFAULT_CONFIG_FILE}" << EOF
 # documentation: https://rspamd.com/doc/modules/dkim_signing.html
 
@@ -254,6 +263,7 @@ function _final_steps() {
 _obtain_hostname_and_domainname
 _require_n_parameters_or_print_usage 0 "${@}"
 _parse_arguments "${@}"
+_preflight_checks
 _create_keys
 _check_permissions
 _setup_default_signing_conf

--- a/target/scripts/startup/setup.d/security/rspamd.sh
+++ b/target/scripts/startup/setup.d/security/rspamd.sh
@@ -82,6 +82,7 @@ function __rspamd__run_early_setup_and_checks() {
       ln -s "${RSPAMD_DMS_OVERRIDE_D}" "${RSPAMD_OVERRIDE_D}"
     else
       __rspamd__log 'warn' "Could not remove '${RSPAMD_OVERRIDE_D}' (not empty?; not a directory?; did you restart properly?) - not linking '${RSPAMD_DMS_OVERRIDE_D}'"
+      __rspamd__log 'warn' "Note that using '${RSPAMD_DMS_OVERRIDE_D}' and placing files manually in '${RSPAMD_OVERRIDE_D}' is not supported"
     fi
   fi
 

--- a/target/scripts/startup/setup.d/security/rspamd.sh
+++ b/target/scripts/startup/setup.d/security/rspamd.sh
@@ -70,7 +70,7 @@ function __rspamd__run_early_setup_and_checks() {
   readonly RSPAMD_OVERRIDE_D='/etc/rspamd/override.d'
   readonly RSPAMD_DMS_D='/tmp/docker-mailserver/rspamd'
 
-  local RSPAMD_DMS_OVERRIDE_D="${RSPAMD_DMS_D}/override.d/"
+  local RSPAMD_DMS_OVERRIDE_D="${RSPAMD_DMS_D}/override.d"
   readonly RSPAMD_DMS_OVERRIDE_D
 
   mkdir -p /var/lib/rspamd/

--- a/test/tests/parallel/set1/spam_virus/rspamd_dkim.bats
+++ b/test/tests/parallel/set1/spam_virus/rspamd_dkim.bats
@@ -4,8 +4,8 @@ load "${REPOSITORY_ROOT}/test/helper/setup"
 BATS_TEST_NAME_PREFIX='[Rspamd] (DKIM) '
 CONTAINER_NAME='dms-test_rspamd-dkim'
 
-DOMAIN_NAME='fixed.com'
-SIGNING_CONF_FILE='/etc/rspamd/override.d/dkim_signing.conf'
+DOMAIN_NAME='example.test'
+SIGNING_CONF_FILE='/tmp/docker-mailserver/rspamd/override.d/dkim_signing.conf'
 
 function setup_file() {
   _init_with_defaults
@@ -59,7 +59,7 @@ function teardown_file() { _default_teardown ; }
   __create_key
   assert_success
   __log_is_free_of_warnings_and_errors
-  assert_output --partial "Supplying a default configuration ('${SIGNING_CONF_FILE}')"
+  assert_output --partial "Supplying a default configuration (to '${SIGNING_CONF_FILE}')"
   refute_output --partial "'${SIGNING_CONF_FILE}' exists, not supplying a default"
   assert_output --partial "Finished DKIM key creation"
   _run_in_container_bash "[[ -f ${SIGNING_CONF_FILE} ]]"


### PR DESCRIPTION
# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->

Instead of using `/etc/rspamd/override.d/dkim_signing.conf`, we will now be using `/tmp/docker-mailserver/rspamd/override.d/dkim_signing.conf`. The new location is persisted (and linked again during startup) and hence better suited.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #3593

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
