### PR TITLE
fix: Ensure correct ownership for the Rspamd DKIM directory

### DIFF
--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -94,6 +94,10 @@ function _setup_apply_fixes_after_configuration() {
 
   _log 'debug' 'Removing files and directories from older versions'
   rm -rf /var/mail-state/spool-postfix/{dev,etc,lib,pid,usr,private/auth}
+
+  # /tmp/docker-mailserver/rspamd/dkim
+  _log 'debug' "Ensuring ${RSPAMD_DMS_DKIM_D} is owned by '_rspamd:_rspamd'"
+  chown -R _rspamd:_rspamd "${RSPAMD_DMS_DKIM_D}"
 }
 
 function _run_user_patches() {


### PR DESCRIPTION
# Description

Applies the suggested fix from reporter: https://github.com/docker-mailserver/docker-mailserver/issues/3800#issuecomment-1905369367
- The UID / GID shifted during a new release.
- Until [DKIM handling is refactored in a new major release](https://github.com/docker-mailserver/docker-mailserver/issues/3630#issuecomment-1903401956), this fix ensures the content maintains the expected `_rspamd` ownership.

Fixes #3800

---

OpenDKIM recently had a [contribution for ownership adjustment](https://github.com/docker-mailserver/docker-mailserver/pull/3783), although that was for the user benefit with config volume files, not an issue with DMS support.

Ownership issues in `/tmp/docker-mailserver` shouldn't matter or need to be fixed for DMS, but the present rspamd DKIM support has a rather relaxed / flexible location where it's associated config points to the files instead of a local internal copy made at runtime.

---

**NOTE:** There is already related script for rspamd during startup that attempts to [get DKIM keys to inspect by parsing `path` settings in `dkim_signing.conf`](https://github.com/docker-mailserver/docker-mailserver/blob/315f33c9fe8fad64bee1f8f4a93e67e887e870ae/target/scripts/startup/setup.d/security/rspamd.sh#L307-L337), logging warnings when the ownership is not `_rspamd`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
