### PR TITLE
update-check: fix 'read' exit status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file. The format 
 - **Internal**:
   - The container startup welcome log message now references `DMS_RELEASE` ([#3676](https://github.com/docker-mailserver/docker-mailserver/pull/3676))
   - `VERSION` was incremented for prior releases to be notified of the v13.0.1 patch release ([#3676](https://github.com/docker-mailserver/docker-mailserver/pull/3676))
+  - Update-check: fix 'read' exit status ([#3688](https://github.com/docker-mailserver/docker-mailserver/pull/3688))
 
 ## [v13.0.1](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.0.1)
 

--- a/target/scripts/update-check.sh
+++ b/target/scripts/update-check.sh
@@ -27,7 +27,7 @@ while true; do
     # compare versions
     if dpkg --compare-versions "${VERSION}" lt "${LATEST}"; then
       # send mail notification to postmaster
-      read -r -d '' MAIL << EOF
+      read -r -d '#' MAIL << EOF
 Hello ${POSTMASTER_ADDRESS}!
 
 There is a docker-mailserver update available on your host: $(hostname -f)
@@ -35,7 +35,7 @@ There is a docker-mailserver update available on your host: $(hostname -f)
 Current version: ${VERSION}
 Latest  version: ${LATEST}
 
-Changelog: ${CHANGELOG_URL}
+Changelog: ${CHANGELOG_URL}#END
 EOF
 
       _log_with_date 'info' "Update available [ ${VERSION} --> ${LATEST} ]"


### PR DESCRIPTION
# Description

Currently, the `read` command fails with exit code 1. That is not an issue, the script continues running.

The problem is, that the delimiter (`-d ''`) is set to a null byte. However, the heredoc does not contain a null byte to terminate.

So this PR changes the delimiter to `#`, which I also added at the end of the heredoc.

As mentioned, that is currently not an issue. It's just not "clean", having a successful command that signals failure via the exit code. This could be a problem in the future, if we decide to introduce `set -e` widely.

PS: `-d ''` is equivalent to `-d $'\0'`.

>-d delim          continue until the first character of DELIM is read, rather than newline


<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->

<!-- Link the issue which will be fixed (if any) here: -->


## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
