### PR TITLE
hotfix: solve #3665

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file. The format 
 
 > **Note**: Changes and additions listed here are contained in the `:edge` image tag. These changes may not be as stable as released changes.
 
+## [v13.0.1](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.0.1)
+
+### Fixed
+
+- This patch release fixes two bugs that Rspamd users encounter on `v13.0.0` - Big thanks to the those that helped to identify these issues!
+  1. The check for correct permission on the private key when signing e-mails with DKIM was flawed. The result was that a false warning was emitted.
+  2. When `RSPAMD_CHECK_AUTHENTICATED=0`, DKIM signing for outbound e-mail was disabled, which is undesirable.
+
 ## [v13.0.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.0.0)
 
 ### Breaking
@@ -78,7 +86,7 @@ All notable changes to this project will be documented in this file. The format 
   - `logrotate` setup + Rspamd log path + tests log helper fallback path ([#3576](https://github.com/docker-mailserver/docker-mailserver/pull/3576))
   - Setup during container startup is now more resilient ([#3578](https://github.com/docker-mailserver/docker-mailserver/pull/3578))
   - Changed DKIM default config location ([#3597](https://github.com/docker-mailserver/docker-mailserver/pull/3597))
-  - Removed the symlink for the `override.d/` directory in favor of using `cp`, integrated into the changedetector service, , added a `--force` option for the Rspamd DKIM management, and provided a dedicated helper script for common ENV variables ([#3599](https://github.com/docker-mailserver/docker-mailserver/pull/3599))
+  - Removed the symlink for the `override.d/` directory in favor of using `cp`, integrated into the changedetector service, added a `--force` option for the Rspamd DKIM management, and provided a dedicated helper script for common ENV variables ([#3599](https://github.com/docker-mailserver/docker-mailserver/pull/3599))
   - Required permissions are now verified for DKIM private key files ([#3627](https://github.com/docker-mailserver/docker-mailserver/pull/3627))
 - **Documentation:**
   - Documentation aligned to Compose v2 conventions, `docker-compose` command changed to `docker compose`, `docker-compose.yaml` to `compose.yaml` ([#3295](https://github.com/docker-mailserver/docker-mailserver/pull/3295))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This patch release fixes two bugs that Rspamd users encounter on `v13.0.0`. Big 
 
 - **Rspamd:**
   - The check for correct permission on the private key when signing e-mails with DKIM was flawed. The result was that a false warning was emitted ([#3669](https://github.com/docker-mailserver/docker-mailserver/pull/3669))
-  - When [`RSPAMD_CHECK_AUTHENTICATED=0`][docs::env-rspamd-check-auth], DKIM signing for outbound e-mail was disabled, which is undesirable ([#3669](https://github.com/docker-mailserver/docker-mailserver/pull/3669))
+  - When [`RSPAMD_CHECK_AUTHENTICATED=0`][docs::env-rspamd-check-auth], DKIM signing for outbound e-mail was disabled, which is undesirable ([#3669](https://github.com/docker-mailserver/docker-mailserver/pull/3669)). **Make sure to check the documentation of [`RSPAMD_CHECK_AUTHENTICATED`][docs::env-rspamd-check-auth]**!
 
 [docs::env-rspamd-check-auth]: https://docker-mailserver.github.io/docker-mailserver/v13.0/config/environment/#rspamd_check_authenticated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [v13.0.1](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.0.1)
 
+This patch release fixes two bugs that Rspamd users encounter on `v13.0.0`. Big thanks to the those that helped to identify these issues!
+
 ### Fixed
 
-- This patch release fixes two bugs that Rspamd users encounter on `v13.0.0` - Big thanks to the those that helped to identify these issues!
-  1. The check for correct permission on the private key when signing e-mails with DKIM was flawed. The result was that a false warning was emitted.
-  2. When `RSPAMD_CHECK_AUTHENTICATED=0`, DKIM signing for outbound e-mail was disabled, which is undesirable.
+- **Rspamd:**
+  - The check for correct permission on the private key when signing e-mails with DKIM was flawed. The result was that a false warning was emitted ([#3669](https://github.com/docker-mailserver/docker-mailserver/pull/3669))
+  - When [`RSPAMD_CHECK_AUTHENTICATED=0`][docs::env-rspamd-check-auth], DKIM signing for outbound e-mail was disabled, which is undesirable ([#3669](https://github.com/docker-mailserver/docker-mailserver/pull/3669))
+
+[docs::env-rspamd-check-auth]: https://docker-mailserver.github.io/docker-mailserver/v13.0/config/environment/#rspamd_check_authenticated
 
 ## [v13.0.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.0.0)
 

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -366,7 +366,9 @@ The purpose of this setting is to opt-out of starting an internal Redis instance
 
 This settings controls whether checks should be performed on emails coming from authenticated users (i.e. most likely outgoing emails). The default value is `0` in order to align better with SpamAssassin. **We recommend** reading through [the Rspamd documentation on scanning outbound emails][rspamd-scanning-outbound] though to decide for yourself whether you need and want this feature.
 
-Note that not all groups are disabled: DKIM signing of e-mails will still happen.
+!!! note "Not all groups are disabled"
+
+    DKIM signing of e-mails will still happen.
 
 - **0** => No checks will be performed for authenticated users
 - 1 => All default checks will be performed for authenticated users

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -366,6 +366,8 @@ The purpose of this setting is to opt-out of starting an internal Redis instance
 
 This settings controls whether checks should be performed on emails coming from authenticated users (i.e. most likely outgoing emails). The default value is `0` in order to align better with SpamAssassin. **We recommend** reading through [the Rspamd documentation on scanning outbound emails][rspamd-scanning-outbound] though to decide for yourself whether you need and want this feature.
 
+Note that not all groups are disabled: DKIM signing of e-mails will still happen.
+
 - **0** => No checks will be performed for authenticated users
 - 1 => All default checks will be performed for authenticated users
 

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -366,7 +366,7 @@ The purpose of this setting is to opt-out of starting an internal Redis instance
 
 This settings controls whether checks should be performed on emails coming from authenticated users (i.e. most likely outgoing emails). The default value is `0` in order to align better with SpamAssassin. **We recommend** reading through [the Rspamd documentation on scanning outbound emails][rspamd-scanning-outbound] though to decide for yourself whether you need and want this feature.
 
-!!! note "Not all groups are disabled"
+!!! note "Not all checks and actions are disabled"
 
     DKIM signing of e-mails will still happen.
 

--- a/mailserver.env
+++ b/mailserver.env
@@ -153,6 +153,8 @@ RSPAMD_LEARN=0
 # is `0` in order to align better with SpamAssassin. We recommend reading
 # through https://rspamd.com/doc/tutorials/scanning_outbound.html though to
 # decide for yourself whether you need and want this feature.
+#
+# Note that not all groups are disabled: DKIM signing of e-mails will still happen.
 RSPAMD_CHECK_AUTHENTICATED=0
 
 # Controls whether the Rspamd Greylisting module is enabled.

--- a/mailserver.env
+++ b/mailserver.env
@@ -154,7 +154,7 @@ RSPAMD_LEARN=0
 # through https://rspamd.com/doc/tutorials/scanning_outbound.html though to
 # decide for yourself whether you need and want this feature.
 #
-# Note that not all groups are disabled: DKIM signing of e-mails will still happen.
+# Note that DKIM signing of e-mails will still happen.
 RSPAMD_CHECK_AUTHENTICATED=0
 
 # Controls whether the Rspamd Greylisting module is enabled.

--- a/target/rspamd/local.d/settings.conf
+++ b/target/rspamd/local.d/settings.conf
@@ -6,7 +6,7 @@ authenticated {
     priority = high;
     authenticated = yes;
     apply {
-        groups_enabled = [];
+        groups_enabled = [dkim];
     }
 }
 # DMS::SED_TAG::1::END

--- a/target/scripts/startup/setup.d/security/rspamd.sh
+++ b/target/scripts/startup/setup.d/security/rspamd.sh
@@ -325,7 +325,7 @@ function __rspamd__check_dkim_permissions() {
       __rspamd__log 'trace' "Checking DKIM file '${FILE}'"
       # See https://serverfault.com/a/829314 for an explanation on `-exec false {} +`
       # We additionally resolve symbolic links to check the permissions of the actual files
-      if find "$(realpath -eL "${FILE}")" -user _rspamd -or -group _rspamd -or -perm -o=r -exec false {} +; then
+      if find "$(realpath -eL "${FILE}")" \( -user _rspamd -or -group _rspamd -or -perm -o=r \) -exec false {} +; then
         __rspamd__log 'warn' "Rspamd DKIM private key file '${FILE}' does not appear to have correct permissions/ownership for Rspamd to use it"
       else
         __rspamd__log 'trace' "DKIM file '${FILE}' permissions and ownership appear correct"

--- a/test/tests/parallel/set1/spam_virus/rspamd_full.bats
+++ b/test/tests/parallel/set1/spam_virus/rspamd_full.bats
@@ -307,5 +307,5 @@ function teardown_file() { _default_teardown ; }
   _run_in_container grep -E -A 6 'authenticated \{' "${MODULE_FILE}"
   assert_success
   assert_output --partial 'authenticated = yes;'
-  assert_output --partial 'groups_enabled = [];'
+  assert_output --partial 'groups_enabled = [dkim];'
 }


### PR DESCRIPTION
# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->

This patch release fixes two bugs that Rspamd users encounter on `v13.0.0`:

1. The check for correct permission on the private key when signing e-mails with DKIM was flawed. The result was that a false warning was emitted.
2. When `RSPAMD_CHECK_AUTHENTICATED=0`, DKIM signing for outbound e-mail was disabled, which is undesirable.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #3665

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
