### PR TITLE
docs: Add Debian 12 breaking change for `opendmarc` package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ The most noteworthy change of this release is the update of the container's base
     - The script now uses `/etc/os-release` to determine the release name of Debian
     - Removed custom installations of Fail2Ban, getmail6 and Rspamd
     - Updated packages lists and added comments for maintainability
+- OpenDMARC upgrade: `v1.4.0` => `v1.4.2`
+  - Previous versions of OpenDMARC would place incoming mail from domains announcing `p=quarantaine` (_that fail the DMARC check_) into the [Postfix "hold" queue](https://www.postfix.org/QSHAPE_README.html#hold_queue) until administrative intervention.
+  - OpenDMARC v1.4.2 has disabled that feature by default, but it can be enabled again by adding the setting `HoldQuarantinedMessages true` to [`/etc/opendmarc.conf`](https://github.com/docker-mailserver/docker-mailserver/blob/v13.3.1/target/opendmarc/opendmarc.conf) (_provided from DMS_).
+    - [Our `user-patches.sh` feature](https://docker-mailserver.github.io/docker-mailserver/latest/config/advanced/override-defaults/user-patches/) provides a convenient approach to updating that config file.
+    - Please let us know if you disagree with the upstream default being carried with DMS, or the value of providing alternative configuration support within DMS.
 - **Postfix:**
   - Postfix upgrade from 3.5 to 3.7 ([#3403](https://github.com/docker-mailserver/docker-mailserver/pull/3403))
     - `compatibility_level` was raised from `2` to `3.6`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ The most noteworthy change of this release is the update of the container's base
     - The script now uses `/etc/os-release` to determine the release name of Debian
     - Removed custom installations of Fail2Ban, getmail6 and Rspamd
     - Updated packages lists and added comments for maintainability
-- OpenDMARC upgrade: `v1.4.0` => `v1.4.2`
+- OpenDMARC upgrade: `v1.4.0` => `v1.4.2` ([#3841](https://github.com/docker-mailserver/docker-mailserver/pull/3841))
   - Previous versions of OpenDMARC would place incoming mail from domains announcing `p=quarantaine` (_that fail the DMARC check_) into the [Postfix "hold" queue](https://www.postfix.org/QSHAPE_README.html#hold_queue) until administrative intervention.
-  - OpenDMARC v1.4.2 has disabled that feature by default, but it can be enabled again by adding the setting `HoldQuarantinedMessages true` to [`/etc/opendmarc.conf`](https://github.com/docker-mailserver/docker-mailserver/blob/v13.3.1/target/opendmarc/opendmarc.conf) (_provided from DMS_).
+  - [OpenDMARC v1.4.2 has disabled that feature by default](https://github.com/trusteddomainproject/OpenDMARC/issues/105), but it can be enabled again by adding the setting `HoldQuarantinedMessages true` to [`/etc/opendmarc.conf`](https://github.com/docker-mailserver/docker-mailserver/blob/v13.3.1/target/opendmarc/opendmarc.conf) (_provided from DMS_).
     - [Our `user-patches.sh` feature](https://docker-mailserver.github.io/docker-mailserver/latest/config/advanced/override-defaults/user-patches/) provides a convenient approach to updating that config file.
     - Please let us know if you disagree with the upstream default being carried with DMS, or the value of providing alternative configuration support within DMS.
 - **Postfix:**


### PR DESCRIPTION
# Description

Part of the breaking changes for v14 with Debian 12 package upgrade, this config change was released in 1.4.2, while we previously had 1.4.0. Thus upstream would seem to treat it as a bugfix 👍 (_but we should probably still mention this, hence the addition to changelog for awareness_)

Can we also get confirmation from @georglauterbach on what the [dmarc equivalent behaviour in rspamd](https://www.rspamd.com/doc/modules/dmarc.html) has been configured for with DMS? (_regardless of explicitly / implicitly_). We should probably have this in sync.

Fixes #3828

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update (CHANGELOG fix)

## Checklist:

- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
