### PR TITLE
bug fix: remove `exit 0` from `update-check.sh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file. The format 
 
 > **Note**: Changes and additions listed here are contained in the `:edge` image tag. These changes may not be as stable as released changes.
 
+- fixe check update mail loop when update is availlable
+
+
 ## [v13.0.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.0.0)
 
 ### Breaking

--- a/target/scripts/update-check.sh
+++ b/target/scripts/update-check.sh
@@ -40,7 +40,7 @@ EOF
       _log_with_date 'info' "Update available [ ${VERSION} --> ${LATEST} ]"
 
       # only notify once
-      echo "${MAIL}" | mail -s "Mailserver update available! [ ${VERSION} --> ${LATEST} ]" "${POSTMASTER_ADDRESS}" && exit 0
+      echo "${MAIL}" | mail -s "Mailserver update available! [ ${VERSION} --> ${LATEST} ]" "${POSTMASTER_ADDRESS}"
     else
       _log_with_date 'info' 'No update available'
     fi


### PR DESCRIPTION
# Description


since release 13.0.0 commit my mailbox is flood by update mail.  I think when script is exit supervisord launch it again

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [X] If necessary I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] **I have added information about changes made in this PR to `CHANGELOG.md`**
