### PR TITLE
bug fix: push `:edge` when `VERSION` is updated as well

### DIFF
--- a/.github/workflows/default_on_push.yml
+++ b/.github/workflows/default_on_push.yml
@@ -11,6 +11,7 @@ on:
       - .gitmodules
       - Dockerfile
       - setup.sh
+      - VERSION # also update :edge when a release happens
     tags:
       - '*.*.*'
 


### PR DESCRIPTION
# Description

Previously, we did not run the workflow on push on `master` when a release happened because the push on master is guarded by a check on which files were changed.

With this change, I added `VERSION` to the list of files to consider when updating `:edge`.

<!-- Link the issue which will be fixed (if any) here: -->
Superseeds #3659

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas