### PR TITLE
Rspamd: add check for DKIM private key files' permissions

### DIFF
--- a/target/bin/rspamd-dkim
+++ b/target/bin/rspamd-dkim
@@ -62,13 +62,6 @@ ${ORANGE}EXIT STATUS${RESET}
 "
 }
 
-function __do_as_rspamd_user() {
-  local COMMAND=${1:?Command required when using __do_as_rspamd_user}
-  _log 'trace' "Running '${*}' as user '_rspamd' now"
-  shift 1
-  su -l '_rspamd' -s "$(command -v "${COMMAND}")" -- "${@}"
-}
-
 function _parse_arguments() {
   FORCE=0
   KEYTYPE='rsa'

--- a/target/scripts/helpers/rspamd.sh
+++ b/target/scripts/helpers/rspamd.sh
@@ -6,10 +6,8 @@
 # in case you want to have correct permissions on newly created files or if
 # you want to check whether Rspamd can perform a specific action.
 function __do_as_rspamd_user() {
-  local COMMAND=${1:?Command required when using __do_as_rspamd_user}
   _log 'trace' "Running '${*}' as user '_rspamd'"
-  shift 1
-  su -l '_rspamd' -s "$(command -v "${COMMAND}")" -- "${@}"
+  su _rspamd -s /bin/bash -c "${*}"
 }
 
 # Calling this function brings common Rspamd-related environment variables

--- a/target/scripts/helpers/rspamd.sh
+++ b/target/scripts/helpers/rspamd.sh
@@ -2,6 +2,13 @@
 
 # shellcheck disable=SC2034 # VAR appears unused.
 
+function __do_as_rspamd_user() {
+  local COMMAND=${1:?Command required when using __do_as_rspamd_user}
+  _log 'trace' "Running '${*}' as user '_rspamd' now"
+  shift 1
+  su -l '_rspamd' -s "$(command -v "${COMMAND}")" -- "${@}"
+}
+
 function _rspamd_get_envs() {
   readonly RSPAMD_LOCAL_D='/etc/rspamd/local.d'
   readonly RSPAMD_OVERRIDE_D='/etc/rspamd/override.d'

--- a/target/scripts/helpers/rspamd.sh
+++ b/target/scripts/helpers/rspamd.sh
@@ -7,14 +7,14 @@
 # you want to check whether Rspamd can perform a specific action.
 function __do_as_rspamd_user() {
   local COMMAND=${1:?Command required when using __do_as_rspamd_user}
-  _log 'trace' "Running '${*}' as user '_rspamd' now"
+  _log 'trace' "Running '${*}' as user '_rspamd'"
   shift 1
   su -l '_rspamd' -s "$(command -v "${COMMAND}")" -- "${@}"
 }
 
 # Calling this function brings common Rspamd-related environment variables
 # into the current context. The environment variables are `readonly`, i.e.
-# the cannot be modified. Use this function when you require common directory
+# they cannot be modified. Use this function when you require common directory
 # names, file names, etc.
 function _rspamd_get_envs() {
   readonly RSPAMD_LOCAL_D='/etc/rspamd/local.d'

--- a/target/scripts/helpers/rspamd.sh
+++ b/target/scripts/helpers/rspamd.sh
@@ -2,6 +2,9 @@
 
 # shellcheck disable=SC2034 # VAR appears unused.
 
+# Perform a specific command as the Rspamd user (`_rspamd`). This is useful
+# in case you want to have correct permissions on newly created files or if
+# you want to check whether Rspamd can perform a specific action.
 function __do_as_rspamd_user() {
   local COMMAND=${1:?Command required when using __do_as_rspamd_user}
   _log 'trace' "Running '${*}' as user '_rspamd' now"
@@ -9,6 +12,10 @@ function __do_as_rspamd_user() {
   su -l '_rspamd' -s "$(command -v "${COMMAND}")" -- "${@}"
 }
 
+# Calling this function brings common Rspamd-related environment variables
+# into the current context. The environment variables are `readonly`, i.e.
+# the cannot be modified. Use this function when you require common directory
+# names, file names, etc.
 function _rspamd_get_envs() {
   readonly RSPAMD_LOCAL_D='/etc/rspamd/local.d'
   readonly RSPAMD_OVERRIDE_D='/etc/rspamd/override.d'

--- a/target/scripts/startup/setup.d/security/rspamd.sh
+++ b/target/scripts/startup/setup.d/security/rspamd.sh
@@ -23,7 +23,7 @@ function _setup_rspamd() {
     __rspamd__setup_check_authenticated
     _rspamd_handle_user_modules_adjustments   # must run last
 
-    # only checks, no setup from here
+    # only performing checks, no further setup handled from here onwards
     __rspamd__check_dkim_permissions
 
     __rspamd__log 'trace' '----------  Setup finished  ----------'
@@ -304,9 +304,9 @@ function __rspamd__setup_check_authenticated() {
   fi
 }
 
-# This function performs a simple check: go through DKIM configuration files, acquire all
-# private key file locations and check whether they exist and whether they can be
-# accesses by Rspamd.
+# This function performs a simple check: go through DKIM configuration files, acquire
+# all private key file locations and check whether they exist and whether they can be
+# accessed by Rspamd.
 function __rspamd__check_dkim_permissions() {
   local DKIM_CONF_FILES DKIM_KEY_FILES
   [[ -f ${RSPAMD_LOCAL_D}/dkim_signing.conf ]] && DKIM_CONF_FILES+=("${RSPAMD_LOCAL_D}/dkim_signing.conf")
@@ -322,11 +322,11 @@ function __rspamd__check_dkim_permissions() {
 
   for FILE in "${DKIM_KEY_FILES[@]}"; do
     if [[ -f ${FILE} ]]; then
-      __rspamd__log 'trace' "Checking DKIM file '${FILE}' now"
+      __rspamd__log 'trace' "Checking DKIM file '${FILE}'"
       if __do_as_rspamd_user cat "${FILE}" &>/dev/null; then
         __rspamd__log 'trace' "DKIM file '${FILE}' permissions and ownership appear correct"
       else
-        __rspamd__log 'warn' "Rspamd DKIM private key file '${FILE}' does not appear to have correct permissions/ownership for Rspamd to use it - please correct permissions/ownership"
+        __rspamd__log 'warn' "Rspamd DKIM private key file '${FILE}' does not appear to have correct permissions/ownership for Rspamd to use it"
       fi
     else
       __rspamd__log 'warn' "Rspamd DKIM private key file '${FILE}' is configured for usage, but does not appear to exist"

--- a/target/scripts/startup/setup.d/security/rspamd.sh
+++ b/target/scripts/startup/setup.d/security/rspamd.sh
@@ -283,6 +283,12 @@ function __rspamd__setup_hfilter_group() {
   fi
 }
 
+# If 'RSPAMD_CHECK_AUTHENTICATED' is enabled, then content checks for all users, i.e.
+# also for authenticated users, are performed.
+#
+# The default that DMS ships does not check authenticated users. In case the checks are
+# enabled, this function will remove the part of the Rspamd configuration that disables
+# checks for authenticated users.
 function __rspamd__setup_check_authenticated() {
   local MODULE_FILE="${RSPAMD_LOCAL_D}/settings.conf"
   readonly MODULE_FILE
@@ -297,6 +303,7 @@ function __rspamd__setup_check_authenticated() {
       "${MODULE_FILE}"
   fi
 }
+
 # This function performs a simple check: go through DKIM configuration files, acquire all
 # private key file locations and check whether they exist and whether they can be
 # accesses by Rspamd.


### PR DESCRIPTION
# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->

The newly added function `__rspamd__check_dkim_permissions` performs a check on DKIM private key files. This is useful to prevent issues like #3621 in the future. The function is deliberately kept simple and may not catch every single misconfiguration in terms of permissions and ownership, but it should be quite accurate.

Please note that the Rspamd setup does NOT change at all, and the checks will not abort the setup in case they fail. A simple warning is emmited.

Reviewing commit-by-commit is advised.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #3621

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes