### PR TITLE
Rspamd: add custom symbol scores for SPF, DKIM & DMARC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file. The format 
 
 > **Note**: Changes and additions listed here are contained in the `:edge` image tag. These changes may not be as stable as released changes.
 
+### Updates
+
+- **Rspamd** ([#3726](https://github.com/docker-mailserver/docker-mailserver/pull/3726)):
+  - symbol scores for SPF, DKIM & DMARC were updated to more closely align with [RFC7489](https://www.rfc-editor.org/rfc/rfc7489#page-24); please note though that complete alignment is undesirable, because other symbols might be added as well, which changes the overall score calculation again, see [this issue](https://github.com/docker-mailserver/docker-mailserver/issues/3690#issuecomment-1866871996)
+
 ## [v13.2.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.2.0)
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,7 @@ EOF
 # -----------------------------------------------
 
 COPY target/rspamd/local.d/ /etc/rspamd/local.d/
+COPY target/rspamd/scores.d/* /etc/rspamd/scores.d/
 
 # -----------------------------------------------
 # --- LDAP & SpamAssassin's Cron ----------------

--- a/target/rspamd/local.d/actions.conf
+++ b/target/rspamd/local.d/actions.conf
@@ -1,9 +1,12 @@
 # documentation: https://rspamd.com/doc/configuration/metrics.html#actions
 # and            https://rspamd.com/doc/configuration/metrics.html
 
-#greylist = 4;
-#add_header = 6;
-#rewrite_subject = 7;
-#reject = 15;
+# These values work in conjunction with the symbol scores in
+# `scores.d/*.conf`. When adjusting them, make sure to understand
+# and to be able to explain the impact on the whole system.
+greylist = 4;
+add_header = 6;
+rewrite_subject = 7;
+reject = 11;
 
 subject = "***SPAM*** %s"

--- a/target/rspamd/scores.d/policies_group.conf
+++ b/target/rspamd/scores.d/policies_group.conf
@@ -1,0 +1,108 @@
+# Please refer to
+# https://github.com/docker-mailserver/docker-mailserver/issues/3690
+# for understanding this file and its scores' values.
+
+symbols = {
+    # SPF
+    "R_SPF_ALLOW" {
+        weight = -1;
+        description = "SPF verification allows sending";
+        groups = ["spf"];
+    }
+    "R_SPF_NA" {
+        weight = 1.5;
+        description = "Missing SPF record";
+        one_shot = true;
+        groups = ["spf"];
+    }
+    "R_SPF_SOFTFAIL" {
+        weight = 2.5;
+        description = "SPF verification soft-failed";
+        groups = ["spf"];
+    }
+    "R_SPF_FAIL" {
+        weight = 4.5;
+        description = "SPF verification failed";
+        groups = ["spf"];
+    }
+
+    "R_SPF_NEUTRAL" { # == R_SPF_NA
+        weight = 1.5;
+        description = "SPF policy is neutral";
+        groups = ["spf"];
+    }
+    "R_SPF_DNSFAIL" { # == R_SPF_SOFTFAIL
+        weight = 2.5;
+        description = "SPF DNS failure";
+        groups = ["spf"];
+    }
+    "R_SPF_PERMFAIL" { # == R_SPF_FAIL
+        weight = 4.5;
+        description = "SPF record is malformed or persistent DNS error";
+        groups = ["spf"];
+    }
+
+    # DKIM
+    "R_DKIM_ALLOW" {
+        weight = -1;
+        description = "DKIM verification succeed";
+        one_shot = true;
+        groups = ["dkim"];
+    }
+    "R_DKIM_NA" {
+        weight = 0;
+        description = "Missing DKIM signature";
+        one_shot = true;
+        groups = ["dkim"];
+    }
+    "R_DKIM_TEMPFAIL" {
+        weight = 1.5;
+        description = "DKIM verification soft-failed";
+        groups = ["dkim"];
+    }
+    "R_DKIM_PERMFAIL" {
+        weight = 4.5;
+        description = "DKIM verification hard-failed (invalid)";
+        groups = ["dkim"];
+    }
+
+    "R_DKIM_REJECT" { # == R_DKIM_PERMFAIL
+        weight = 4.5;
+        description = "DKIM verification failed";
+        one_shot = true;
+        groups = ["dkim"];
+    }
+
+    # DMARC
+    "DMARC_NA" {
+        weight = 1;
+        description = "No DMARC record";
+        groups = ["dmarc"];
+    }
+    "DMARC_POLICY_QUARANTINE" {
+        weight = 1.5;
+        description = "DMARC quarantine policy";
+        groups = ["dmarc"];
+    }
+    "DMARC_POLICY_REJECT" {
+        weight = 2;
+        description = "DMARC reject policy";
+        groups = ["dmarc"];
+    }
+
+    "DMARC_POLICY_ALLOW" { # no equivalent
+        weight = -1;
+        description = "DMARC permit policy";
+        groups = ["dmarc"];
+    }
+    "DMARC_POLICY_ALLOW_WITH_FAILURES" { # no equivalent
+        weight = -0.5;
+        description = "DMARC permit policy with DKIM/SPF failure";
+        groups = ["dmarc"];
+    }
+    "DMARC_POLICY_SOFTFAIL" { # == DMARC_POLICY_QUARANTINE
+        weight = 1.5;
+        description = "DMARC soft-failed";
+        groups = ["dmarc"];
+    }
+}


### PR DESCRIPTION
# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->

This PR adjusts Rspamd's symbol scores to better align with [RFC7489](https://www.rfc-editor.org/rfc/rfc7489#page-24), see #3690.

<!-- Link the issue which will be fixed (if any) here: -->
Closes #3690

## Type of change

<!-- Delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] This change requires a documentation update (**does it?**)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
