### PR TITLE
docs(bin/setup): Add an example for an alias with multiple recipients

### DIFF
--- a/target/bin/addalias
+++ b/target/bin/addalias
@@ -33,7 +33,7 @@ ${ORANGE}EXAMPLES${RESET}
     ${LWHITE}./setup.sh alias add alias@example.com recipient@example.com${RESET}
         Add the alias 'alias@example.com' for the mail account 'recipient@example.com'.
 
-    ${LWHITE}./setup.sh alias add alias@example.com "recipient@example.com, another-recipient@example.com"${RESET}
+    ${LWHITE}./setup.sh alias add alias@example.com 'recipient@example.com, another-recipient@example.com'${RESET}
         Multiple recipients are separated by comma.
 
 ${ORANGE}EXIT STATUS${RESET}

--- a/target/bin/addalias
+++ b/target/bin/addalias
@@ -33,6 +33,9 @@ ${ORANGE}EXAMPLES${RESET}
     ${LWHITE}./setup.sh alias add alias@example.com recipient@example.com${RESET}
         Add the alias 'alias@example.com' for the mail account 'recipient@example.com'.
 
+    ${LWHITE}./setup.sh alias add alias2@example.com "tgt1@example.com, tgt2@example.com"${RESET}
+        Multiple recipients are separated by comma.
+
 ${ORANGE}EXIT STATUS${RESET}
     Exit status is 0 if command was successful. If wrong arguments are provided
     or arguments contain errors, the script will exit early with exit status 1.

--- a/target/bin/addalias
+++ b/target/bin/addalias
@@ -33,7 +33,7 @@ ${ORANGE}EXAMPLES${RESET}
     ${LWHITE}./setup.sh alias add alias@example.com recipient@example.com${RESET}
         Add the alias 'alias@example.com' for the mail account 'recipient@example.com'.
 
-    ${LWHITE}./setup.sh alias add alias2@example.com "tgt1@example.com, tgt2@example.com"${RESET}
+    ${LWHITE}./setup.sh alias add alias@example.com "recipient@example.com, another-recipient@example.com"${RESET}
         Multiple recipients are separated by comma.
 
 ${ORANGE}EXIT STATUS${RESET}


### PR DESCRIPTION
Small documentation improvement as there are different common mechanisms for this kind of action.