### PR TITLE
docs: Add reference to fetchmail `compose.yaml` example

### DIFF
--- a/docs/content/config/advanced/mail-fetchmail.md
+++ b/docs/content/config/advanced/mail-fetchmail.md
@@ -26,9 +26,7 @@ Generate a file called `fetchmail.cf` and place it in the `docker-data/dms/confi
 
 A detailed description of the configuration options can be found in the [online version of the manual page][fetchmail-docs].
 
-### IMAP Configuration
-
-!!! example
+!!! example "IMAP Configuration"
 
     ```fetchmailrc
     poll 'imap.gmail.com' proto imap
@@ -38,9 +36,7 @@ A detailed description of the configuration options can be found in the [online 
       ssl
     ```
 
-### POP3 Configuration
-
-!!! example
+!!! example "POP3 Configuration"
 
     ```fetchmailrc
     poll 'pop3.gmail.com' proto pop3
@@ -54,7 +50,9 @@ A detailed description of the configuration options can be found in the [online 
 
     Don’t forget the last line! (_eg: `is 'user1@example.com'`_). After `is`, you have to specify an email address from the configuration file: `docker-data/dms/config/postfix-accounts.cf`.
 
-More details how to configure fetchmail can be found in the [fetchmail man page in the chapter “The run control file”][fetchmail-docs-run].
+!!! tip
+
+    More details how to configure fetchmail can be found in the [fetchmail man page in the chapter “The run control file”][fetchmail-docs-run].
 
 ### Polling Interval
 
@@ -77,49 +75,54 @@ To debug your `fetchmail.cf` configuration run this command:
 
 For more information about the configuration script `setup.sh` [read the corresponding docs][docs-setup].
 
-Here a sample output of `./setup.sh debug fetchmail`:
+!!! example "Sample output of `setup debug fetchmail`"
 
-```log
-fetchmail: 6.3.26 querying outlook.office365.com (protocol POP3) at Mon Aug 29 22:11:09 2016: poll started
-Trying to connect to 132.245.48.18/995...connected.
-fetchmail: Server certificate:
-fetchmail: Issuer Organization: Microsoft Corporation
-fetchmail: Issuer CommonName: Microsoft IT SSL SHA2
-fetchmail: Subject CommonName: outlook.com
-fetchmail: Subject Alternative Name: outlook.com
-fetchmail: Subject Alternative Name: *.outlook.com
-fetchmail: Subject Alternative Name: office365.com
-fetchmail: Subject Alternative Name: *.office365.com
-fetchmail: Subject Alternative Name: *.live.com
-fetchmail: Subject Alternative Name: *.internal.outlook.com
-fetchmail: Subject Alternative Name: *.outlook.office365.com
-fetchmail: Subject Alternative Name: outlook.office.com
-fetchmail: Subject Alternative Name: attachment.outlook.office.net
-fetchmail: Subject Alternative Name: attachment.outlook.officeppe.net
-fetchmail: Subject Alternative Name: *.office.com
-fetchmail: outlook.office365.com key fingerprint: 3A:A4:58:42:56:CD:BD:11:19:5B:CF:1E:85:16:8E:4D
-fetchmail: POP3< +OK The Microsoft Exchange POP3 service is ready. [SABFADEAUABSADAAMQBDAEEAMAAwADAANwAuAGUAdQByAHAAcgBkADAAMQAuAHAAcgBvAGQALgBlAHgAYwBoAGEAbgBnAGUAbABhAGIAcwAuAGMAbwBtAA==]
-fetchmail: POP3> CAPA
-fetchmail: POP3< +OK
-fetchmail: POP3< TOP
-fetchmail: POP3< UIDL
-fetchmail: POP3< SASL PLAIN
-fetchmail: POP3< USER
-fetchmail: POP3< .
-fetchmail: POP3> USER user1@outlook.com
-fetchmail: POP3< +OK
-fetchmail: POP3> PASS *
-fetchmail: POP3< +OK User successfully logged on.
-fetchmail: POP3> STAT
-fetchmail: POP3< +OK 0 0
-fetchmail: No mail for user1@outlook.com at outlook.office365.com
-fetchmail: POP3> QUIT
-fetchmail: POP3< +OK Microsoft Exchange Server 2016 POP3 server signing off.
-fetchmail: 6.3.26 querying outlook.office365.com (protocol POP3) at Mon Aug 29 22:11:11 2016: poll completed
-fetchmail: normal termination, status 1
-```
+    ```log
+    fetchmail: 6.3.26 querying outlook.office365.com (protocol POP3) at Mon Aug 29 22:11:09 2016: poll started
+    Trying to connect to 132.245.48.18/995...connected.
+    fetchmail: Server certificate:
+    fetchmail: Issuer Organization: Microsoft Corporation
+    fetchmail: Issuer CommonName: Microsoft IT SSL SHA2
+    fetchmail: Subject CommonName: outlook.com
+    fetchmail: Subject Alternative Name: outlook.com
+    fetchmail: Subject Alternative Name: *.outlook.com
+    fetchmail: Subject Alternative Name: office365.com
+    fetchmail: Subject Alternative Name: *.office365.com
+    fetchmail: Subject Alternative Name: *.live.com
+    fetchmail: Subject Alternative Name: *.internal.outlook.com
+    fetchmail: Subject Alternative Name: *.outlook.office365.com
+    fetchmail: Subject Alternative Name: outlook.office.com
+    fetchmail: Subject Alternative Name: attachment.outlook.office.net
+    fetchmail: Subject Alternative Name: attachment.outlook.officeppe.net
+    fetchmail: Subject Alternative Name: *.office.com
+    fetchmail: outlook.office365.com key fingerprint: 3A:A4:58:42:56:CD:BD:11:19:5B:CF:1E:85:16:8E:4D
+    fetchmail: POP3< +OK The Microsoft Exchange POP3 service is ready. [SABFADEAUABSADAAMQBDAEEAMAAwADAANwAuAGUAdQByAHAAcgBkADAAMQAuAHAAcgBvAGQALgBlAHgAYwBoAGEAbgBnAGUAbABhAGIAcwAuAGMAbwBtAA==]
+    fetchmail: POP3> CAPA
+    fetchmail: POP3< +OK
+    fetchmail: POP3< TOP
+    fetchmail: POP3< UIDL
+    fetchmail: POP3< SASL PLAIN
+    fetchmail: POP3< USER
+    fetchmail: POP3< .
+    fetchmail: POP3> USER user1@outlook.com
+    fetchmail: POP3< +OK
+    fetchmail: POP3> PASS *
+    fetchmail: POP3< +OK User successfully logged on.
+    fetchmail: POP3> STAT
+    fetchmail: POP3< +OK 0 0
+    fetchmail: No mail for user1@outlook.com at outlook.office365.com
+    fetchmail: POP3> QUIT
+    fetchmail: POP3< +OK Microsoft Exchange Server 2016 POP3 server signing off.
+    fetchmail: 6.3.26 querying outlook.office365.com (protocol POP3) at Mon Aug 29 22:11:11 2016: poll completed
+    fetchmail: normal termination, status 1
+    ```
+
+!!! tip "Troubleshoot with this reference `compose.yaml`"
+
+    [Here is a minimal `compose.yaml` example][fetchmail-compose-example] that runs two instances of DMS locally, with one configured with `fetchmail.cf`.
 
 [docs-setup]: ../../config/setup.sh.md
 [fetchmail-website]: https://www.fetchmail.info
 [fetchmail-docs]: https://www.fetchmail.info/fetchmail-man.html
 [fetchmail-docs-run]: https://www.fetchmail.info/fetchmail-man.html#31
+[fetchmail-compose-example]: https://github.com/orgs/docker-mailserver/discussions/3994#discussioncomment-9290570


### PR DESCRIPTION
# Description

- Some minor adjustments to the existing fetchmail docs content (shifted into admonitions).
- Included a [link to a recent discussion](https://github.com/orgs/docker-mailserver/discussions/3994#discussioncomment-9290570), providing a reference to a full `compose.yaml` setup to troubleshoot fetchmail locally with two DMS instances.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
