### PR TITLE
docs: Minor revisions to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,27 @@
 
 [ci::status]: https://img.shields.io/github/actions/workflow/status/docker-mailserver/docker-mailserver/default_on_push.yml?branch=master&color=blue&label=CI&logo=github&logoColor=white&style=for-the-badge
 [ci::github]: https://github.com/docker-mailserver/docker-mailserver/actions
-[docker::pulls]: https://img.shields.io/docker/pulls/mailserver/docker-mailserver.svg?style=for-the-badge&logo=docker&logoColor=white
+[docker::pulls]: https://img.shields.io/docker/pulls/mailserver/docker-mailserver.svg?style=for-the-badge&logo=docker&logoColor=white&color=blue
 [docker::hub]: https://hub.docker.com/r/mailserver/docker-mailserver/
-[documentation::badge]: https://img.shields.io/badge/DOCUMENTATION-GH%20PAGES-0078D4?style=for-the-badge&logo=git&logoColor=white
+[documentation::badge]: https://img.shields.io/badge/DOCUMENTATION-GH%20PAGES-0078D4?style=for-the-badge&logo=googledocs&logoColor=white
 [documentation::web]: https://docker-mailserver.github.io/docker-mailserver/latest/
 
 ## :page_with_curl: About
 
-A production-ready fullstack but simple containerized mail server (SMTP, IMAP, LDAP, Anti-spam, Anti-virus, etc.). Only configuration files, no SQL database. Keep it simple and versioned. Easy to deploy and upgrade. Originally created by @tomav, this project is now maintained by volunteers since January 2021.
+A production-ready fullstack but simple containerized mail server (SMTP, IMAP, LDAP, Anti-spam, Anti-virus, etc.).
+- Only configuration files, no SQL database. Keep it simple and versioned. Easy to deploy and upgrade.
+- Originally created by [@tomav](https://github.com/tomav), this project is now maintained by volunteers since January 2021.
 
-## :bulb: Documentation
+## <!-- Adds a thin line break separator style -->
 
-We provide a [dedicated documentation][documentation::web] hosted on GitHub Pages. Make sure to read it as it contains all the information necessary to set up and configure your mail server. The documentation is crafted with Markdown & [MkDocs Material](https://squidfunk.github.io/mkdocs-material/).
+> [!TIP]
+> Be sure to read [our documentation][documentation::web]. It provides guidance on initial setup of your mail server.
 
-## :boom: Issues
-
-If you have issues, please search through [the documentation][documentation::web] **for your version** before opening an issue. The issue tracker is for issues, not for personal support. Make sure the version of the documentation matches the image version you're using!
+> [!IMPORTANT]
+> If you have issues, please search through [the documentation][documentation::web] **for your version** before opening an issue.
+> 
+> The issue tracker is for issues, not for personal support.  
+> Make sure the version of the documentation matches the image version you're using!
 
 ## :link: Links to Useful Resources
 


### PR DESCRIPTION
# Description

Slight formatting changes:
- Docker badge colour was not consistent with blue shade.
- About paragraph adapted to use some bullet points, additionally linking to project creator profile.
- Docs + Issues sections merged and converted to admonitions (_or as Github calls them [alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts), feature [since Dec 2023](https://github.blog/changelog/2023-12-14-new-markdown-extension-alerts-provide-distinctive-styling-for-significant-content/)_).

Happy to revert if there's any disagreement, seemed more appropriate.

### Before

> ![image](https://github.com/docker-mailserver/docker-mailserver/assets/5098581/33c280ba-e8af-42bb-8cde-9919f44c70be)

### After

> ![image](https://github.com/docker-mailserver/docker-mailserver/assets/5098581/8bafed95-41ac-4a0b-8831-4fe9f28b03f1)


## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)
