### PR TITLE
fix: Apply SELinux security context after moving to mail-state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ The most noteworthy change of this release is the update of the container's base
   - `RELAY_HOST` ENV no longer enforces configuring outbound SMTP to require credentials. Like `DEFAULT_RELAY_HOST` it can now configure a relay where credentials are optional.
   - Restarting DMS should not be required when configuring relay hosts without these ENV, but solely via `setup relay ...`, as change detection events now apply relevant Postfix setting changes for supporting credentials too.
 - Rspamd configuration: Add a missing comma in `local_networks` so that all internal IP addresses are actually considered as internal ([#3862](https://github.com/docker-mailserver/docker-mailserver/pull/3862))
-- Ensure correct SELinux security context labels for files and directories moved to mail-state during setup ([#3890](https://github.com/docker-mailserver/docker-mailserver/pull/3890))
+- Ensure correct SELinux security context labels for files and directories moved to the mail-state volume during setup ([#3890](https://github.com/docker-mailserver/docker-mailserver/pull/3890))
 
 ## [v13.3.1](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.3.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ The most noteworthy change of this release is the update of the container's base
   - `RELAY_HOST` ENV no longer enforces configuring outbound SMTP to require credentials. Like `DEFAULT_RELAY_HOST` it can now configure a relay where credentials are optional.
   - Restarting DMS should not be required when configuring relay hosts without these ENV, but solely via `setup relay ...`, as change detection events now apply relevant Postfix setting changes for supporting credentials too.
 - Rspamd configuration: Add a missing comma in `local_networks` so that all internal IP addresses are actually considered as internal ([#3862](https://github.com/docker-mailserver/docker-mailserver/pull/3862))
+- Ensure correct SELinux security context labels for files and directories moved to mail-state during setup ([#3890](https://github.com/docker-mailserver/docker-mailserver/pull/3890))
 
 ## [v13.3.1](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.3.1)
 

--- a/target/scripts/startup/setup.d/mail_state.sh
+++ b/target/scripts/startup/setup.d/mail_state.sh
@@ -50,7 +50,7 @@ function _setup_save_states() {
         mv "${SERVICEFILE}" "${DEST}"
         # Apply SELinux security context to match the state directory, so access
         # is not restricted to the current running container:
-        chcon -R --reference="${STATEDIR}" "${DEST}" 2> /dev/null || true
+        chcon -R --reference="${STATEDIR}" "${DEST}" 2>/dev/null || true
       fi
 
       # Symlink the original file in the container ($SERVICEFILE) to be
@@ -74,7 +74,7 @@ function _setup_save_states() {
         mv "${SERVICEDIR}" "${DEST}"
         # Apply SELinux security context to match the state directory, so access
         # is not restricted to the current running container:
-        chcon -R --reference="${STATEDIR}" "${DEST}" 2> /dev/null || true
+        chcon -R --reference="${STATEDIR}" "${DEST}" 2>/dev/null || true
       fi
 
       # Symlink the original path in the container ($SERVICEDIR) to be

--- a/target/scripts/startup/setup.d/mail_state.sh
+++ b/target/scripts/startup/setup.d/mail_state.sh
@@ -50,7 +50,7 @@ function _setup_save_states() {
         mv "${SERVICEFILE}" "${DEST}"
         # Apply SELinux security context to match the state directory, so access
         # is not restricted to the current running container:
-        chcon -R --reference="${STATEDIR}" "${DEST}"
+        chcon -R --reference="${STATEDIR}" "${DEST}" 2> /dev/null || true
       fi
 
       # Symlink the original file in the container ($SERVICEFILE) to be
@@ -74,7 +74,7 @@ function _setup_save_states() {
         mv "${SERVICEDIR}" "${DEST}"
         # Apply SELinux security context to match the state directory, so access
         # is not restricted to the current running container:
-        chcon -R --reference="${STATEDIR}" "${DEST}"
+        chcon -R --reference="${STATEDIR}" "${DEST}" 2> /dev/null || true
       fi
 
       # Symlink the original path in the container ($SERVICEDIR) to be

--- a/target/scripts/startup/setup.d/mail_state.sh
+++ b/target/scripts/startup/setup.d/mail_state.sh
@@ -48,6 +48,9 @@ function _setup_save_states() {
         _log 'trace' "Moving ${SERVICEFILE} to ${DEST}"
         # Empty volume was mounted, or new content from enabling a feature ENV:
         mv "${SERVICEFILE}" "${DEST}"
+        # Apply SELinux security context to match the state directory, so access
+        # is not restricted to the current running container:
+        chcon -R --reference="${STATEDIR}" "${DEST}"
       fi
 
       # Symlink the original file in the container ($SERVICEFILE) to be
@@ -69,6 +72,9 @@ function _setup_save_states() {
         _log 'trace' "Moving contents of ${SERVICEDIR} to ${DEST}"
         # Empty volume was mounted, or new content from enabling a feature ENV:
         mv "${SERVICEDIR}" "${DEST}"
+        # Apply SELinux security context to match the state directory, so access
+        # is not restricted to the current running container:
+        chcon -R --reference="${STATEDIR}" "${DEST}"
       fi
 
       # Symlink the original path in the container ($SERVICEDIR) to be


### PR DESCRIPTION
# Description

After `setup.d/mail_state.sh` moves files/dirs from the container itself to `/var/mail-state`, they retains their SELinux security context labels, which are bound to the current container. When using named volumes, this leads to the files/dirs becoming inaccessible.

This PR lets the setup script apply the security context from the mail-state directory after moving, so they are still accessible when a new container is created that re-uses a named volume. The result is that the moved files will have the same security context as if they were created by the script.

This also explains the issue only occurs with the mail-state volume. In the other volumes only new files are created, instead of files being moved.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #3887 

## Type of change

<!-- Delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
