### PR TITLE
docs: Add maintenance comment for `main.cf:reject_unknown_sender_domain`

### DIFF
--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -68,6 +68,7 @@ smtpd_forbid_bare_newline = yes
 # smtpd_forbid_bare_newline_exclusions = $mynetworks
 
 # Custom defined parameters for DMS:
+# reject_unknown_sender_domain: https://github.com/docker-mailserver/docker-mailserver/issues/3716#issuecomment-1868033234
 dms_smtpd_sender_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unknown_sender_domain
 # Submission ports 587 and 465 support for SPOOF_PROTECTION=1
 mua_sender_restrictions = reject_authenticated_sender_login_mismatch, $dms_smtpd_sender_restrictions


### PR DESCRIPTION
# Description

This is just a minor addition inlined to the config for maintainers to be aware of.

Perhaps there would be a better way to approach documenting stuff like this, but while closing through my tabs I figured this was a useful comment to reference related to the setting if it's ever being changed or needs to be better understood (_linked issue is a common failure that can be encountered related to this restriction_).

---

Feel free to reject or discuss a better approach (_perhaps a single issue link that collects such information, or a markdown document for technical insights related to maintaining configs_ 🤷‍♂️ )