### PR TITLE
Rspamd scripts: only correct permissions when directory exists

### DIFF
--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -97,8 +97,10 @@ function _setup_apply_fixes_after_configuration() {
 
   _rspamd_get_envs
   # /tmp/docker-mailserver/rspamd/dkim
-  _log 'debug' "Ensuring '${RSPAMD_DMS_DKIM_D}' is owned by '_rspamd:_rspamd'"
-  chown -R _rspamd:_rspamd "${RSPAMD_DMS_DKIM_D}"
+  if [[ -d ${RSPAMD_DMS_DKIM_D} ]]; then
+    _log 'debug' "Ensuring '${RSPAMD_DMS_DKIM_D}' is owned by '_rspamd:_rspamd'"
+    chown -R _rspamd:_rspamd "${RSPAMD_DMS_DKIM_D}"
+  fi
 }
 
 function _run_user_patches() {


### PR DESCRIPTION
# Description

Only fix the permissions on the Rspamd DKIM directory when the directory actually exists. I just updated my deployment and saw

```txt
chown: cannot access '/tmp/docker-mailserver/rspamd/dkim': No such file or directory
```

This PR fixes the issue above.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**

Changelog entry not required IMO.