### PR TITLE
fix: `update-check.sh` should query GH Releases

### DIFF
--- a/.github/workflows/default_on_push.yml
+++ b/.github/workflows/default_on_push.yml
@@ -11,7 +11,6 @@ on:
       - .gitmodules
       - Dockerfile
       - setup.sh
-      - VERSION # also update :edge when a release happens
     tags:
       - '*.*.*'
 

--- a/.github/workflows/generic_publish.yml
+++ b/.github/workflows/generic_publish.yml
@@ -66,18 +66,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 'Acquire the image version'
-        id: get-version
-        shell: bash
-        run: echo "version=$(<VERSION)" >>"${GITHUB_OUTPUT}"
-
       - name: 'Build and publish images'
         uses: docker/build-push-action@v5.1.0
         with:
           context: .
           build-args: |
+            DMS_RELEASE=${{ github.ref_type == 'tag' && github.ref_name || 'edge' }}
             VCS_REVISION=${{ github.sha }}
-            VCS_VERSION=${{ steps.get-version.outputs.version }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.prep.outputs.tags }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project will be documented in this file. The format 
 
 > **Note**: Changes and additions listed here are contained in the `:edge` image tag. These changes may not be as stable as released changes.
 
+### Added
+
+
+
+### Updates
+
+
+
+### Fixed
+
+- **Internal:**
+  - The update check service now queries the latest GH release for a version tag instead of a `VERSION` file from the repo.
+
 ## [v13.0.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.0.0)
 
 ### Breaking

--- a/Dockerfile
+++ b/Dockerfile
@@ -295,8 +295,8 @@ COPY target/scripts/startup/setup.d /usr/local/bin/setup.d
 #
 
 FROM stage-main AS stage-final
+ARG DMS_RELEASE=edge
 ARG VCS_REVISION=unknown
-ARG VCS_VERSION=edge
 
 WORKDIR /
 EXPOSE 25 587 143 465 993 110 995 4190
@@ -327,4 +327,5 @@ LABEL org.opencontainers.image.source="https://github.com/docker-mailserver/dock
 # ARG invalidates cache when it is used by a layer (implicitly affects RUN)
 # Thus to maximize cache, keep these lines last:
 LABEL org.opencontainers.image.revision=${VCS_REVISION}
-LABEL org.opencontainers.image.version=${VCS_VERSION}
+LABEL org.opencontainers.image.version=${DMS_RELEASE}
+ENV DMS_RELEASE=${DMS_RELEASE}

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,7 @@ BATS_PARALLEL_JOBS     ?= 2
 all: lint build generate-accounts tests clean
 
 build: ALWAYS_RUN
-	@ DOCKER_BUILDKIT=1 docker build \
-		--tag $(IMAGE_NAME) \
-		--build-arg VCS_VERSION=$(shell git rev-parse --short HEAD) \
-		--build-arg VCS_REVISION=$(shell cat VERSION) \
-		.
+	@ docker build --tag $(IMAGE_NAME) .
 
 generate-accounts: ALWAYS_RUN
 	@ cp test/config/templates/postfix-accounts.cf test/config/postfix-accounts.cf

--- a/docs/content/examples/tutorials/docker-build.md
+++ b/docs/content/examples/tutorials/docker-build.md
@@ -10,7 +10,7 @@ You'll need to retrieve the git submodules prior to building your own Docker ima
 
 ```sh
 git submodule update --init --recursive
-docker build -t <YOUR CUSTOM IMAGE NAME> .
+docker build --tag <YOUR CUSTOM IMAGE NAME> .
 ```
 
 Or, you can clone and retrieve the submodules in one command:
@@ -21,19 +21,26 @@ git clone --recurse-submodules https://github.com/docker-mailserver/docker-mails
 
 ### About Docker
 
-#### Version
+#### Minimum supported version
 
-We make use of build-features that require a recent version of Docker. Depending on your distribution, please have a look at [the official installation documentation for Docker](https://docs.docker.com/engine/install/) to get the latest version. Otherwise, you may encounter issues, for example with the `--link` flag for a [`#!dockerfile COPY`](https://docs.docker.com/engine/reference/builder/#copy) command.
+We make use of build features that require a recent version of Docker. v23.0 or newer is advised, but earlier releases may work.
 
-#### Environment
+- To get the latest version for your distribution, please have a look at [the official installation documentation for Docker](https://docs.docker.com/engine/install/).
+- If you are using a version of Docker prior to v23.0, you will need to enable BuildKit via the ENV [`DOCKER_BUILDKIT=1`](https://docs.docker.com/build/buildkit/#getting-started).
 
-If you are not using `make` to build the image, note that you will need to provide `DOCKER_BUILDKIT=1` to the `docker build` command for the build to succeed.
+#### Build Arguments (Optional)
 
-#### Build Arguments
+The `Dockerfile` includes several build [`ARG`][docker-docs::builder-arg] instructions that can be configured:
 
-The `Dockerfile` takes additional, so-called build arguments. These are
+- `DOVECOT_COMMUNITY_REPO`: Install Dovecot from the community repo instead of from Debian (default = 1) 
+- `DMS_RELEASE`: The image version (default = edge)
+- `VCS_REVISION`: The git commit hash used for the build (default = unknown)
 
-1. `VCS_VERSION`: the image version (default = edge)
-2. `VCS_REVISION`: the image revision (default = unknown)
+!!! note
 
-When using `make` to build the image, these are filled with proper values. You can build the image without supplying these arguments just fine though.
+    - `DMS_RELEASE` (_when not `edge`_) will be used to check for updates from our GH releases page at runtime due to the default feature [`ENABLE_UPDATE_CHECK=1`][docs::env-update-check].
+    - Both `DMS_RELEASE` and `VCS_REVISION` are also used with `opencontainers` metadata [`LABEL`][docker-docs::builder-label] instructions.
+
+[docs::env-update-check]: https://docker-mailserver.github.io/docker-mailserver/latest/config/environment/#enable_update_check
+[docker-docs::builder-arg]: https://docs.docker.com/engine/reference/builder/#using-arg-variables
+[docker-docs::builder-label]: https://docs.docker.com/engine/reference/builder/#label

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -205,6 +205,11 @@ function _install_getmail() {
   apt-get "${QUIET}" autoremove
 }
 
+function _install_utils() {
+  _log 'debug' 'Installing utils sourced from Github'
+  curl -sL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq
+}
+
 function _remove_data_after_package_installations() {
   _log 'debug' 'Deleting sensitive files (secrets)'
   rm /etc/postsrsd.secret
@@ -228,5 +233,6 @@ _install_dovecot
 _install_rspamd
 _install_fail2ban
 _install_getmail
+_install_utils
 _remove_data_after_package_installations
 _post_installation_steps

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -207,7 +207,7 @@ function _install_getmail() {
 
 function _install_utils() {
   _log 'debug' 'Installing utils sourced from Github'
-  curl -sL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq
+  curl -sL https://github.com/01mf02/jaq/releases/latest/download/jaq-v1.2.0-x86_64-unknown-linux-musl -o /usr/bin/jaq && chmod +x /usr/bin/jaq
 }
 
 function _remove_data_after_package_installations() {

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -120,7 +120,7 @@ function _register_functions() {
 
   [[ ${SMTP_ONLY}               -ne 1 ]] && _register_start_daemon '_start_daemon_dovecot'
 
-  [[ ${ENABLE_UPDATE_CHECK} -eq 1 && ${DMS_RELEASE} != 'edge' ]] && _register_start_daemon '_start_daemon_update_check'
+  [[ ${ENABLE_UPDATE_CHECK} -eq 1 ]] && [[ ${DMS_RELEASE} != 'edge' ]] && _register_start_daemon '_start_daemon_update_check'
 
   # The order here matters: Since Rspamd is using Redis, Redis should be started before Rspamd.
   [[ ${ENABLE_RSPAMD_REDIS}     -eq 1 ]] && _register_start_daemon '_start_daemon_rspamd_redis'

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -120,7 +120,7 @@ function _register_functions() {
 
   [[ ${SMTP_ONLY}               -ne 1 ]] && _register_start_daemon '_start_daemon_dovecot'
 
-  [[ ${ENABLE_UPDATE_CHECK}     -eq 1 ]] && _register_start_daemon '_start_daemon_update_check'
+  [[ ${ENABLE_UPDATE_CHECK} -eq 1 && ${DMS_RELEASE} != 'edge' ]] && _register_start_daemon '_start_daemon_update_check'
 
   # The order here matters: Since Rspamd is using Redis, Redis should be started before Rspamd.
   [[ ${ENABLE_RSPAMD_REDIS}     -eq 1 ]] && _register_start_daemon '_start_daemon_rspamd_redis'

--- a/target/scripts/update-check.sh
+++ b/target/scripts/update-check.sh
@@ -3,7 +3,7 @@
 # shellcheck source=./helpers/log.sh
 source /usr/local/bin/helpers/log.sh
 
-VERSION="${DMS_VERSION#v}"
+VERSION="${DMS_RELEASE#v}"
 VERSION_URL='https://github.com/docker-mailserver/docker-mailserver/releases/latest'
 CHANGELOG_URL='https://github.com/docker-mailserver/docker-mailserver/blob/master/CHANGELOG.md'
 

--- a/target/scripts/update-check.sh
+++ b/target/scripts/update-check.sh
@@ -4,7 +4,7 @@
 source /usr/local/bin/helpers/log.sh
 
 VERSION="${DMS_VERSION#v}"
-VERSION_URL='https://raw.githubusercontent.com/docker-mailserver/docker-mailserver/master/VERSION'
+VERSION_URL='https://github.com/docker-mailserver/docker-mailserver/releases/latest'
 CHANGELOG_URL='https://github.com/docker-mailserver/docker-mailserver/blob/master/CHANGELOG.md'
 
 # check for correct syntax
@@ -17,10 +17,10 @@ fi
 
 while true; do
   # get remote version information
-  LATEST=$(curl -Lsf "${VERSION_URL}")
+  LATEST=$(curl -sfL -H 'accept: application/json' "${VERSION_URL}" | yq .tag_name)
 
   # did we get a valid response?
-  if [[ ${LATEST} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  if [[ ${LATEST} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     _log_with_date 'debug' 'Remote version information fetched'
 
     # compare versions

--- a/target/scripts/update-check.sh
+++ b/target/scripts/update-check.sh
@@ -3,7 +3,7 @@
 # shellcheck source=./helpers/log.sh
 source /usr/local/bin/helpers/log.sh
 
-VERSION=$(</VERSION)
+VERSION="${DMS_VERSION#v}"
 VERSION_URL='https://raw.githubusercontent.com/docker-mailserver/docker-mailserver/master/VERSION'
 CHANGELOG_URL='https://github.com/docker-mailserver/docker-mailserver/blob/master/CHANGELOG.md'
 

--- a/target/scripts/update-check.sh
+++ b/target/scripts/update-check.sh
@@ -17,10 +17,11 @@ fi
 
 while true; do
   # get remote version information
-  LATEST=$(curl -sfL -H 'accept: application/json' "${VERSION_URL}" | yq .tag_name)
+  # JSON response provides a field for the release tag, the `v` prefix is removed with `[1:]`
+  LATEST=$(curl -sfL -H 'accept: application/json' "${VERSION_URL}" | jaq -r '.tag_name[1:]')
 
   # did we get a valid response?
-  if [[ ${LATEST} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  if [[ ${LATEST} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     _log_with_date 'debug' 'Remote version information fetched'
 
     # compare versions


### PR DESCRIPTION
# Description

We have had 3 concerns encountered related to this feature in the past.

**Resolved by:**
- CI will now provide the `VERSION` as an image ENV (`DMS_RELEASE`) in the `Dockerfile` to build. No need to manually update `VERSION` (_well, until a future release warrants removing it_).
- Future releases will now check the GH Releases page instead of current `master` branch `VERSION` file.

**Past concerns addressed:**
1. `:edge` should not care about the update process, these concerns should not have been raised:
   - https://github.com/docker-mailserver/docker-mailserver/pull/3659
   - https://github.com/docker-mailserver/docker-mailserver/pull/3662#pullrequestreview-1749456998
2. A release was made [without bumping `VERSION` accordingly](https://github.com/docker-mailserver/docker-mailserver/issues/2952#issuecomment-1364304849):
   - The fix was to [publish a new patch version/tag](https://github.com/docker-mailserver/docker-mailserver/pull/2944).
   - Wouldn't be a problem when checking GH releases for tag version.
3. A concern when the [release PR is pushed but tagging an official release is delayed](https://github.com/docker-mailserver/docker-mailserver/pull/3641#issuecomment-1826478255):
   - `:edge` unaffected since it's not actually tied to the `/VERSION` file that it would compare to Github `VERSION`.
   - Tagged releases would avoid sending notification until a new tagged release is actually published.

---

## Additional context

Applies changes were originally proposed here:
- https://github.com/docker-mailserver/docker-mailserver/pull/3641#issuecomment-1826483637
- https://github.com/docker-mailserver/docker-mailserver/pull/3641#issuecomment-1827027920

**ℹ️ Note:**
- The curl response will be the tag value, which includes a `v` to strip away. Whereas the current `VERSION` file has no `v` prefix.
- `VERSION` should remain committed for now. Prior versions will still check it, notably v13. Perhaps by v14 or later removing the file would fine? 🤷‍♂️ 

**⚠️ Caution:**
- I have not verified the workflow.
  - I expect the value is correct from the Github Actions [`context` docs](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) + [conditional expression](https://docs.github.com/en/actions/learn-github-actions/expressions#example) example.
  - We do have an [existing workflow using `github.ref` / `${GITHUB_REF}`](https://github.com/docker-mailserver/docker-mailserver/blob/68a43eb4970f2ab7680ffa470a1d26e37fa375f0/.github/workflows/docs-production-deploy.yml#L33-L41), `github.ref_name` should be just the tag like in the JSON `tag_name` field.

---

### `yq` vs `jaq`

I have expressed interest in [`yq`](https://github.com/mikefarah/yq) previously for managing DKIM / rspamd config (_and processing JSON output from `step` CLI for TLS cert tools_):
- https://github.com/docker-mailserver/docker-mailserver/pull/3599#discussion_r1371202623
- https://github.com/docker-mailserver/docker-mailserver/pull/3627/files#r1387243971
- https://github.com/orgs/kcl-lang/discussions/804#discussioncomment-7430551
- https://github.com/docker-mailserver/docker-mailserver/issues/3630

However it weighs 9.3MB vs an alternative [`jaq`](https://github.com/01mf02/jaq) at 1.7MB, which in this case was simpler to query the JSON field for the tag and strip the `v` prefix character.

See the `jaq` link for preference of it over `jq`. Docs wise, if using `jaq` elsewhere in DMS scripts you can follow the `jq` docs, or see the `jaq` README for some additional features/capabilities.

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
