### PR TITLE
ci: `.gitattributes` - Ensure `eol=lf` for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,9 +20,8 @@
 
 ## BUILD:
 .dockerignore       text
-Dockerfile          text
+Dockerfile          text eol=lf
 Makefile
-VERSION
 
 ## EXAMPLE (RUNTIME):
 *.env               text
@@ -75,8 +74,8 @@ target/postsrsd/**  text
 #################################################
 
 ## BATS
-*.bash              text
-*.bats              text
+*.bash              text eol=lf
+*.bats              text eol=lf
 
 ## CONFIG (test/config/)
 ### OpenLDAP image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to this project will be documented in this file. The format 
 - **Rspamd** ([#3726](https://github.com/docker-mailserver/docker-mailserver/pull/3726)):
   - symbol scores for SPF, DKIM & DMARC were updated to more closely align with [RFC7489](https://www.rfc-editor.org/rfc/rfc7489#page-24); please note though that complete alignment is undesirable, because other symbols might be added as well, which changes the overall score calculation again, see [this issue](https://github.com/docker-mailserver/docker-mailserver/issues/3690#issuecomment-1866871996)
 
+### Fixes
+
+- **Internal:**
+  - `.gitattributes`: Always use LF line endings on checkout for files with shell script content ([#3755](https://github.com/docker-mailserver/docker-mailserver/pull/3755))
+
 ## [v13.2.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.2.0)
 
 ### Security


### PR DESCRIPTION
# Description

- These files should always use LF for line endings.
- `Dockerfile` does not like building with HereDoc `RUN` scripts that expect LF.

---

Cloned on Windows, but ran Docker build from WSL2 which failed as Windows checkout used CRLF:

```
 => [stage-base 2/6] COPY target/bin/sedfile /usr/local/bin/sedfile                                                                                                                                               0.0s
 => ERROR [stage-base 3/6] RUN <<EOF (chmod +x /usr/local/bin/sedfile...)                                                                                                                                         0.4s
------
 > [stage-base 3/6] RUN <<EOF (chmod +x /usr/local/bin/sedfile...):
0.372 chmod: cannot access '/usr/local/bin/sedfile'$'\r': No such file or directory
------
Dockerfile:23
--------------------
  22 |     COPY target/bin/sedfile /usr/local/bin/sedfile
  23 | >>> RUN <<EOF
  24 | >>>   chmod +x /usr/local/bin/sedfile
  25 | >>>   adduser --quiet --system --group --disabled-password --home /var/lib/clamav --no-create-home --uid 200 clamav
  26 | >>> EOF
  27 |
--------------------
ERROR: failed to solve: process "/bin/bash -e -o pipefail -c   chmod +x /usr/local/bin/sedfile\r\n  adduser --quiet --system --group --disabled-password --home /var/lib/clamav --no-create-home --uid 200 clamav\r\n" did not complete successfully: exit code: 1
make: *** [Makefile:21: build] Error 1
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
