### PR TITLE
fix: Ensure configs are sanitized for parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ The most noteworthy change of this release is the update of the container's base
 - **Tests:**
   - Refactored helper methods for sending e-mails with specific `Message-ID` headers and the helpers for retrieving + filtering logs, which together help isolate logs relevant to specific mail when multiple mails have been processed within a single test. ([#3786](https://github.com/docker-mailserver/docker-mailserver/pull/3786))
 
+### Fixes
+
+- DMS config files that are parsed line by line are now more robust to parse by detecting and fixing line-endings ([#3819](https://github.com/docker-mailserver/docker-mailserver/pull/3819))
+
 ## [v13.3.1](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.3.1)
 
 ### Fixes

--- a/target/scripts/helpers/accounts.sh
+++ b/target/scripts/helpers/accounts.sh
@@ -25,10 +25,6 @@ function _create_accounts() {
     _log 'trace' "Regenerating postfix user list"
     echo "# WARNING: this file is auto-generated. Modify ${DATABASE_ACCOUNTS} to edit the user list." > /etc/postfix/vmailbox
 
-    # checking that ${DATABASE_ACCOUNTS} ends with a newline
-    # shellcheck disable=SC1003
-    sed -i -e '$a\' "${DATABASE_ACCOUNTS}"
-
     chown dovecot:dovecot "${DOVECOT_USERDB_FILE}"
     chmod 640 "${DOVECOT_USERDB_FILE}"
 
@@ -162,10 +158,6 @@ function _create_masters() {
     sed -i 's|\r||g' "${DATABASE_DOVECOT_MASTERS}"
 
     _log 'trace' "Regenerating dovecot masters list"
-
-    # checking that ${DATABASE_DOVECOT_MASTERS} ends with a newline
-    # shellcheck disable=SC1003
-    sed -i -e '$a\' "${DATABASE_DOVECOT_MASTERS}"
 
     chown dovecot:dovecot "${DOVECOT_MASTERDB_FILE}"
     chmod 640 "${DOVECOT_MASTERDB_FILE}"

--- a/target/scripts/helpers/accounts.sh
+++ b/target/scripts/helpers/accounts.sh
@@ -19,9 +19,6 @@ function _create_accounts() {
   _create_masters
 
   if [[ -f ${DATABASE_ACCOUNTS} ]]; then
-    _log 'trace' "Checking file line endings"
-    sed -i 's|\r||g' "${DATABASE_ACCOUNTS}"
-
     _log 'trace' "Regenerating postfix user list"
     echo "# WARNING: this file is auto-generated. Modify ${DATABASE_ACCOUNTS} to edit the user list." > /etc/postfix/vmailbox
 
@@ -154,9 +151,6 @@ function _create_masters() {
 
   local DATABASE_DOVECOT_MASTERS='/tmp/docker-mailserver/dovecot-masters.cf'
   if [[ -f ${DATABASE_DOVECOT_MASTERS} ]]; then
-    _log 'trace' "Checking file line endings"
-    sed -i 's|\r||g' "${DATABASE_DOVECOT_MASTERS}"
-
     _log 'trace' "Regenerating dovecot masters list"
 
     chown dovecot:dovecot "${DOVECOT_MASTERDB_FILE}"

--- a/target/scripts/helpers/aliases.sh
+++ b/target/scripts/helpers/aliases.sh
@@ -12,11 +12,6 @@ function _handle_postfix_virtual_config() {
   local DATABASE_VIRTUAL=/tmp/docker-mailserver/postfix-virtual.cf
 
   if [[ -f ${DATABASE_VIRTUAL} ]]; then
-    # fixing old virtual user file
-    if grep -q ",$" "${DATABASE_VIRTUAL}"; then
-      sed -i -e "s|, |,|g" -e "s|,$||g" "${DATABASE_VIRTUAL}"
-    fi
-
     cp -f "${DATABASE_VIRTUAL}" /etc/postfix/virtual
   else
     _log 'debug' "'${DATABASE_VIRTUAL}' not provided - no mail alias/forward created"

--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -17,6 +17,12 @@ function _escape_for_sed() {
 # Returns input after filtering out lines that are:
 # empty, white-space, comments (`#` as the first non-whitespace character)
 function _get_valid_lines_from_file() {
+  # Correctly detect missing final newline:
+  # https://stackoverflow.com/questions/38746/how-to-detect-file-ends-in-newline#comment82380232_25749716
+  if [[ $(tail -c1 "${1}" | wc -l) -gt 0 ]]; then
+    _log 'warn' "${1} is missing a final newline. The last line will not be processed!"
+  fi
+
   grep --extended-regexp --invert-match "^\s*$|^\s*#" "${1}" || true
 }
 

--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -26,11 +26,13 @@ function _get_valid_lines_from_file() {
 # This is to sanitize configs from users that unknowingly introduced CRLF:
 function _convert_crlf_to_lf_if_necessary() {
   if [[ $(file "${1}") =~ 'CRLF' ]]; then
-    _log 'warn' "${1} contains CRLF line-endings."
+    _log 'warn' "File '${1}' contains CRLF line-endings"
 
-    if [[ -w "${1}" ]]; then
+    if [[ -w ${1} ]]; then
       _log 'debug' 'Converting CRLF to LF'
       sed -i 's|\r||g' "${1}"
+    else
+      _log 'warn' "File '${1}' is not writable - cannot change CRLF to LF"
     fi
   fi
 }
@@ -43,12 +45,12 @@ function _append_final_newline_if_missing() {
   # https://unix.stackexchange.com/questions/159557/how-to-non-invasively-test-for-write-access-to-a-file
   if [[ $(tail -c1 "${1}" | wc -l) -eq 0 ]]; then
     # Avoid fixing when the destination is read-only:
-    if [[ -w "${1}" ]]; then
+    if [[ -w ${1} ]]; then
       printf '\n' >> "${1}"
 
-      _log 'warn' "${1} was missing a final newline. This has been fixed."
+      _log 'info' "File '${1}' was missing a final newline - this has been fixed"
     else
-      _log 'warn' "${1} is missing a final newline. The last line will not be processed!"
+      _log 'warn' "File '${1}' is missing a final newline - it is not writable, hence it was not fixed - the last line will not be processed!"
     fi
   fi
 }

--- a/target/scripts/startup/setup.d/postfix.sh
+++ b/target/scripts/startup/setup.d/postfix.sh
@@ -127,9 +127,7 @@ function __postfix__setup_override_configuration() {
   local OVERRIDE_CONFIG_POSTFIX_MASTER='/tmp/docker-mailserver/postfix-master.cf'
   if [[ -f ${OVERRIDE_CONFIG_POSTFIX_MASTER} ]]; then
     while read -r LINE; do
-      if [[ ${LINE} =~ ^[0-9a-z] ]]; then
-        postconf -P "${LINE}"
-      fi
+      [[ ${LINE} =~ ^[0-9a-z] ]] && postconf -P "${LINE}"
     done < <(_get_valid_lines_from_file "${OVERRIDE_CONFIG_POSTFIX_MASTER}")
     __postfix__log 'trace' "Adjusted '/etc/postfix/master.cf' according to '${OVERRIDE_CONFIG_POSTFIX_MASTER}'"
   else

--- a/target/scripts/startup/setup.d/postfix.sh
+++ b/target/scripts/startup/setup.d/postfix.sh
@@ -109,8 +109,9 @@ function _setup_postfix_late() {
 function __postfix__setup_override_configuration() {
   __postfix__log 'debug' 'Overriding / adjusting configuration with user-supplied values'
 
-  if [[ -f /tmp/docker-mailserver/postfix-main.cf ]]; then
-    cat /tmp/docker-mailserver/postfix-main.cf >>/etc/postfix/main.cf
+  local OVERRIDE_CONFIG_POSTFIX_MAIN='/tmp/docker-mailserver/postfix-main.cf'
+  if [[ -f ${OVERRIDE_CONFIG_POSTFIX_MAIN} ]]; then
+    cat "${OVERRIDE_CONFIG_POSTFIX_MAIN}" >>/etc/postfix/main.cf
     _adjust_mtime_for_postfix_maincf
 
     # do not directly output to 'main.cf' as this causes a read-write-conflict
@@ -118,20 +119,21 @@ function __postfix__setup_override_configuration() {
 
     mv /tmp/postfix-main-new.cf /etc/postfix/main.cf
     _adjust_mtime_for_postfix_maincf
-    __postfix__log 'trace' "Adjusted '/etc/postfix/main.cf' according to '/tmp/docker-mailserver/postfix-main.cf'"
+    __postfix__log 'trace' "Adjusted '/etc/postfix/main.cf' according to '${OVERRIDE_CONFIG_POSTFIX_MAIN}'"
   else
-    __postfix__log 'trace' "No extra Postfix settings loaded because optional '/tmp/docker-mailserver/postfix-main.cf' was not provided"
+    __postfix__log 'trace' "No extra Postfix settings loaded because optional '${OVERRIDE_CONFIG_POSTFIX_MAIN}' was not provided"
   fi
 
-  if [[ -f /tmp/docker-mailserver/postfix-master.cf ]]; then
+  local OVERRIDE_CONFIG_POSTFIX_MASTER='/tmp/docker-mailserver/postfix-master.cf'
+  if [[ -f ${OVERRIDE_CONFIG_POSTFIX_MASTER} ]]; then
     while read -r LINE; do
       if [[ ${LINE} =~ ^[0-9a-z] ]]; then
         postconf -P "${LINE}"
       fi
-    done < /tmp/docker-mailserver/postfix-master.cf
-    __postfix__log 'trace' "Adjusted '/etc/postfix/master.cf' according to '/tmp/docker-mailserver/postfix-master.cf'"
+    done < <(_get_valid_lines_from_file "${OVERRIDE_CONFIG_POSTFIX_MASTER}")
+    __postfix__log 'trace' "Adjusted '/etc/postfix/master.cf' according to '${OVERRIDE_CONFIG_POSTFIX_MASTER}'"
   else
-    __postfix__log 'trace' "No extra Postfix settings loaded because optional '/tmp/docker-mailserver/postfix-master.cf' was not provided"
+    __postfix__log 'trace' "No extra Postfix settings loaded because optional '${OVERRIDE_CONFIG_POSTFIX_MASTER}' was not provided"
   fi
 }
 

--- a/test/helper/setup.bash
+++ b/test/helper/setup.bash
@@ -102,7 +102,6 @@ function _init_with_defaults() {
 
   # The config volume cannot be read-only as some data needs to be written at container startup
   #
-  # - two sed failures (unknown lines)
   # - dovecot-quotas.cf (setup-stack.sh:_setup_dovecot_quotas)
   # - postfix-aliases.cf (setup-stack.sh:_setup_postfix_aliases)
   # TODO: Check how many tests need write access. Consider using `docker create` + `docker cp` for easier cleanup.

--- a/test/tests/parallel/set3/scripts/helper_functions.bats
+++ b/test/tests/parallel/set3/scripts/helper_functions.bats
@@ -70,3 +70,49 @@ SOURCE_BASE_PATH="${REPOSITORY_ROOT:?Expected REPOSITORY_ROOT to be set}/target/
   assert_failure
   assert_output --partial "ENV var name must be provided to _env_var_expect_integer"
 }
+
+@test '(utils.sh) _convert_crlf_to_lf_if_necessary' {
+  # shellcheck source=../../../../../target/scripts/helpers/log.sh
+  source "${SOURCE_BASE_PATH}/log.sh"
+  # shellcheck source=../../../../../target/scripts/helpers/utils.sh
+  source "${SOURCE_BASE_PATH}/utils.sh"
+
+  # Create a temporary file in the BATS test-case folder:
+  local TMP_DMS_CONFIG=$(mktemp -p "${BATS_TEST_TMPDIR}" -t 'dms_XXX.cf')
+  # A file with mixed line-endings including CRLF:
+  echo -en 'line one\nline two\r\n' > "${TMP_DMS_CONFIG}"
+
+  # Confirm CRLF detected:
+  run file "${TMP_DMS_CONFIG}"
+  assert_output --partial 'CRLF'
+
+  # Helper method detects and fixes:
+  _convert_crlf_to_lf_if_necessary "${TMP_DMS_CONFIG}"
+  run file "${TMP_DMS_CONFIG}"
+  refute_output --partial 'CRLF'
+
+  rm "${TMP_DMS_CONFIG}"
+}
+
+@test '(utils.sh) _append_final_newline_if_missing' {
+  # shellcheck source=../../../../../target/scripts/helpers/log.sh
+  source "${SOURCE_BASE_PATH}/log.sh"
+  # shellcheck source=../../../../../target/scripts/helpers/utils.sh
+  source "${SOURCE_BASE_PATH}/utils.sh"
+
+  # Create a temporary file in the BATS test-case folder:
+  local TMP_DMS_CONFIG=$(mktemp -p "${BATS_TEST_TMPDIR}" -t 'dms_XXX.cf')
+  # A file missing a final newline:
+  echo -en 'line one\nline two' > "${TMP_DMS_CONFIG}"
+
+  # Confirm missing newline:
+  run bash -c "tail -c 1 '${TMP_DMS_CONFIG}' | wc -l"
+  assert_output '0'
+
+  # Helper method detects and fixes:
+  _append_final_newline_if_missing "${TMP_DMS_CONFIG}"
+  run bash -c "tail -c 1 '${TMP_DMS_CONFIG}' | wc -l"
+  assert_output '1'
+
+  rm "${TMP_DMS_CONFIG}"
+}

--- a/test/tests/parallel/set3/scripts/helper_functions.bats
+++ b/test/tests/parallel/set3/scripts/helper_functions.bats
@@ -90,8 +90,6 @@ SOURCE_BASE_PATH="${REPOSITORY_ROOT:?Expected REPOSITORY_ROOT to be set}/target/
   _convert_crlf_to_lf_if_necessary "${TMP_DMS_CONFIG}"
   run file "${TMP_DMS_CONFIG}"
   refute_output --partial 'CRLF'
-
-  rm "${TMP_DMS_CONFIG}"
 }
 
 @test '(utils.sh) _append_final_newline_if_missing' {
@@ -113,6 +111,4 @@ SOURCE_BASE_PATH="${REPOSITORY_ROOT:?Expected REPOSITORY_ROOT to be set}/target/
   _append_final_newline_if_missing "${TMP_DMS_CONFIG}"
   run bash -c "tail -c 1 '${TMP_DMS_CONFIG}' | wc -l"
   assert_output '1'
-
-  rm "${TMP_DMS_CONFIG}"
 }


### PR DESCRIPTION
# Description

This PR is to address a [parsing concern with `postfix-master.cf`](https://github.com/docker-mailserver/docker-mailserver/issues/3546#issuecomment-1905896062) (_no final newline ignores last line of file_), which happens to be the only config we loop through with `read` to process individual lines from but wasn't using the common helper method.

New helper methods added replace very old corrections (_that we had only for `postfix-accounts.cf`_):
- [`sed -i -e '$a\' /tmp/postfix/accounts.cf`](https://github.com/docker-mailserver/docker-mailserver/commit/63a7be0e975b39b72fe666a61517e32d32b98f55) (_2015, [associated issue](https://github.com/docker-mailserver/docker-mailserver/issues/13)_)
- [`sed -i 's/\r//g' /tmp/docker-mailserver/postfix-accounts.cf`](https://github.com/docker-mailserver/docker-mailserver/pull/160) (_2016, [associated issue](https://github.com/docker-mailserver/docker-mailserver/issues/159)_)
- [`sed -i -e "s|, |,|g" -e "s|,$||g" "${DATABASE_VIRTUAL}"`](https://github.com/docker-mailserver/docker-mailserver/pull/897) (_2018, removed as this should definitely not be a concern anymore?_)

This is also a follow-up PR to https://github.com/docker-mailserver/docker-mailserver/pull/2820 (_which provides more details on those replaced / removed sed calls_)

Commit history is fairly clean with additional context in commit messages if needed.

---

`sed '$a\'` ([`sed` docs](https://www.gnu.org/software/sed/manual/html_node/Other-Commands.html#index-Appending-text-after-a-line)) in particular didn't seem to offer any extra value than just a `printf '\n'`.

I've included several links in comment for the helper as context. That could be removed too, but that sed example was presumably taken from there (top answer), while another better clarifies why `tail -c 1` + ` wc -l` is chosen for detection.

---

I could drop the `-w` read-only conditional, I just recall `setup.bash` in tests having a concern about read-only mount support. Not that our inputs should really cause any concerns there with this change. Let me know, happy to drop that guard (_might affect those eventual plans for error handling magic I've seen discussed_ 😝 ).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
