### PR TITLE
fix: `packages.sh` - Download `jaq` via release `tag` not `latest`

### DIFF
--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -38,7 +38,8 @@ function _pre_installation_steps() {
 function _install_utils() {
   _log 'debug' 'Installing utils sourced from Github'
   _log 'trace' 'Installing jaq'
-  curl -sSfL "https://github.com/01mf02/jaq/releases/latest/download/jaq-v1.2.0-$(uname -m)-unknown-linux-gnu" -o /usr/bin/jaq && chmod +x /usr/bin/jaq
+  local JAQ_TAG='v1.3.0'
+  curl -sSfL "https://github.com/01mf02/jaq/releases/download/${JAQ_TAG}/jaq-${JAQ_TAG}-$(uname -m)-unknown-linux-gnu" -o /usr/bin/jaq && chmod +x /usr/bin/jaq
 
   _log 'trace' 'Installing swaks'
   local SWAKS_VERSION='20240103.0'


### PR DESCRIPTION
# Description

As the filename includes the version / tag, we cannot rely on the latest URL to be stable.

This additionally bumps `jaq` from `v1.2.0` to [`v1.3.0`](https://github.com/01mf02/jaq/releases/tag/v1.3.0).

---

I performed a build locally with `make build` and while it didn't fail on the build, I was watching the log output and noticed a curl 404 line, which turned out to be:

```
7.203 [  TRACE  ]  Installing jaq
7.848 curl: (22) The requested URL returned error: 404
```

The build AFAIK failed for other reasons (Debian package repos being unavailable, which is common experience lately for me), so I'm not sure if the `jaq` curl failure above would normally be caught (_**EDIT:** Had a successful build, it wasn't caught as a failure_):

<details>
<summary>Debian package build log failure snippets</summary>

```
61.90 Ign:215 http://deb.debian.org/debian bookworm/main amd64 whois amd64 5.5.17
65.90 Err:177 http://deb.debian.org/debian bookworm/main amd64 libio-string-perl all 1.08-4
65.90   Could not connect to debian.map.fastlydns.net:80 (151.101.166.132), connection timed out Unable to connect to deb.debian.org:http: [IP: 151.101.166.132 80]

...

65.90 Err:215 http://deb.debian.org/debian bookworm/main amd64 whois amd64 5.5.17
65.90   Unable to connect to deb.debian.org:http: [IP: 151.101.166.132 80]
65.90 Fetched 56.9 MB in 47s (1207 kB/s)
65.90 E: Failed to fetch http://deb.debian.org/debian/pool/main/libi/libio-string-perl/libio-string-perl_1.08-4_all.deb  Could not connect to debian.map.fastlydns.net:80 (151.101.166.132), connection timed out Unable to connect to deb.debian.org:http: [IP: 151.101.166.132 80]

...

65.90 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
------
Dockerfile:31
--------------------
  29 |     COPY target/scripts/helpers/log.sh /usr/local/bin/helpers/log.sh
  30 |
  31 | >>> RUN /bin/bash /build/packages.sh && rm -r /build
  32 |
  33 |     # -----------------------------------------------
--------------------
ERROR: failed to solve: process "/bin/bash -e -o pipefail -c /bin/bash /build/packages.sh && rm -r /build" did not complete successfully: exit code: 100
make: *** [Makefile:21: build] Error 1
```

**NOTE:** The initial package install with postfix was successful, usually I just run `make build` a few times and it'll be successful, perhaps the system (Docker on WSL2) has trouble with DNS or too many queries 🤷‍♂️ (_it's common for the debian package web  search frontend to be unreachable via host browsers too though_)

</details>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
