### PR TITLE
docs: Clarify default for ENV `FETCHMAIL_PARALLEL`

### DIFF
--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -578,7 +578,9 @@ Note: activate this only if you are confident in your bayes database for identif
 ##### FETCHMAIL_PARALLEL
 
 - **0** => `fetchmail` runs with a single config file `/etc/fetchmailrc`
-- 1 => `/etc/fetchmailrc` is split per poll entry. For every poll entry a separate fetchmail instance is started to allow having multiple imap idle configurations defined.
+- 1 => `/etc/fetchmailrc` is split per poll entry. For every poll entry a separate fetchmail instance is started to [allow having multiple imap idle connections per server][fetchmail-imap-workaround] (_when poll entries reference the same IMAP server_).
+
+[fetchmail-imap-workaround]: https://otremba.net/wiki/Fetchmail_(Debian)#Immediate_Download_via_IMAP_IDLE
 
 Note: The defaults of your fetchmailrc file need to be at the top of the file. Otherwise it won't be added correctly to all separate `fetchmail` instances.
 #### Getmail

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -578,7 +578,7 @@ Note: activate this only if you are confident in your bayes database for identif
 ##### FETCHMAIL_PARALLEL
 
 - **0** => `fetchmail` runs with a single config file `/etc/fetchmailrc`
-- 1 => `/etc/fetchmailrc` is split per poll entry. For every poll entry a separate fetchmail instance is started  to allow having multiple imap idle configurations defined.
+- 1 => `/etc/fetchmailrc` is split per poll entry. For every poll entry a separate fetchmail instance is started to allow having multiple imap idle configurations defined.
 
 Note: The defaults of your fetchmailrc file need to be at the top of the file. Otherwise it won't be added correctly to all separate `fetchmail` instances.
 #### Getmail

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -578,7 +578,7 @@ Note: activate this only if you are confident in your bayes database for identif
 ##### FETCHMAIL_PARALLEL
 
   **0** => `fetchmail` runs with a single config file `/etc/fetchmailrc`
-  **1** => `/etc/fetchmailrc` is split per poll entry. For every poll entry a separate fetchmail instance is started  to allow having multiple imap idle configurations defined.
+  1 => `/etc/fetchmailrc` is split per poll entry. For every poll entry a separate fetchmail instance is started  to allow having multiple imap idle configurations defined.
 
 Note: The defaults of your fetchmailrc file need to be at the top of the file. Otherwise it won't be added correctly to all separate `fetchmail` instances.
 #### Getmail

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -577,8 +577,8 @@ Note: activate this only if you are confident in your bayes database for identif
 
 ##### FETCHMAIL_PARALLEL
 
-  **0** => `fetchmail` runs with a single config file `/etc/fetchmailrc`
-  1 => `/etc/fetchmailrc` is split per poll entry. For every poll entry a separate fetchmail instance is started  to allow having multiple imap idle configurations defined.
+- **0** => `fetchmail` runs with a single config file `/etc/fetchmailrc`
+- 1 => `/etc/fetchmailrc` is split per poll entry. For every poll entry a separate fetchmail instance is started  to allow having multiple imap idle configurations defined.
 
 Note: The defaults of your fetchmailrc file need to be at the top of the file. Otherwise it won't be added correctly to all separate `fetchmail` instances.
 #### Getmail

--- a/mailserver.env
+++ b/mailserver.env
@@ -397,6 +397,8 @@ ENABLE_FETCHMAIL=0
 
 # The interval to fetch mail in seconds
 FETCHMAIL_POLL=300
+# Workaround IMAP bug by splitting fetchmail.cf per poll entry
+FETCHMAIL_PARALLEL=0
 
 # Enable or disable `getmail`.
 #

--- a/mailserver.env
+++ b/mailserver.env
@@ -397,7 +397,9 @@ ENABLE_FETCHMAIL=0
 
 # The interval to fetch mail in seconds
 FETCHMAIL_POLL=300
-# Workaround IMAP bug by splitting fetchmail.cf per poll entry
+# Use multiple fetchmail instances (1 per poll entry in fetchmail.cf)
+# Supports multiple IMAP IDLE connections when a server is used across multiple poll entries
+# https://otremba.net/wiki/Fetchmail_(Debian)#Immediate_Download_via_IMAP_IDLE
 FETCHMAIL_PARALLEL=0
 
 # Enable or disable `getmail`.


### PR DESCRIPTION
Make this easier to find when brosing the default environment. Adjust documentation to properly mark the actual default value.