### PR TITLE
Fix typo and broken README link

### DIFF
--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -212,7 +212,7 @@ Configures the handling of creating mails with forged sender addresses.
 
 ##### ENABLE_SRS
 
-Enables the Sender Rewriting Scheme. SRS is needed if DMS acts as forwarder. See [postsrsd](https://github.com/roehling/postsrsd/blob/master/README.md#sender-rewriting-scheme-crash-course) for further explanation.
+Enables the Sender Rewriting Scheme. SRS is needed if DMS acts as forwarder. See [postsrsd](https://github.com/roehling/postsrsd/blob/main/README.rst) for further explanation.
 
 - **0** => Disabled
 - 1 => Enabled

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -2,7 +2,7 @@
 title: Usage
 ---
 
-This pages explains how to get started with DMS. The guide uses Docker Compose as a reference. In our examples, a volume mounts the host location [`docker-data/dms/config/`][docs::dms-volumes-config] to `/tmp/docker-mailserver/` inside the container.
+This page explains how to get started with DMS. The guide uses Docker Compose as a reference. In our examples, a volume mounts the host location [`docker-data/dms/config/`][docs::dms-volumes-config] to `/tmp/docker-mailserver/` inside the container.
 
 [docs::dms-volumes-config]: ./config/advanced/optional-config.md#volumes-config
 


### PR DESCRIPTION
- Fix typo in `docs/content/usage.md`
- Correct broken README link for SRS in `docs/content/config/environment.md`