### PR TITLE
Rspamd: only declare Rspamd variables when not already declared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ The most noteworthy change of this release is the update of the container's base
 ### Fixes
 
 - DMS config files that are parsed line by line are now more robust to parse by detecting and fixing line-endings ([#3819](https://github.com/docker-mailserver/docker-mailserver/pull/3819))
-- variables related to Rspamd are declared as `readonly`, which would cause warnings in the log when being re-declared; we now guard agains this issue ([#3837](https://github.com/docker-mailserver/docker-mailserver/pull/3837))
+- Variables related to Rspamd are declared as `readonly`, which would cause warnings in the log when being re-declared; we now guard against this issue ([#3837](https://github.com/docker-mailserver/docker-mailserver/pull/3837))
 
 ## [v13.3.1](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.3.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The most noteworthy change of this release is the update of the container's base
 ### Fixes
 
 - DMS config files that are parsed line by line are now more robust to parse by detecting and fixing line-endings ([#3819](https://github.com/docker-mailserver/docker-mailserver/pull/3819))
+- variables related to Rspamd are declared as `readonly`, which would cause warnings in the log when being re-declared; we now guard agains this issue ([#3837](https://github.com/docker-mailserver/docker-mailserver/pull/3837))
 
 ## [v13.3.1](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.3.1)
 

--- a/target/scripts/helpers/rspamd.sh
+++ b/target/scripts/helpers/rspamd.sh
@@ -15,14 +15,19 @@ function __do_as_rspamd_user() {
 # they cannot be modified. Use this function when you require common directory
 # names, file names, etc.
 function _rspamd_get_envs() {
-  readonly RSPAMD_LOCAL_D='/etc/rspamd/local.d'
-  readonly RSPAMD_OVERRIDE_D='/etc/rspamd/override.d'
+  # If the variables are already set, we cannot set them again as they are declared
+  # with `readonly`. Checking whether one is declared suffices, because either all
+  # are declared at once, or none.
+  if [[ ! -v RSPAMD_LOCAL_D ]]; then
+    readonly RSPAMD_LOCAL_D='/etc/rspamd/local.d'
+    readonly RSPAMD_OVERRIDE_D='/etc/rspamd/override.d'
 
-  readonly RSPAMD_DMS_D='/tmp/docker-mailserver/rspamd'
-  readonly RSPAMD_DMS_DKIM_D="${RSPAMD_DMS_D}/dkim"
-  readonly RSPAMD_DMS_OVERRIDE_D="${RSPAMD_DMS_D}/override.d"
+    readonly RSPAMD_DMS_D='/tmp/docker-mailserver/rspamd'
+    readonly RSPAMD_DMS_DKIM_D="${RSPAMD_DMS_D}/dkim"
+    readonly RSPAMD_DMS_OVERRIDE_D="${RSPAMD_DMS_D}/override.d"
 
-  readonly RSPAMD_DMS_CUSTOM_COMMANDS_F="${RSPAMD_DMS_D}/custom-commands.conf"
+    readonly RSPAMD_DMS_CUSTOM_COMMANDS_F="${RSPAMD_DMS_D}/custom-commands.conf"
+  fi
 }
 
 # Parses `RSPAMD_DMS_CUSTOM_COMMANDS_F` and executed the directives given by the file.


### PR DESCRIPTION
# Description

Rspamd-related variables are declared with `readonly` in the corresponding helper. To avoid warnings in the log, we guard on whether they have already been declared.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes an issues raised in #3827

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**