### PR TITLE
ci: Allow lint workflow to be manually triggered

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,10 +1,10 @@
 name: Lint
 
 on:
+  # A workflow that creates a PR will not trigger this workflow,
+  # Providing a manual trigger as a workaround
+  workflow_dispatch:
   pull_request:
-    paths-ignore:
-      # Managed by workflow: contributors.yml
-      - CONTRIBUTORS.md
   push:
     branches: [ master ]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ All notable changes to this project will be documented in this file. The format 
   - Update-check: fix 'read' exit status ([#3688](https://github.com/docker-mailserver/docker-mailserver/pull/3688))
 - **Rspamd:**
   - Switch to official arm64 packages to avoid segfaults ([#3686](https://github.com/docker-mailserver/docker-mailserver/pull/3686))
+- **CI / Automation:**
+  - The lint workflow can now be manually triggered by maintainers ([#3714]https://github.com/docker-mailserver/docker-mailserver/pull/3714)
 
 ## [v13.0.1](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.0.1)
 


### PR DESCRIPTION
# Description

It seemed like the [linting workflow might have been possible to ignore the required check](https://github.com/docker-mailserver/docker-mailserver/pull/3705#issuecomment-1861945746), but [that was not the case](https://github.com/docker-mailserver/docker-mailserver/pull/3704#issuecomment-1861966192).

New attempt is to allow maintainers to activate the linting workflow via `workflow_dispatch` trigger. This can be accessed via the Actions tab with a dropdown on the workflow to select what branch to run it on.

![image](https://github.com/docker-mailserver/docker-mailserver/assets/5098581/2dd78de5-9d46-44fa-bba6-0d8723143b79)

Without this a different event must occur to trigger the workflow, which is inconvenient for automated PRs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
