### PR TITLE
ci: `docs-preview-deploy.yml` - Use official v4 `download-artifact`

### DIFF
--- a/.github/workflows/docs-preview-deploy.yml
+++ b/.github/workflows/docs-preview-deploy.yml
@@ -23,14 +23,13 @@ jobs:
       # Restore workflow context #
       # ======================== #
 
-      # The official Github Action for downloading artifacts does not support multi-workflow
+      # Retrieve the artifact uploaded from `docs-preview-prepare.yml` workflow run that triggered this deployment
       - name: 'Download build artifact'
-        uses: dawidd6/action-download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
+          name: preview-build
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_id: ${{ github.event.workflow_run.id }}
-          workflow: docs-preview-prepare.yml
-          name: preview-build
 
       - name: 'Extract build artifact'
         run: tar -xf artifact.tar.zst


### PR DESCRIPTION
# Description

Unverified, but should match what the v4 docs expect.

This action is handles initial setup of the deployment workflow (_for doc previews to Netlify_).

**Reference:**
- https://github.com/actions/download-artifact/issues/3#issuecomment-1894005257
- https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/
- https://github.com/actions/download-artifact?tab=readme-ov-file#download-artifacts-from-other-workflow-runs-or-repositories

---

## Context

The 1st part that builds docs for PRs without trust for security reasons (_as [documented in the original PR for this workflow](https://github.com/docker-mailserver/docker-mailserver/pull/1988)_) uploads the artifact to be deployed as shown here:

https://github.com/docker-mailserver/docker-mailserver/blob/9ac11021e1c33d87ec706f3f76b6c3197f1f000d/.github/workflows/docs-preview-prepare.yml#L52-L80

With required secrets in deployment (GH Token + Netfliy):

https://github.com/docker-mailserver/docker-mailserver/blob/9ac11021e1c33d87ec706f3f76b6c3197f1f000d/.github/workflows/docs-preview-deploy.yml#L63-L64

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)
