### PR TITLE
chore: Add maintenance comment for `sed` usage

### DIFF
--- a/target/scripts/startup/setup.d/security/misc.sh
+++ b/target/scripts/startup/setup.d/security/misc.sh
@@ -70,6 +70,8 @@ function __setup__security__spamassassin() {
   if [[ ${ENABLE_SPAMASSASSIN} -eq 1 ]]; then
     _log 'debug' 'Enabling and configuring SpamAssassin'
 
+    # Maintainers should take care in attempting to change these sed commands. Alternatives were already explored:
+    # https://github.com/docker-mailserver/docker-mailserver/pull/3767#issuecomment-1885989591
     # shellcheck disable=SC2016
     sed -i -r 's|^\$sa_tag_level_deflt (.*);|\$sa_tag_level_deflt = '"${SA_TAG}"';|g' /etc/amavis/conf.d/20-debian_defaults
 


### PR DESCRIPTION
# Description

This is a more explicit reminder for any future contributors that get thrown off by the usage of `sed` here and may be inclined to change it.

Add a link to [reference a comment](https://github.com/docker-mailserver/docker-mailserver/pull/3767#issuecomment-1885989591) where it's already been explored what the alternative `sed` invocations available are.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

---

Feel free to reject, but seems worthwhile to document? 🤷‍♂️ 