### PR TITLE
fix(rspamd): Add missing comma to `local_networks` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The most noteworthy change of this release is the update of the container's base
   - `DEFAULT_RELAY_HOST` ENV can now also use the `RELAY_USER` + `RELAY_PASSWORD` ENV for supplying credentials.
   - `RELAY_HOST` ENV no longer enforces configuring outbound SMTP to require credentials. Like `DEFAULT_RELAY_HOST` it can now configure a relay where credentials are optional.
   - Restarting DMS should not be required when configuring relay hosts without these ENV, but solely via `setup relay ...`, as change detection events now apply relevant Postfix setting changes for supporting credentials too.
+- Rspamd configuration: Add a missing comma in `local_networks` so that all internal IP addresses are actually considered as internal ([3862](https://github.com/docker-mailserver/docker-mailserver/pull/3862))
 
 ## [v13.3.1](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.3.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ The most noteworthy change of this release is the update of the container's base
   - `DEFAULT_RELAY_HOST` ENV can now also use the `RELAY_USER` + `RELAY_PASSWORD` ENV for supplying credentials.
   - `RELAY_HOST` ENV no longer enforces configuring outbound SMTP to require credentials. Like `DEFAULT_RELAY_HOST` it can now configure a relay where credentials are optional.
   - Restarting DMS should not be required when configuring relay hosts without these ENV, but solely via `setup relay ...`, as change detection events now apply relevant Postfix setting changes for supporting credentials too.
-- Rspamd configuration: Add a missing comma in `local_networks` so that all internal IP addresses are actually considered as internal ([3862](https://github.com/docker-mailserver/docker-mailserver/pull/3862))
+- Rspamd configuration: Add a missing comma in `local_networks` so that all internal IP addresses are actually considered as internal ([#3862](https://github.com/docker-mailserver/docker-mailserver/pull/3862))
 
 ## [v13.3.1](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.3.1)
 

--- a/target/rspamd/local.d/options.inc
+++ b/target/rspamd/local.d/options.inc
@@ -1,3 +1,3 @@
 pidfile = false;
 soft_reject_on_timeout = true;
-local_networks = "127.0.0.1/8, 10.0.0.0/8, 172.16.0.0/12 192.168.0.0/16";
+local_networks = "127.0.0.1/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16";


### PR DESCRIPTION
# Description

For rspamd, when setting `sign_local = true;` in `dkim_signing.conf`, I expect that normal internal IP addresses are "local" by default. Looking at `options.inc`, however, you can see that a comma is missing between the last two IP blocks. So the intention is clearly there, but it does not work.

This PR adds the comma. Mails sent from an IP in 192.168.*.* are now signed on my system, which did not work before.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
