### PR TITLE
ci: Linter EC should use `/check` as the mount path

### DIFF
--- a/test/linting/lint.sh
+++ b/test/linting/lint.sh
@@ -17,11 +17,14 @@ SHELLCHECK_VERSION='0.9.0'
 source "${REPOSITORY_ROOT}/target/scripts/helpers/log.sh"
 
 function _eclint() {
+  # `/check` is used instead of `/ci` as the mount path due to:
+  # https://github.com/editorconfig-checker/editorconfig-checker/issues/268#issuecomment-1826200253
+  # `.ecrc.json` continues to explicitly ignores the `.git/` path to avoid any potential confusion
   if docker run --rm --tty \
-    --volume "${REPOSITORY_ROOT}:/ci:ro" \
-    --workdir "/ci" \
+    --volume "${REPOSITORY_ROOT}:/check:ro" \
+    --workdir "/check" \
     --name dms-test_eclint \
-    "mstruebing/editorconfig-checker:${ECLINT_VERSION}" ec -config "/ci/test/linting/.ecrc.json"
+    "mstruebing/editorconfig-checker:${ECLINT_VERSION}" ec -config "/check/test/linting/.ecrc.json"
   then
     _log 'info' 'ECLint succeeded'
   else


### PR DESCRIPTION
# Description

This internal container path of the image has been allowed as an exception for `git` to avoid a safety check, that would otherwise  cause [EC to fail detection for `git`](https://github.com/editorconfig-checker/editorconfig-checker/issues/268#issuecomment-1826200253), triggering fallback logic.

This shouldn't have any real impact on our CI, which [already has an explicit ignore for `.git/`](https://github.com/docker-mailserver/docker-mailserver/blob/2a716cf4a4e0eec9ec12d99fcc6e9c5e625a63f8/test/linting/.ecrc.json#L6). Just a change to better align with upstream documentation and include some context via comments for maintainers 👍 
