### PR TITLE
chore: Disable `smtputf8` support in config directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file. The format 
 
 > **Note**: Changes and additions listed here are contained in the `:edge` image tag. These changes may not be as stable as released changes.
 
+### Updates
+
+- **Internal:**
+  - Postfix is now configured with `smtputf8_enable = no` in our default `main.cf` config (_instead of during container startup_). ([#3750](https://github.com/docker-mailserver/docker-mailserver/pull/3750))
+
 ## [v13.2.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.2.0)
 
 ### Security

--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -5,6 +5,9 @@ biff = no
 append_dot_mydomain = no
 readme_directory = no
 
+# Disabled as not compatible with Dovecot
+smtputf8_enable = no
+
 # Basic configuration
 # myhostname =
 alias_maps = hash:/etc/aliases

--- a/target/scripts/startup/setup.d/postfix.sh
+++ b/target/scripts/startup/setup.d/postfix.sh
@@ -19,9 +19,6 @@ function _setup_postfix_early() {
     postconf "inet_protocols = ${POSTFIX_INET_PROTOCOLS}"
   fi
 
-  __postfix__log 'trace' "Disabling SMTPUTF8 support"
-  postconf 'smtputf8_enable = no'
-
   __postfix__log 'trace' "Configuring SASLauthd"
   if [[ ${ENABLE_SASLAUTHD} -eq 1 ]] && [[ ! -f /etc/postfix/sasl/smtpd.conf ]]; then
     cat >/etc/postfix/sasl/smtpd.conf << EOF

--- a/test/tests/parallel/set3/mta/smtp_delivery.bats
+++ b/test/tests/parallel/set3/mta/smtp_delivery.bats
@@ -277,6 +277,10 @@ function _successful() {
     --protocol ESMTP \
     --server mail.example.test \
     --quit-after FIRST-EHLO
+
+  # Ensure the output is actually related to what we want to refute against:
+  assert_output --partial 'EHLO mail.external.tld'
+  assert_output --partial '221 2.0.0 Bye'
   refute_output --partial 'SMTPUTF8'
 }
 


### PR DESCRIPTION
# Description

This was always configured disabled at runtime, better to just set explicitly in `main.cf` unless config diverges when Dovecot is enabled to opt-out of this feature.

The related test now ensures that we're refuting against the expected output returned. The refute alone would still pass if the command wasn't returning the correct output to check against.

## Feature reference

This feature still does not appear to have compatibility with Dovecot. References:
- Postfix `SMTPUTF8` docs (_has a limitations section, it can advertise support but it is not complete_): https://www.postfix.org/SMTPUTF8_README.html
- Original PR: https://github.com/docker-mailserver/docker-mailserver/pull/1223
- Original issue (_with comment stating this requires milter support too, not just dovecot_): https://github.com/docker-mailserver/docker-mailserver/issues/1117#issuecomment-520137499
- Late 2022 PR with Dovecot maintainer response in April 2023 stating support was still lacking: https://github.com/dovecot/core/pull/188
  - Dec 2022 a user chimes in that they're unable to use a UTF-8 internationalized TLD.

## Reproduction

FWIW, I could not seem to reproduce failure regardless of this setting be enabled or not.
- I tried sending mail with swaks within the same DMS container and `PERMIT_DOCKER=container` on port 465 authenticated which perhaps bypassed the issue.
- Both times the logs seem to suggest that Dovecot was accepting the mail over LMTP and storing it, despite using a subject line with UTF8 value. Not sure if `swaks` or the terminal affected that (_the terminal WSL2 did not play well with editing content after these multi-byte graphemes were pasted_ 😅 )

If someone believes this feature is working properly and should be enabled, submit a test-case which can trigger the failure you experience with this setting disabled, and another test-case where it correctly delivers the mail with the setting enabled (_use our `postfix-main.cf` override support_).

UTF8 in the subject line [presumably failed in the past at least](https://unix.stackexchange.com/questions/320091/configure-postfix-and-dovecot-lmtp-to-receive-mail-via-smtputf8).
- There may have been improvements since then (2017) which improved on that, but the SMTPUTF8 support may not be complete (_as per Dovecot April 2023 update_).
- In 2021 / 2022, [Dovecot mailing list did mention an issue with DNS related support](https://dovecot.org/pipermail/dovecot/2022-June/124830.html) regarding IDN + EAI mapping. Postfix is apparently lacking support in that area too.

**UPDATE:** Read the Postfix limitations again, local-part UTF8 in the envelope sender/receiver is ok, but not the domain-part (subject to DNS). This fails even with `smtputf8_enable = yes`

```
=== Trying 0.0.0.0:465...
=== Connected to 0.0.0.0.
<-  220 mail.example.test ESMTP
 -> EHLO external.test
<-  250-mail.example.test
<-  250-PIPELINING
<-  250-SIZE 10240000
<-  250-ETRN
<-  250-AUTH PLAIN LOGIN
<-  250-AUTH=PLAIN LOGIN
<-  250-ENHANCEDSTATUSCODES
<-  250-8BITMIME
<-  250-DSN
<-  250-SMTPUTF8
<-  250 CHUNKING
 -> AUTH LOGIN
<-  334 VXNlcm5hbWU6
 -> aGVsbG9AZXhhbXBsZS50ZXN0
<-  334 UGFzc3dvcmQ6
 -> YmFkLXBhc3N3b3Jk
<-  235 2.7.0 Authentication successful
 -> MAIL FROM:<someone@💩.test>
<** 501 5.1.7 Bad sender address syntax
 -> QUIT
<-  221 2.0.0 Bye
=== Connection closed with remote host.
```

Logs related to that differed by setting on/off:

```console
# smtputf8_enable = yes
Jan  5 05:43:35 original postfix/submissions/smtpd[16866]: warning: Illegal address syntax from localhost[127.0.0.1] in MAIL command: <someone@💩.test>

# smtputf8_enable = no
Jan  5 05:44:36 original postfix/submissions/smtpd[17156]: warning: Illegal address syntax from localhost[127.0.0.1] in MAIL command: <someone@????.test>
```

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
