### PR TITLE
docs: Fix typo on usage page

### DIFF
--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -11,7 +11,7 @@ This page explains how to get started with DMS. The guide uses Docker Compose as
 Before you can get started with deploying your own mail server, there are some requirements to be met:
 
 1. You need to have a host that you can manage.
-2. You need to own a domain, and you need to able to manage DNS for this domain.
+2. You need to own a domain, and you need to be able to manage DNS for this domain.
 
 ### Host Setup
 


### PR DESCRIPTION
# Description

reading through the docs while setting up dms I found this typo

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**