### PR TITLE
logs: improve format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,22 @@ clean: ALWAYS_RUN
 # --- Tests  ------------------------------------
 # -----------------------------------------------
 
+run-local-test: ALWAYS_RUN
+	docker run --rm -it \
+		--env OVERRIDE_HOSTNAME=mail.example.test \
+		--env LOG_LEVEL=trace \
+		--env POSTFIX_INET_PROTOCOLS=ipv4 \
+		--env DOVECOT_INET_PROTOCOLS=ipv4 \
+		--env ENABLE_RSPAMD=1 \
+		--env ENABLE_AMAVIS=0 \
+		--env ENABLE_CLAMAV=0 \
+		--env ENABLE_FAIL2BAN=0 \
+		--env ENABLE_OPENDMARC=0 \
+		--env ENABLE_OPENDKIM=0 \
+		--env ENABLE_POLICYD_SPF=0 \
+		--env TZ=Europe/Berlin \
+		mailserver-testing:ci
+
 tests: ALWAYS_RUN
 # See https://github.com/docker-mailserver/docker-mailserver/pull/2857#issuecomment-1312724303
 # on why `generate-accounts` is run before each set (TODO/FIXME)

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -7,7 +7,7 @@
 # shellcheck source=./helpers/index.sh
 source /usr/local/bin/helpers/index.sh
 
-_log_with_date 'debug' 'Starting changedetector'
+_log 'debug' 'Starting changedetector'
 
 # ATTENTION: Do not remove!
 # This script requires some environment variables to be properly set.
@@ -30,9 +30,9 @@ if [[ ! -f ${CHKSUM_FILE} ]]; then
   _exit_with_error "'${CHKSUM_FILE}' is missing" 0
 fi
 
-_log_with_date 'trace' "Using postmaster address '${POSTMASTER_ADDRESS}'"
+_log 'trace' "Using postmaster address '${POSTMASTER_ADDRESS}'"
 
-_log_with_date 'debug' "Changedetector is ready"
+_log 'debug' "Changedetector is ready"
 
 function _check_for_changes() {
   # get chksum and check it, no need to lock config yet
@@ -44,7 +44,7 @@ function _check_for_changes() {
   # 1 – files differ
   # 2 – inaccessible or missing argument
   if [[ ${?} -eq 1 ]]; then
-    _log_with_date 'info' 'Change detected'
+    _log 'info' 'Change detected'
     _create_lock # Shared config safety lock
 
     local CHANGED
@@ -55,14 +55,14 @@ function _check_for_changes() {
     _postfix_dovecot_changes
     _rspamd_changes
 
-    _log_with_date 'debug' 'Reloading services due to detected changes'
+    _log 'debug' 'Reloading services due to detected changes'
 
     [[ ${ENABLE_AMAVIS} -eq 1 ]] && _reload_amavis
     _reload_postfix
     [[ ${SMTP_ONLY} -ne 1 ]] && dovecot reload
 
     _remove_lock
-    _log_with_date 'debug' 'Completed handling of detected change'
+    _log 'debug' 'Completed handling of detected change'
 
     # mark changes as applied
     mv "${CHKSUM_FILE}.new" "${CHKSUM_FILE}"
@@ -106,7 +106,7 @@ function _postfix_dovecot_changes() {
   || [[ ${CHANGED} =~ ${DMS_DIR}/dovecot-quotas.cf   ]] \
   || [[ ${CHANGED} =~ ${DMS_DIR}/dovecot-masters.cf  ]]
   then
-    _log_with_date 'trace' 'Regenerating accounts (Dovecot + Postfix)'
+    _log 'trace' 'Regenerating accounts (Dovecot + Postfix)'
     [[ ${SMTP_ONLY} -ne 1 ]] && _create_accounts
   fi
 
@@ -120,7 +120,7 @@ function _postfix_dovecot_changes() {
   || [[ ${CHANGED} =~ ${DMS_DIR}/postfix-relaymap.cf      ]] \
   || [[ ${CHANGED} =~ ${DMS_DIR}/postfix-sasl-password.cf ]]
   then
-    _log_with_date 'trace' 'Regenerating relay config (Postfix)'
+    _log 'trace' 'Regenerating relay config (Postfix)'
     _rebuild_relayhost
   fi
 
@@ -133,7 +133,7 @@ function _postfix_dovecot_changes() {
   if [[ ${CHANGED} =~ ${DMS_DIR}/postfix-accounts.cf ]] \
   || [[ ${CHANGED} =~ ${DMS_DIR}/postfix-virtual.cf  ]]
   then
-    _log_with_date 'trace' 'Regenerating vhosts (Postfix)'
+    _log 'trace' 'Regenerating vhosts (Postfix)'
     _create_postfix_vhost
   fi
 
@@ -156,14 +156,14 @@ function _ssl_changes() {
     || [[ ${CHANGED} =~ ${SSL_ALT_CERT_PATH:-${REGEX_NEVER_MATCH}} ]] \
     || [[ ${CHANGED} =~ ${SSL_ALT_KEY_PATH:-${REGEX_NEVER_MATCH}} ]]
     then
-      _log_with_date 'debug' 'Manual certificates have changed - extracting certificates'
+      _log 'debug' 'Manual certificates have changed - extracting certificates'
       _setup_ssl
     fi
   # `acme.json` is only relevant to Traefik, and is where it stores the certificates it manages.
   # When a change is detected it's assumed to be a possible cert renewal that needs to be
   # extracted for `docker-mailserver` services to adjust to.
   elif [[ ${CHANGED} =~ /etc/letsencrypt/acme.json ]]; then
-    _log_with_date 'debug' "'/etc/letsencrypt/acme.json' has changed - extracting certificates"
+    _log 'debug' "'/etc/letsencrypt/acme.json' has changed - extracting certificates"
     _setup_ssl
 
     # Prevent an unnecessary change detection from the newly extracted cert files by updating their hashes in advance:
@@ -185,23 +185,23 @@ function _rspamd_changes() {
 
     # "${RSPAMD_DMS_D}/override.d"
     if [[ ${CHANGED} =~ ${RSPAMD_DMS_OVERRIDE_D}/.* ]]; then
-      _log_with_date 'trace' 'Rspamd - Copying configuration overrides'
+      _log 'trace' 'Rspamd - Copying configuration overrides'
       rm "${RSPAMD_OVERRIDE_D}"/*
       cp "${RSPAMD_DMS_OVERRIDE_D}"/* "${RSPAMD_OVERRIDE_D}"
     fi
 
     # "${RSPAMD_DMS_D}/custom-commands.conf"
     if [[ ${CHANGED} =~ ${RSPAMD_DMS_CUSTOM_COMMANDS_F} ]]; then
-      _log_with_date 'trace' 'Rspamd - Generating new configuration from custom commands'
+      _log 'trace' 'Rspamd - Generating new configuration from custom commands'
       _rspamd_handle_user_modules_adjustments
     fi
 
     # "${RSPAMD_DMS_D}/dkim"
     if [[ ${CHANGED} =~ ${RSPAMD_DMS_DKIM_D} ]]; then
-      _log_with_date 'trace' 'Rspamd - DKIM files updated'
+      _log 'trace' 'Rspamd - DKIM files updated'
     fi
 
-    _log_with_date 'debug' 'Rspamd configuration has changed - restarting service'
+    _log 'debug' 'Rspamd configuration has changed - restarting service'
     supervisorctl restart rspamd
   fi
 }

--- a/target/scripts/helpers/log.sh
+++ b/target/scripts/helpers/log.sh
@@ -104,11 +104,6 @@ function _log() {
   fi
 }
 
-# Like `_log` but adds a timestamp in front of the message.
-function _log_with_date() {
-  _log "${1}" "$(date '+%Y-%m-%d %H:%M:%S')  ${2}"
-}
-
 # Get the value of the environment variable LOG_LEVEL if
 # it is set. Otherwise, try to query the common environment
 # variables file. If this does not yield a value either,

--- a/target/scripts/update-check.sh
+++ b/target/scripts/update-check.sh
@@ -10,8 +10,8 @@ CHANGELOG_URL='https://github.com/docker-mailserver/docker-mailserver/blob/maste
 # check for correct syntax
 # number + suffix. suffix must be 's' for seconds, 'm' for minutes, 'h' for hours or 'd' for days.
 if [[ ! ${UPDATE_CHECK_INTERVAL} =~ ^[0-9]+[smhd]{1}$ ]]; then
-  _log_with_date 'warn' "Invalid 'UPDATE_CHECK_INTERVAL' value '${UPDATE_CHECK_INTERVAL}'"
-  _log_with_date 'warn' 'Falling back to daily update checks'
+  _log 'warn' "Invalid 'UPDATE_CHECK_INTERVAL' value '${UPDATE_CHECK_INTERVAL}'"
+  _log 'warn' 'Falling back to daily update checks'
   UPDATE_CHECK_INTERVAL='1d'
 fi
 
@@ -21,7 +21,7 @@ while true; do
 
   # did we get a valid response?
   if [[ ${LATEST} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    _log_with_date 'debug' 'Remote version information fetched'
+    _log 'debug' 'Remote version information fetched'
 
     # compare versions
     if dpkg --compare-versions "${VERSION}" lt "${LATEST}"; then
@@ -37,15 +37,15 @@ Latest  version: ${LATEST}
 Changelog: ${CHANGELOG_URL}
 EOF
 
-      _log_with_date 'info' "Update available [ ${VERSION} --> ${LATEST} ]"
+      _log 'info' "Update available [ ${VERSION} --> ${LATEST} ]"
 
       # only notify once
       echo "${MAIL}" | mail -s "Mailserver update available! [ ${VERSION} --> ${LATEST} ]" "${POSTMASTER_ADDRESS}" && exit 0
     else
-      _log_with_date 'info' 'No update available'
+      _log 'info' 'No update available'
     fi
   else
-    _log_with_date 'warn' 'Update check failed'
+    _log 'warn' 'Update check failed'
   fi
 
   # check again in 'UPDATE_CHECK_INTERVAL' time

--- a/test/tests/parallel/set1/spam_virus/rspamd_partly.bats
+++ b/test/tests/parallel/set1/spam_virus/rspamd_partly.bats
@@ -44,7 +44,7 @@ function teardown_file() { _default_teardown ; }
   run docker logs "${CONTAINER_NAME}"
   assert_success
   for SERVICE in 'Amavis/SA' 'OpenDKIM' 'OpenDMARC' 'policyd-spf'; do
-    assert_output --regexp ".*WARNING.*Running ${SERVICE} & Rspamd at the same time is discouraged"
+    assert_output --regexp ".*Running ${SERVICE} & Rspamd at the same time is discouraged"
   done
 }
 

--- a/test/tests/parallel/set1/tls/dhparams.bats
+++ b/test/tests/parallel/set1/tls/dhparams.bats
@@ -50,7 +50,7 @@ function teardown() { _default_teardown ; }
   # Should emit a warning:
   run docker logs "${CONTAINER_NAME}"
   assert_success
-  assert_output --partial '[ WARNING ]  Using self-generated dhparams is considered insecure - unless you know what you are doing, please remove'
+  assert_output --partial 'Using self-generated dhparams is considered insecure - unless you know what you are doing, please remove'
 }
 
 # Ensures the docker image services (Postfix and Dovecot) have the expected DH files:


### PR DESCRIPTION
# Description

This PR updates `log.sh` to add timestamps to all messages. Review commit by commit. The date command format string was taken [from here](https://unix.stackexchange.com/a/629504) where I searched for ISO8601 compliance.

Old format:

```txt
[  ERROR  ]  ndawkggdryg gydg ygdrrjdwjk
[ WARNING ]  adwdad ad  awdadawdaw
[   INF   ]  ndawkjdwjk
[  DEBUG  ]  da dadwadwda d aw
[  TRACE  ]  ndaw d adw da dd d dawkjdwjk
[  TRACE  ]  hdxhfdhfth fshfebhsjbf eh
[  DEBUG  ]  djaksdajdna nadjakw dakd awjkn
[  DEBUG  ]  danjdadaw
[  TRACE  ]  sads fshfebhsjbf eh
[  TRACE  ]  dgdht adwd eh
[  TRACE  ]  dadada  dadwddwadadwdaebhsjbf eh
[   INF   ]  dac dnajkd and akd jakwnd wjd nakjndwjdnak dwnjdajk
```

New format:

```txt
2023-11-21T16:40:14+01:00  ERROR  ndawkggdryg gydg ygdrrjdwjk
2023-11-21T16:40:14+01:00  WARN   adwdad ad  awdadawdaw
2023-11-21T16:40:14+01:00  INFO   ndawkjdwjk
2023-11-21T16:40:14+01:00  DEBUG  da dadwadwda d aw
2023-11-21T16:40:14+01:00  TRACE  ndaw d adw da dd d dawkjdwjk
2023-11-21T16:40:14+01:00  TRACE  hdxhfdhfth fshfebhsjbf eh
2023-11-21T16:40:14+01:00  DEBUG  djaksdajdna nadjakw dakd awjkn
2023-11-21T16:40:14+01:00  DEBUG  danjdadaw
2023-11-21T16:40:14+01:00  TRACE  sads fshfebhsjbf eh
2023-11-21T16:40:14+01:00  TRACE  dgdht adwd eh
2023-11-21T16:40:14+01:00  TRACE  dadada  dadwddwadadwdaebhsjbf eh
2023-11-21T16:40:14+01:00  INFO   dac dnajkd and akd jakwnd wjd nakjndwjdnak dwnjdajk
```

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
