### PR TITLE
Add warning when container was restarted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file. The format 
 
 The most noteworthy change of this release is the update of the container's base image from Debian 11 ("Bullseye") to Debian 12 ("Bookworm"). This update alone involves breaking changes and requires a careful update!
 
+### Added
+
+- **Internal:**
+  - Add warning when DMS was restarted, which is not supported ([#3821](https://github.com/docker-mailserver/docker-mailserver/pull/3821)).
+
 ### Breaking
 
 - **Updated base image to Debian 12** ([#3403](https://github.com/docker-mailserver/docker-mailserver/pull/3403))

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -180,8 +180,12 @@ _setup
 _run_user_patches
 _start_daemons
 
-# marker to check if container was restarted
-date >/CONTAINER_START
+if [[ -f /CONTAINER_START ]]; then
+  _log 'warn' "docker-mailserver was restarted, which is not supported. This can lead to unexpected behaviour. Use 'docker compose up --force-recreate' to use a fresh container."
+else
+  # create marker to check if container was restarted
+  date >/CONTAINER_START
+fi
 
 _log 'info' "${HOSTNAME} is up and running"
 


### PR DESCRIPTION
# Description

DMS does not (yet) support container restarts and a clean start is necessary. This PR adds a warning when DMS was restarted.

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->

<!-- Link the issue which will be fixed (if any) here: -->

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
