### PR TITLE
docs(fix): New external link icon workaround for mkdocs-material 9.5.5

### DIFF
--- a/docs/content/assets/css/customizations.css
+++ b/docs/content/assets/css/customizations.css
@@ -16,12 +16,16 @@ If you want to append instead, switch `::before` to `::after`.
   src: url('../fonts/external-link.woff') format('woff');
 }
 
-/* Matches the two nav link classes that start with `http` `href` values, regular docs pages use relative URLs instead. */
-.md-tabs__link[href^="http"]::before, .md-nav__link[href^="http"]::before {
+/* 
+   Since mkdocs-material 9.5.5 broke support in our docs from DMS v13.3.1, we now use our own class name,
+   which has been included for the two external nav links in mkdocs.yml via workaround (insert HTML).
+*/
+.icon-external-link::before {
   display: inline-block; /* treat similar to text */
   font-family: 'external-link';
   content:'\0041'; /* represents "A" which our font renders as an icon instead of the "A" glyph */
   font-size: 80%; /* icon is a little too big by default, scale it down */
+  margin-right: 4px;
 }
 
 /* ============================================================================================================= */

--- a/docs/content/assets/css/customizations.css
+++ b/docs/content/assets/css/customizations.css
@@ -16,9 +16,9 @@ If you want to append instead, switch `::before` to `::after`.
   src: url('../fonts/external-link.woff') format('woff');
 }
 
-/* 
-   Since mkdocs-material 9.5.5 broke support in our docs from DMS v13.3.1, we now use our own class name,
-   which has been included for the two external nav links in mkdocs.yml via workaround (insert HTML).
+/*
+  Since mkdocs-material 9.5.5 broke support in our docs from DMS v13.3.1, we now use our own class name,
+  which has been included for the two external nav links in mkdocs.yml via workaround (insert HTML).
 */
 .icon-external-link::before {
   display: inline-block; /* treat similar to text */

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -173,5 +173,5 @@ nav:
     - 'General Information': contributing/general.md
     - 'Tests': contributing/tests.md
     - 'Issues and Pull Requests': contributing/issues-and-pull-requests.md
-  - 'DockerHub': https://hub.docker.com/r/mailserver/docker-mailserver/
-  - 'GHCR': https://github.com/docker-mailserver/docker-mailserver/pkgs/container/docker-mailserver
+  - '<span class="icon-external-link"></span>DockerHub': https://hub.docker.com/r/mailserver/docker-mailserver/
+  - '<span class="icon-external-link"></span>GHCR': https://github.com/docker-mailserver/docker-mailserver/pkgs/container/docker-mailserver


### PR DESCRIPTION
# Description

This is the easiest to maintain workaround now available. Upstream continues to reject the value such a feature for accessibility.

**Approaches evaluated:**
- Previous CSS workaround has become a maintenance burden to adapt (_becomes very verbose to support deploy/preview/dev environments_).
- An unofficial approach via redirect template as a workaround has a bad UX (_at least when tested locally_) as it loads a placeholder page for the sole purpose of redirecting via a separate HTML document, just to display an icon 🙄 
- A similar approach to the current CSS was available, but requires to be a paid sponsor of the project until they reach $20k monthly funding milestone. That is $7k away and I doubt anyone here is interested in $15/month perpetually for a fix.
- The final alternative suggested that is minimal effort is a bit ugly, and **the chosen solution going forward**. The `mkdocs.yml` file gets some raw HTML included into the two external nav links, this just adds a span element to include a `class` of our own that we can reference in CSS.

Fixes #3822

---

Another alternative that was suggested by the primary mkdocs-material dev is to disable [Instant Navigation](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-loading) feature, since that is what broke our current CSS by removing the relative URLs at runtime on the client (browser).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**

I don't think this needs a changelog entry?
