### PR TITLE
docs: add Gmail SMTP Guide in email forwarding for documentation

### DIFF
--- a/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
+++ b/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
@@ -45,7 +45,7 @@ This page provides a guide for configuring DMS to use [GMAIL as an SMTP relay ho
     ```
 
 [docs::relay]: ./relay-hosts.md
-[gmail-smtp]: https://support.google.com/a/answer/2956491?sjid=10042458694956130936-AP
+[gmail-smtp]: https://support.google.com/a/answer/2956491
 [gmail-smtp::relay-host]: https://support.google.com/a/answer/176600
 [gmail-smtp::relay-port]: https://support.google.com/a/answer/2956491
 [gmail-smtp::account-id]: https://myaccount.google.com/security?gar=1

--- a/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
+++ b/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
@@ -8,9 +8,9 @@ This page provides a guide for configuring DMS to use [GMAIL as an SMTP relay ho
 
     [Configure a relay host in DMS][docs::relay] to forward all your mail through:
 
-    - `RELAY_HOST` should match your [SMTP Server Endpoint][gmail-smtp::relay-host].
+    - `RELAY_HOST` should be either `smtp.gmail.com` (_for a personal GMAIL account_) or `smtp-relay.gmail.com` (_when using Google Workspace_). For more information, view [these docs for the two supported SMTP endpoints][gmail-smtp::relay-host].
     - `RELAY_PORT` should be set to [one of the supported Gmail SMTP ports][gmail-smtp::relay-port] (_eg: 587 for STARTTLS_).
-    - `RELAY_USER` and `RELAY_PASSWORD` should be set to your [Gmail Account ID][gmail-smtp::account-id].
+    - `RELAY_USER` and `RELAY_PASSWORD` should be set to your credentials for [Gmail][gmail-smtp::account-id].
 
     ```env
     RELAY_HOST=smtp.gmail.com
@@ -18,8 +18,8 @@ This page provides a guide for configuring DMS to use [GMAIL as an SMTP relay ho
     # Alternative to RELAY_HOST + RELAY_PORT which is compatible with LDAP:
     DEFAULT_RELAY_HOST=[smtp.gmail.com]:587
 
-    RELAY_USER=someone@gmail.com
-    RELAY_PASSWORD=xxx
+    RELAY_USER=username@gmail.com
+    RELAY_PASSWORD=secret
     ```
 
 !!! warning "Process of providing RELAY_PASSWORD"

--- a/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
+++ b/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
@@ -40,7 +40,7 @@ This page provides a guide for configuring DMS to use [GMAIL as an SMTP relay ho
     ```log
     postfix/smtp[910]: Trusted TLS connection established to smtp.gmail.com[64.233.188.109]:587:
       TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits)
-    postfix/smtp[910]: 4BCB547D9D: to=&lt;someone@gmail.com&gt;, relay=smtp.gmail.com[64.233.188.109]:587,
+    postfix/smtp[910]: 4BCB547D9D: to=<username@gmail.com>, relay=smtp.gmail.com[64.233.188.109]:587,
       delay=2.9, delays=0.01/0.02/1.7/1.2, dsn=2.0.0, status=sent (250 2.0.0 OK  17... - gsmtp)
     ```
 

--- a/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
+++ b/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
@@ -35,7 +35,7 @@ This page provides a guide for configuring DMS to use [GMAIL as an SMTP relay ho
 !!! note "Verify the relay host is configured correctly"
 
     To verify proper operation, send an email to some external account of yours and inspect the mail headers.
-    You will also see the connection to GMAIL SMTP in the mail logs:
+    You will also see the connection to the Gmail relay host in the mail logs:
 
     ```log
     postfix/smtp[910]: Trusted TLS connection established to smtp.gmail.com[64.233.188.109]:587:

--- a/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
+++ b/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
@@ -6,11 +6,14 @@ This page provides a guide for configuring DMS to use [GMAIL as an SMTP relay ho
 
 !!! example "Configuration via ENV"
 
-    [Configure a relay host in DMS][docs::relay] to forward all your mail through:
+    [Configure a relay host in DMS][docs::relay]. This example shows how the related ENV settings map to the Gmail service config:
 
-    - `RELAY_HOST` should be either `smtp.gmail.com` (_for a personal GMAIL account_) or `smtp-relay.gmail.com` (_when using Google Workspace_). For more information, view [these docs for the two supported SMTP endpoints][gmail-smtp::relay-host].
+    - `RELAY_HOST` should be configured as [advised by Gmail][gmail-smtp::relay-host], there are two SMTP endpoints to choose:
+        - `smtp.gmail.com` (_for a personal Gmail account_)
+        - `smtp-relay.gmail.com` (_when using Google Workspace_)
     - `RELAY_PORT` should be set to [one of the supported Gmail SMTP ports][gmail-smtp::relay-port] (_eg: 587 for STARTTLS_).
-    - `RELAY_USER` and `RELAY_PASSWORD` should be set to your credentials for [Gmail][gmail-smtp::account-id].
+    - `RELAY_USER` should be your gmail address (`user@gmail.com`).
+    - `RELAY_PASSWORD` should be your [App Password][gmail-smtp::app-password], **not** your personal gmail account password.
 
     ```env
     RELAY_HOST=smtp.gmail.com
@@ -22,15 +25,16 @@ This page provides a guide for configuring DMS to use [GMAIL as an SMTP relay ho
     RELAY_PASSWORD=secret
     ```
 
-!!! warning "Process of providing RELAY_PASSWORD"
-
-    You should use your [2-step verification app password][gmail-smtp::2-step-password], **not** your gmail account password.
-    `setup relay add-auth` is a better alternative, which manages the credentials via a config file.
+!!! tip
+    
+    - As per our main [relay host docs page][docs::relay], you may prefer to configure your credentials via `setup relay add-auth` instead of the `RELAY_USER` + `RELAY_PASSWORD` ENV.
+    - If you configure for `smtp-relay.gmail.com`, the `DEFAULT_RELAY_HOST` ENV should be all you need as shown in the above example. Credentials can be optional when using Google Workspace (`smtp-relay.gmail.com`), which supports restricting connections to trusted IP addresses.
 
 !!! note "Verify the relay host is configured correctly"
 
-    To verify proper operation, send an email to some external account of yours and inspect the mail headers.
-    You will also see the connection to the Gmail relay host in the mail logs:
+    To verify proper operation, send an email to an external account of yours and inspect the mail headers.
+
+    You will also see the connection to the Gmail relay host (`smtp.gmail.com`) in the mail logs:
 
     ```log
     postfix/smtp[910]: Trusted TLS connection established to smtp.gmail.com[64.233.188.109]:587:
@@ -43,5 +47,4 @@ This page provides a guide for configuring DMS to use [GMAIL as an SMTP relay ho
 [gmail-smtp]: https://support.google.com/a/answer/2956491
 [gmail-smtp::relay-host]: https://support.google.com/a/answer/176600
 [gmail-smtp::relay-port]: https://support.google.com/a/answer/2956491
-[gmail-smtp::account-id]: https://myaccount.google.com/security?gar=1
-[gmail-smtp::2-step-password]: https://support.google.com/accounts/answer/185833
+[gmail-smtp::app-password]: https://support.google.com/accounts/answer/185833

--- a/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
+++ b/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
@@ -29,7 +29,7 @@ This page provides a guide for configuring DMS to use [GMAIL as an SMTP relay ho
     
 !!! tip
 
-    If you have set up GMAIL SMTP, you can Filter messages for spam and viruses before they reach external recipients
+    If you have set up GMAIL SMTP, you can filter messages for spam and viruses before they reach external recipients
     and also apply email security and advanced Gmail settings to outgoing messages.
 
 !!! note "Verify the relay host is configured correctly"

--- a/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
+++ b/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
@@ -1,0 +1,52 @@
+---
+title: 'Mail Forwarding | GMAIL SMTP'
+---
+
+[GMAIL SMTP (Simple Message Transport Protocol)][gmail-smtp] provides a simple way for cloud based applications to send and receive email.
+
+!!! example "Configuration via ENV"
+
+    [Configure a relay host in DMS][docs::relay] to forward all your mail through GMAIL SMTP:
+
+    - `RELAY_HOST` should match your [SMTP Server Endpoint][gmail-smtp::relay-host].
+    - `RELAY_PORT` should be set to [one of the supported Gmail SMTP ports][gmail-smtp::relay-port] (_eg: 587 for STARTTLS_).
+    - `RELAY_USER` and `RELAY_PASSWORD` should be set to your [Gmail Account ID][gmail-smtp::account-id].
+
+    ```env
+    RELAY_HOST=smtp.gmail.com
+    RELAY_PORT=587
+    # Alternative to RELAY_HOST + RELAY_PORT which is compatible with LDAP:
+    DEFAULT_RELAY_HOST=[smtp.gmail.com]:587
+
+    RELAY_USER=someone@gmail.com
+    RELAY_PASSWORD=xxx
+    ```
+
+!!! warning "Process of providing RELAY_PASSWORD"
+
+    You should use your [2-step verification app password][gmail-smtp::2-step-password], **not** your gmail account password.
+    `setup relay add-auth` is a better alternative, which manages the credentials via a config file.
+    
+!!! tip
+
+    If you have set up GMAIL SMTP, you can Filter messages for spam and viruses before they reach external recipients
+    and also apply email security and advanced Gmail settings to outgoing messages.
+
+!!! note "Verify the relay host is configured correctly"
+
+    To verify proper operation, send an email to some external account of yours and inspect the mail headers.
+    You will also see the connection to GMAIL SMTP in the mail logs:
+
+    ```log
+    postfix/smtp[910]: Trusted TLS connection established to smtp.gmail.com[64.233.188.109]:587:
+      TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits)
+    postfix/smtp[910]: 4BCB547D9D: to=&lt;someone@gmail.com&gt;, relay=smtp.gmail.com[64.233.188.109]:587,
+      delay=2.9, delays=0.01/0.02/1.7/1.2, dsn=2.0.0, status=sent (250 2.0.0 OK  17... - gsmtp)
+    ```
+
+[docs::relay]: ./relay-hosts.md
+[gmail-smtp]: https://support.google.com/a/answer/2956491?sjid=10042458694956130936-AP
+[gmail-smtp::relay-host]: https://support.google.com/a/answer/176600
+[gmail-smtp::relay-port]: https://support.google.com/a/answer/2956491
+[gmail-smtp::account-id]: https://myaccount.google.com/security?gar=1
+[gmail-smtp::2-step-password]: https://support.google.com/accounts/answer/185833

--- a/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
+++ b/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
@@ -2,7 +2,7 @@
 title: 'Mail Forwarding | GMAIL SMTP'
 ---
 
-[GMAIL SMTP (Simple Message Transport Protocol)][gmail-smtp] provides a simple way for cloud based applications to send and receive email.
+This page provides a guide for configuring DMS to use [GMAIL as an SMTP relay host][gmail-smtp].
 
 !!! example "Configuration via ENV"
 

--- a/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
+++ b/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
@@ -6,7 +6,7 @@ This page provides a guide for configuring DMS to use [GMAIL as an SMTP relay ho
 
 !!! example "Configuration via ENV"
 
-    [Configure a relay host in DMS][docs::relay] to forward all your mail through GMAIL SMTP:
+    [Configure a relay host in DMS][docs::relay] to forward all your mail through:
 
     - `RELAY_HOST` should match your [SMTP Server Endpoint][gmail-smtp::relay-host].
     - `RELAY_PORT` should be set to [one of the supported Gmail SMTP ports][gmail-smtp::relay-port] (_eg: 587 for STARTTLS_).

--- a/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
+++ b/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
@@ -1,5 +1,5 @@
 ---
-title: 'Mail Forwarding | GMAIL SMTP'
+title: 'Mail Forwarding | Configure Gmail as a relay host'
 ---
 
 This page provides a guide for configuring DMS to use [GMAIL as an SMTP relay host][gmail-smtp].

--- a/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
+++ b/docs/content/config/advanced/mail-forwarding/gmail-smtp.md
@@ -26,11 +26,6 @@ This page provides a guide for configuring DMS to use [GMAIL as an SMTP relay ho
 
     You should use your [2-step verification app password][gmail-smtp::2-step-password], **not** your gmail account password.
     `setup relay add-auth` is a better alternative, which manages the credentials via a config file.
-    
-!!! tip
-
-    If you have set up GMAIL SMTP, you can filter messages for spam and viruses before they reach external recipients
-    and also apply email security and advanced Gmail settings to outgoing messages.
 
 !!! note "Verify the relay host is configured correctly"
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -161,6 +161,7 @@ nav:
         - 'Email Forwarding':
           - 'Relay Hosts': config/advanced/mail-forwarding/relay-hosts.md
           - 'AWS SES': config/advanced/mail-forwarding/aws-ses.md
+          - 'GMAIL SMTP': config/advanced/mail-forwarding/gmail-smtp.md
         - 'Full-Text Search': config/advanced/full-text-search.md
         - 'Kubernetes': config/advanced/kubernetes.md
         - 'IPv6': config/advanced/ipv6.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -161,7 +161,7 @@ nav:
         - 'Email Forwarding':
           - 'Relay Hosts': config/advanced/mail-forwarding/relay-hosts.md
           - 'AWS SES': config/advanced/mail-forwarding/aws-ses.md
-          - 'GMAIL SMTP': config/advanced/mail-forwarding/gmail-smtp.md
+          - 'Configure Gmail as a relay host': config/advanced/mail-forwarding/gmail-smtp.md
         - 'Full-Text Search': config/advanced/full-text-search.md
         - 'Kubernetes': config/advanced/kubernetes.md
         - 'IPv6': config/advanced/ipv6.md


### PR DESCRIPTION
# Description
 deployed docs example
  ![image](https://github.com/docker-mailserver/docker-mailserver/assets/94730032/c2f29878-24d2-41b3-9d45-290f3f8a7461)


---

I used Gmail as the relay host and succeeded after several attempts. Based on this experience, I would like to contribute to the docs on how to quickly connect to Gmail SMTP.
Currently, the part about integrating with the Gmail SMTP server cannot be found in the guide.
Therefore, I created guidelines such as how to use two-step authentication to use Gmail SMTP, what values ​​should be entered in the host and port, and how to change the sender address.

Here is the link if this docs will be deployed.  <a href="https://docker-mailserver.github.io/docker-mailserver/edge/config/advanced/mail-forwarding/gmail-smtp">Gmail SMTP</a>


## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
