### PR TITLE
chore(logwatch): Add `ignore.conf` to ignore logs from Dovecot `index-worker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ The most noteworthy change of this release is the update of the container's base
   - The `rewrite_subject` action, is now disabled by default. It has been replaced with the new `SPAM_SUBJECT` environment variable, which implements the functionality via a Sieve script instead which is anti-spam service agnostic ([#3820](https://github.com/docker-mailserver/docker-mailserver/pull/3820))
   - `RSPAMD_NEURAL` was added and is disabled by default. If switched on it will enable the experimental Rspamd "Neural network" module to add a layer of analysis to spam detection ([#3833](https://github.com/docker-mailserver/docker-mailserver/pull/3833))
   - The symbol weights of SPF, DKIM and DMARC have been adjusted again. Fixes a bug and includes more appropriate combinations of symbols ([#3913](https://github.com/docker-mailserver/docker-mailserver/pull/3913), [#3923](https://github.com/docker-mailserver/docker-mailserver/pull/3923))
+- **Dovecot:**
+  - `logwatch` now filters out non-error logs related to the status of the `index-worker` process for FTS indexing. ([#4012](https://github.com/docker-mailserver/docker-mailserver/pull/4012))
 
 ### Fixes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -273,6 +273,7 @@ EOF
 # -----------------------------------------------
 
 COPY target/logwatch/maillog.conf /etc/logwatch/conf/logfiles/maillog.conf
+COPY target/logwatch/ignore.conf /etc/logwatch/conf/ignore.conf
 
 # -----------------------------------------------
 # --- Supervisord & Start -----------------------

--- a/target/logwatch/ignore.conf
+++ b/target/logwatch/ignore.conf
@@ -1,0 +1,1 @@
+dovecot: indexer-worker\([^\)]+\).*Indexed

--- a/target/logwatch/ignore.conf
+++ b/target/logwatch/ignore.conf
@@ -1,1 +1,2 @@
+# ignore output from dovecot-fts-xapian about successfully indexed messages
 dovecot: indexer-worker\([^\)]+\).*Indexed


### PR DESCRIPTION
When using the dovecot-fts-xapian plugin as described in the "Full-Text Search" article of the projects' documentation, the daily logwatch emails get cluttered with output from the indexing of emails. 
This pull request adds an ignore.conf to the logwatch configuration with a regular expression to filter out the corresponding messages. 

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**