### PR TITLE
chore: Remove base-60 port quote warning from example `compose.yaml`

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -7,7 +7,6 @@ services:
     env_file: mailserver.env
     # More information about the mail-server ports:
     # https://docker-mailserver.github.io/docker-mailserver/latest/config/security/understanding-the-ports/
-    # To avoid conflicts with yaml base-60 float, DO NOT remove the quotation marks.
     ports:
       - "25:25"    # SMTP  (explicit TLS => STARTTLS, Authentication is DISABLED => use port 465/587 instead)
       - "143:143"  # IMAP4 (explicit TLS => STARTTLS)


### PR DESCRIPTION
This should not be relevant to users of `docker compose` which is the primary demographic.

However, I know that we have users with other compose clients that parse `compose.yaml` where it may still be a gotcha, so feel free to reject this PR 👍 

---

## Additional information

`docker compose` (v2) [uses the v3 version of `go-yaml`](https://github.com/docker/compose/blob/4ae2e0ec551d5707da2639fb7e1783cc1a21892e/go.mod#L56C2-L56C18) for parsing YAML where **this gotcha will not occur**. This package [intentionally avoids base-60 syntax](https://github.com/go-yaml/yaml?tab=readme-ov-file#compatibility) that we have raised awareness in our example `compose.yaml`. The Go rewrite of `docker compose` did not exist back when we added this AFAIK, and the earlier Python based version of Docker Compose was more prevalent (now EOL), which is where the bug was probably being encountered.

It's worth noting that while base-60 syntax (_aka sexagesimal_) is valid for YAML 1.1, it's been [**removed with YAML 1.2** of the spec](https://yaml.org/spec/1.2.2/ext/changes/). YAML 1.2 spec was **published in 2009Q3**, so there's been adequate time for parsers in modern maintained software to update to that.

The **last bug report** to [motivate the PR to add this](https://github.com/docker-mailserver/docker-mailserver/pull/1859) warning comment [was in March 2021](https://github.com/docker-mailserver/docker-mailserver/issues/1858#issuecomment-803700403), but the reporter did not provide much details about their environment. Presumably it'd be the fault of the YAML parser distributed with the `docker-compose` (Python) package though 🤷‍♂️ (_plus maintainers had confirmed it on their own systems_). So 12 years roughly may not have been adequate time 😅 

The [referenced **compose spec** still raises this awareness](https://github.com/compose-spec/compose-spec/blob/c35d19323fdfd7dbf9db30022498e29ef5ebeab2/spec.md?plain=1#L1623), which is fair as it's more generic towards implementers parsing YAML. It was [added to the spec directly](https://github.com/compose-spec/compose-spec/commit/dc687ad6c7d63ece2996f40fc9310c6679ee3b00#diff-bc6661da34ecae62fbe724bb93fd69b91a7f81143f2683a81163231de7e3b545R865) (Jan 2020) with many other changes and no PR process, no context provided.
