### PR TITLE
docs: Add context to `sender-cleanup` in Postfix `master.cf`

### DIFF
--- a/target/postfix/master.cf
+++ b/target/postfix/master.cf
@@ -46,6 +46,8 @@ pickup         fifo  n       -       n       60      1       pickup
   -o content_filter=
   -o receive_override_options=no_header_body_checks
 
+# This relates to submission(s) services defined above:
+# https://www.postfix.org/BUILTIN_FILTER_README.html#mx_submission
 sender-cleanup unix  n       -       n       -       0       cleanup
   -o syslog_name=postfix/sender-cleanup
   -o header_checks=pcre:/etc/postfix/maps/sender_header_filter.pcre


### PR DESCRIPTION
# Description

Came across this docs page which seems relevant to a separate cleanup service we have configured for submission(s) services.

I figured a little documentation on that might be helpful if ever relevant for maintenance.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)