### PR TITLE
fix: Move spam to mailbox associated to the `\Junk` special-use attribute (#3918)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,9 @@ The most noteworthy change of this release is the update of the container's base
     - `smtpd_relay_restrictions` (relay policy) is now evaluated after `smtpd_recipient_restrictions` (spam policy). Previously it was evaluated before `smtpd_recipient_restrictions`. Mail to be relayed via DMS must now pass through the spam policy first.
     - The TLS fingerprint policy has changed the default from MD5 to SHA256 (_DMS does not modify this Postfix parameter, but may affect any user customizations that do_).
 - **Dovecot**
-  - If `MOVE_SPAM_TO_JUNK=1`, spam messages now will be moved to one mailbox with `\Junk` special-use attribute. If there is no such mailbox, messages will be moved to 'Junk' mailbox, as earlier. This change may break configurations with the file `spam_to_junk.sieve` patched via `user-patches.sh`.
+  - The "Junk" mailbox (folder) is now referenced by it's [special-use flag `\Junk`](https://docker-mailserver.github.io/docker-mailserver/v13.3/examples/use-cases/imap-folders/) instead of an explicit mailbox. ([#3925](https://github.com/docker-mailserver/docker-mailserver/pull/3925))
+    - This provides compatibility for the Junk mailbox when it's folder name differs (_eg: Renamed to "Spam"_).
+    - Potential breakage if your deployment modifies our `spam_to_junk.sieve` sieve script (_which is created during container startup when ENV `MOVE_SPAM_TO_JUNK=1`_) that handles storing spam mail into a users "Junk" mailbox folder.
 - **rsyslog:**
   - Debian 12 adjusted the `rsyslog` configuration for the default file template from `RSYSLOG_TraditionalFileFormat` to `RSYSLOG_FileFormat` (_upstream default since 2012_). This change may affect you if you have any monitoring / analysis of log output (_eg: `mail.log` / `docker logs`_).
     - The two formats are roughly equivalent to [RFC 3164](https://www.rfc-editor.org/rfc/rfc3164)) and [RFC 5424](https://datatracker.ietf.org/doc/html/rfc5424#section-1) respectively.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ The most noteworthy change of this release is the update of the container's base
       - DMS `main.cf` has renamed `postscreen_dnsbl_whitelist_threshold` to `postscreen_dnsbl_allowlist_threshold` as part of this change.
     - `smtpd_relay_restrictions` (relay policy) is now evaluated after `smtpd_recipient_restrictions` (spam policy). Previously it was evaluated before `smtpd_recipient_restrictions`. Mail to be relayed via DMS must now pass through the spam policy first.
     - The TLS fingerprint policy has changed the default from MD5 to SHA256 (_DMS does not modify this Postfix parameter, but may affect any user customizations that do_).
+- **Dovecot**
+  - If `MOVE_SPAM_TO_JUNK=1`, spam messages now will be moved to one mailbox with `\Junk` special-use attribute. If there is no such mailbox, messages will be moved to 'Junk' mailbox, as earlier. This change may break configurations with the file `spam_to_junk.sieve` patched via `user-patches.sh`.
 - **rsyslog:**
   - Debian 12 adjusted the `rsyslog` configuration for the default file template from `RSYSLOG_TraditionalFileFormat` to `RSYSLOG_FileFormat` (_upstream default since 2012_). This change may affect you if you have any monitoring / analysis of log output (_eg: `mail.log` / `docker logs`_).
     - The two formats are roughly equivalent to [RFC 3164](https://www.rfc-editor.org/rfc/rfc3164)) and [RFC 5424](https://datatracker.ietf.org/doc/html/rfc5424#section-1) respectively.

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -329,9 +329,9 @@ Note: More information at <https://dovecot.org/doc/dovecot-example.conf>
 ##### MOVE_SPAM_TO_JUNK
 
 - 0 => Spam messages will be delivered in the mailbox.
-- **1** => Spam messages will be delivered in the `Junk` folder.
+- **1** => Spam messages will be delivered in a folder with '\Junk' special-use attribute.
 
-Routes mail identified as spam into the recipient(s) Junk folder (_via a Dovecot Sieve script_).
+Routes mail identified as spam into the recipient(s) folder with '\Junk' special-use attribute set (_via a Dovecot Sieve script_).
 
 !!! info
 

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -328,10 +328,12 @@ Note: More information at <https://dovecot.org/doc/dovecot-example.conf>
 
 ##### MOVE_SPAM_TO_JUNK
 
-- 0 => Spam messages will be delivered in the mailbox.
-- **1** => Spam messages will be delivered in a folder with '\Junk' special-use attribute.
+- 0 => Spam messages will be delivered to the inbox.
+- **1** => Spam messages will be delivered to the Junk mailbox.
 
-Routes mail identified as spam into the recipient(s) folder with '\Junk' special-use attribute set (_via a Dovecot Sieve script_).
+Routes mail identified as spam into the recipient(s) Junk mailbox (_a specialized folder for junk associated to the [special-use flag `\Junk`][docs::dovecot::special-use-flag], handled via a Dovecot sieve script internally_).
+
+[docs::dovecot::special-use-flag]: ../examples/use-cases/imap-folders.md
 
 !!! info
 

--- a/target/dovecot/90-sieve.conf
+++ b/target/dovecot/90-sieve.conf
@@ -51,7 +51,7 @@ plugin {
   # deprecated imapflags extension in addition to all extensions were already
   # enabled by default.
   #sieve_extensions = +notify +imapflags
-  sieve_extensions = +notify +imapflags +vnd.dovecot.pipe +vnd.dovecot.filter
+  sieve_extensions = +notify +imapflags +special-use +vnd.dovecot.pipe +vnd.dovecot.filter
 
   # Which Sieve language extensions are ONLY available in global scripts. This
   # can be used to restrict the use of certain Sieve extensions to administrator

--- a/target/scripts/startup/setup.d/security/misc.sh
+++ b/target/scripts/startup/setup.d/security/misc.sh
@@ -304,11 +304,11 @@ function _setup_spam_to_junk() {
     _log 'debug' 'Spam emails will be moved to the Junk folder'
     mkdir -p /usr/lib/dovecot/sieve-global/after/
     cat >/usr/lib/dovecot/sieve-global/after/spam_to_junk.sieve << EOF
-require ["fileinto","mailbox"];
+require ["fileinto","special-use"];
 
 if anyof (header :contains "X-Spam-Flag" "YES",
           header :contains "X-Spam" "Yes") {
-    fileinto "Junk";
+    fileinto :specialuse "\\\\Junk" "Junk";
 }
 EOF
     sievec /usr/lib/dovecot/sieve-global/after/spam_to_junk.sieve

--- a/test/config/junk-mailbox/user-patches.sh
+++ b/test/config/junk-mailbox/user-patches.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+##
+# This user script will be executed between configuration and starting daemons
+# To enable it you must save it in your config directory as "user-patches.sh"
+##
+
+echo "[user-patches.sh] Adjusting 'Junk' mailbox name to verify special-use flag delivers to modified mailbox folder name"
+
+sed -i -e 's/mailbox Junk/mailbox Spam/' /etc/dovecot/conf.d/15-mailboxes.conf
+
+### Before / After ###
+
+# mailbox Junk {
+#   auto = subscribe
+#   special_use = \Junk
+# }
+
+# mailbox Spam {
+#   auto = subscribe
+#   special_use = \Junk
+# }

--- a/test/config/junk-mailbox/user-patches.sh
+++ b/test/config/junk-mailbox/user-patches.sh
@@ -4,7 +4,7 @@
 # To enable it you must save it in your config directory as "user-patches.sh"
 ##
 
-echo "[user-patches.sh] Adjusting 'Junk' mailbox name to verify special-use flag delivers to modified mailbox folder name"
+echo "[user-patches.sh] Adjusting 'Junk' mailbox name to verify delivery to Junk mailbox based on special-use flag instead of mailbox's name"
 
 sed -i -e 's/mailbox Junk/mailbox Spam/' /etc/dovecot/conf.d/15-mailboxes.conf
 

--- a/test/tests/parallel/set1/spam_virus/rspamd_full.bats
+++ b/test/tests/parallel/set1/spam_virus/rspamd_full.bats
@@ -232,7 +232,7 @@ function teardown_file() { _default_teardown ; }
   _service_log_should_contain_string 'rspamd' 'add header "Gtube pattern"'
 
   _print_mail_log_for_msgid 'rspamd-test-email-header'
-  assert_output --partial "fileinto action: stored mail into mailbox 'Junk'"
+  assert_output --partial "fileinto action: stored mail into mailbox [SPECIAL-USE \\Junk]"
 
   _count_files_in_directory_in_container /var/mail/localhost.localdomain/user1/new/ 2
   _count_files_in_directory_in_container /var/mail/localhost.localdomain/user1/.Junk/new/ 1

--- a/test/tests/parallel/set1/spam_virus/spam_junk_folder.bats
+++ b/test/tests/parallel/set1/spam_virus/spam_junk_folder.bats
@@ -52,6 +52,8 @@ function teardown() { _default_teardown ; }
 @test "(enabled + MOVE_SPAM_TO_JUNK=1) should deliver spam message into Junk mailbox" {
   export CONTAINER_NAME=${CONTAINER3_NAME}
 
+  _init_with_defaults
+
   local CUSTOM_SETUP_ARGUMENTS=(
     --env ENABLE_AMAVIS=1
     --env ENABLE_SPAMASSASSIN=1
@@ -60,12 +62,11 @@ function teardown() { _default_teardown ; }
     --env MOVE_SPAM_TO_JUNK=1
     --env PERMIT_DOCKER=container
   )
-  _init_with_defaults
+
+  # Adjust 'Junk' mailbox name to verify special-use flag delivers to modified mailbox folder name
+  mv "${TEST_TMP_CONFIG}/junk-mailbox/user-patches.sh" "${TEST_TMP_CONFIG}/"
+
   _common_container_setup 'CUSTOM_SETUP_ARGUMENTS'
-  _run_in_container sed -i -e 's/mailbox Junk/mailbox Spam/' /etc/dovecot/conf.d/15-mailboxes.conf
-  assert_success
-  _run_in_container dovecot reload
-  assert_success
 
   _should_send_spam_message
   _should_be_received_by_amavis 'Passed SPAM {RelayedTaggedInbound,Quarantined}'

--- a/test/tests/parallel/set1/spam_virus/spam_junk_folder.bats
+++ b/test/tests/parallel/set1/spam_virus/spam_junk_folder.bats
@@ -49,7 +49,7 @@ function teardown() { _default_teardown ; }
   _should_receive_spam_at '/var/mail/localhost.localdomain/user1/new/'
 }
 
-@test "(enabled + MOVE_SPAM_TO_JUNK=1) should deliver spam message into folder with \Junk attribute" {
+@test "(enabled + MOVE_SPAM_TO_JUNK=1) should deliver spam message into Junk mailbox" {
   export CONTAINER_NAME=${CONTAINER3_NAME}
 
   local CUSTOM_SETUP_ARGUMENTS=(
@@ -70,7 +70,7 @@ function teardown() { _default_teardown ; }
   _should_send_spam_message
   _should_be_received_by_amavis 'Passed SPAM {RelayedTaggedInbound,Quarantined}'
 
-  # Should move delivered spam to Junk folder
+  # Should move delivered spam to the Junk mailbox (adjusted to be located at '.Spam/')
   _should_receive_spam_at '/var/mail/localhost.localdomain/user1/.Spam/new/'
 }
 

--- a/test/tests/parallel/set1/spam_virus/spam_junk_folder.bats
+++ b/test/tests/parallel/set1/spam_virus/spam_junk_folder.bats
@@ -63,7 +63,7 @@ function teardown() { _default_teardown ; }
     --env PERMIT_DOCKER=container
   )
 
-  # Adjust 'Junk' mailbox name to verify special-use flag delivers to modified mailbox folder name
+  # Adjust 'Junk' mailbox name to verify delivery to Junk mailbox based on special-use flag instead of mailbox's name
   mv "${TEST_TMP_CONFIG}/junk-mailbox/user-patches.sh" "${TEST_TMP_CONFIG}/"
 
   _common_container_setup 'CUSTOM_SETUP_ARGUMENTS'


### PR DESCRIPTION
If `MOVE_SPAM_TO_JUNK=1`, spam messages now will be moved to one mailbox with `\Junk` special-use attribute. If there is no such mailbox, messages will be moved to 'Junk' mailbox, as earlier.
This change simplifies configuration in case Junk mailbox needs to be renamed.

Fixes #3918

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under docs/)
- [x] If necessary, I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added information about changes made in this PR to CHANGELOG.md