### PR TITLE
fix: only set `virtual_mailbox_maps` to texthash when not using LDAP

### DIFF
--- a/target/scripts/startup/setup.d/postfix.sh
+++ b/target/scripts/startup/setup.d/postfix.sh
@@ -79,7 +79,9 @@ EOF
     # /etc/postfix/vmailbox is created by: scripts/helpers/accounts.sh:_create_accounts()
     # This file config is for Postfix to verify a mail account exists before accepting
     # mail arriving and delivering it to Dovecot over LMTP.
-    postconf 'virtual_mailbox_maps = texthash:/etc/postfix/vmailbox'
+    if [[ ${ACCOUNT_PROVISIONER} == 'FILE' ]]; then
+      postconf 'virtual_mailbox_maps = texthash:/etc/postfix/vmailbox'
+    fi
     postconf 'virtual_transport = lmtp:unix:/var/run/dovecot/lmtp'
   fi
 


### PR DESCRIPTION
Fixes #3692

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
