### PR TITLE
fix: Drop special bits from Postfix `maildrop/` and `public/` directory permissions

### DIFF
--- a/docs/content/config/advanced/kubernetes.md
+++ b/docs/content/config/advanced/kubernetes.md
@@ -190,7 +190,7 @@ spec:
           imagePullPolicy: IfNotPresent
 
           securityContext:
-            allowPrivilegeEscalation: false
+            allowPrivilegeEscalation: true # required for SUID/SGID to work
             readOnlyRootFilesystem: false
             runAsUser: 0
             runAsGroup: 0

--- a/docs/content/config/advanced/kubernetes.md
+++ b/docs/content/config/advanced/kubernetes.md
@@ -190,7 +190,10 @@ spec:
           imagePullPolicy: IfNotPresent
 
           securityContext:
-            allowPrivilegeEscalation: true # required for SUID/SGID to work
+            # Required to support SGID via `postdrop` executable
+            # in `/var/mail-state` for Postfix (maildrop + public dirs):
+            # https://github.com/docker-mailserver/docker-mailserver/pull/3625
+            allowPrivilegeEscalation: true
             readOnlyRootFilesystem: false
             runAsUser: 0
             runAsGroup: 0

--- a/target/scripts/startup/setup.d/mail_state.sh
+++ b/target/scripts/startup/setup.d/mail_state.sh
@@ -105,10 +105,10 @@ function _setup_save_states() {
     # These two require the postdrop(103) group:
     chgrp -R postdrop "${STATEDIR}"/spool-postfix/{maildrop,public}
 
-    # After changing the group, special bits (set-gid, sticky) may be stripped, restore them:
-    # Ref: https://github.com/docker-mailserver/docker-mailserver/pull/3149#issuecomment-1454981309
-    chmod 1730 "${STATEDIR}/spool-postfix/maildrop"
-    chmod 2710 "${STATEDIR}/spool-postfix/public"
+    # These permissions rely on the `postdrop` binary (and alike) having proper SUID/SGID bits set.
+    # Ref: https://github.com/docker-mailserver/docker-mailserver/issues/3619
+    chmod 730 "${STATEDIR}/spool-postfix/maildrop"
+    chmod 710 "${STATEDIR}/spool-postfix/public"
   elif [[ ${ONE_DIR} -eq 1 ]]; then
     _log 'warn' "'ONE_DIR=1' but no volume was mounted to '${STATEDIR}'"
   else

--- a/target/scripts/startup/setup.d/mail_state.sh
+++ b/target/scripts/startup/setup.d/mail_state.sh
@@ -105,8 +105,8 @@ function _setup_save_states() {
     # These two require the postdrop(103) group:
     chgrp -R postdrop "${STATEDIR}"/spool-postfix/{maildrop,public}
 
-    # These permissions rely on the `postdrop` binary (and alike) having proper SUID/SGID bits set.
-    # Ref: https://github.com/docker-mailserver/docker-mailserver/issues/3619
+    # These permissions rely on the `postdrop` binary having the SGID bit set.
+    # Ref: https://github.com/docker-mailserver/docker-mailserver/pull/3625
     chmod 730 "${STATEDIR}/spool-postfix/maildrop"
     chmod 710 "${STATEDIR}/spool-postfix/public"
   elif [[ ${ONE_DIR} -eq 1 ]]; then


### PR DESCRIPTION
# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->

1. Adjusts the K8s documentation, which requires `allowPrivilegeEscalation: true` as it turns out
2. Adjusts permsissions on `/var/spool/postfix/{maildrop,public}`. This is more tricky, but #3619 provides good insights. In short, we do not seem to require SUID/SGID/sticky bits on these directories as the binaries that place files in these directories already have the proper SGID bits set on them.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #3619

CC @innotecsol

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change is a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
