### PR TITLE
docs: Fix typo "adkim=4" at DMARC section

### DIFF
--- a/v12.1/config/best-practices/dkim_dmarc_spf/index.html
+++ b/v12.1/config/best-practices/dkim_dmarc_spf/index.html
@@ -1818,7 +1818,7 @@
 <p>With DMS, DMARC is pre-configured out of the box. You may disable extra and excessive DMARC checks when using Rspamd via <code>ENABLE_OPENDMARC=0</code>.</p>
 <p>The only thing you need to do in order to enable DMARC on a "DNS-level" is to add new <code>TXT</code>. In contrast to <a href="#dkim">DKIM</a>, DMARC DNS entries do not require any keys, but merely setting the <a href="https://github.com/internetstandards/toolbox-wiki/blob/master/DMARC-how-to.md#overview-of-dmarc-configuration-tags">configuration values</a>. You can either handcraft the entry by yourself or use one of available generators (like <a href="https://dmarcguide.globalcyberalliance.org">this one</a>).</p>
 <p>Typically something like this should be good to start with:</p>
-<div class="highlight"><pre><span></span><code>_dmarc.example.com. IN TXT &quot;v=DMARC1; p=none; sp=none; fo=0; adkim=4; aspf=r; pct=100; rf=afrf; ri=86400; rua=mailto:dmarc.report@example.com; ruf=mailto:dmarc.report@example.com&quot;
+<div class="highlight"><pre><span></span><code>_dmarc.example.com. IN TXT &quot;v=DMARC1; p=none; sp=none; fo=0; adkim=r; aspf=r; pct=100; rf=afrf; ri=86400; rua=mailto:dmarc.report@example.com; ruf=mailto:dmarc.report@example.com&quot;
 </code></pre></div>
 <p>Or a bit more strict policies (<em>mind <code>p=quarantine</code> and <code>sp=quarantine</code></em>):</p>
 <div class="highlight"><pre><span></span><code>_dmarc.example.com. IN TXT &quot;v=DMARC1; p=quarantine; sp=quarantine; fo=0; adkim=r; aspf=r; pct=100; rf=afrf; ri=86400; rua=mailto:dmarc.report@example.com; ruf=mailto:dmarc.report@example.com&quot;


### PR DESCRIPTION
# Description
There is invalid value "4" of adkim at line 1821 in GitHub docs.
https://github.com/docker-mailserver/docker-mailserver/blob/1d14c72445bf5643b16f6c620e3dbd44ede6562b/v12.1/config/best-practices/dkim_dmarc_spf/index.html#L1818-L1825

I have changed `adkim=4` to `adkim=r`

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->

<!-- Link the issue which will be fixed (if any) here: -->

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes