### PR TITLE
fix: `/var/mail-state` should not symlink non-existing directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@ The most noteworthy change of this release is the update of the container's base
 - Rspamd configuration: Add a missing comma in `local_networks` so that all internal IP addresses are actually considered as internal ([#3862](https://github.com/docker-mailserver/docker-mailserver/pull/3862))
 - Ensure correct SELinux security context labels for files and directories moved to the mail-state volume during setup ([#3890](https://github.com/docker-mailserver/docker-mailserver/pull/3890))
 - Use correct environment variable for fetchmail ([#3901](https://github.com/docker-mailserver/docker-mailserver/pull/3901))
-- When `ENABLE_GETMAIL=1` the expected state directory `/var/lib/getmail/` is now created for the Getmail service ([#4018](https://github.com/docker-mailserver/docker-mailserver/pull/4018))
+- When using `ENABLE_GETMAIL=1` the undocumented internal location `/var/lib/getmail/` usage has been removed. Only the config volume `/tmp/docker-mailserver/getmail/` location is supported when Getmail has not been configured to deliver mail to Dovecot as advised in the DMS docs ([#4018](https://github.com/docker-mailserver/docker-mailserver/pull/4018))
 - Dovecot dummy accounts (_virtual alias workaround for dovecot feature `ENABLE_QUOTAS=1`_) now correctly matches the home location of the user for that alias ([#3997](https://github.com/docker-mailserver/docker-mailserver/pull/3997))
 
 ## [v13.3.1](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.3.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ The most noteworthy change of this release is the update of the container's base
 - Rspamd configuration: Add a missing comma in `local_networks` so that all internal IP addresses are actually considered as internal ([#3862](https://github.com/docker-mailserver/docker-mailserver/pull/3862))
 - Ensure correct SELinux security context labels for files and directories moved to the mail-state volume during setup ([#3890](https://github.com/docker-mailserver/docker-mailserver/pull/3890))
 - Use correct environment variable for fetchmail ([#3901](https://github.com/docker-mailserver/docker-mailserver/pull/3901))
+- When `ENABLE_GETMAIL=1` the expected state directory `/var/lib/getmail/` is now created for the Getmail service ([#4018](https://github.com/docker-mailserver/docker-mailserver/pull/4018))
 - Dovecot dummy accounts (_virtual alias workaround for dovecot feature `ENABLE_QUOTAS=1`_) now correctly matches the home location of the user for that alias ([#3997](https://github.com/docker-mailserver/docker-mailserver/pull/3997))
 
 ## [v13.3.1](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v13.3.1)

--- a/target/bin/debug-fetchmail
+++ b/target/bin/debug-fetchmail
@@ -5,7 +5,13 @@ source /usr/local/bin/helpers/log.sh
 # shellcheck source=../scripts/startup/setup.d/fetchmail.sh
 source /usr/local/bin/setup.d/fetchmail.sh
 
-_setup_fetchmail
+# TODO: This should probably not implicitly enable the feature.
+# The setup method will feature gate and output a debug log if
+# the feature is not enabled.
+#
+# Dropping the ENV here will require updating legacy test:
+# test/tests/parallel/set3/scripts/setup_cli.bats
+ENABLE_FETCHMAIL=1 _setup_fetchmail
 
 su -s /bin/sh -c "/usr/bin/fetchmail \
   --verbose \

--- a/target/bin/debug-fetchmail
+++ b/target/bin/debug-fetchmail
@@ -5,7 +5,7 @@ source /usr/local/bin/helpers/log.sh
 # shellcheck source=../scripts/startup/setup.d/fetchmail.sh
 source /usr/local/bin/setup.d/fetchmail.sh
 
-ENABLE_FETCHMAIL=1 _setup_fetchmail
+_setup_fetchmail
 
 su -s /bin/sh -c "/usr/bin/fetchmail \
   --verbose \

--- a/target/bin/debug-getmail
+++ b/target/bin/debug-getmail
@@ -7,13 +7,7 @@ source /usr/local/bin/setup.d/getmail.sh
 
 _setup_getmail
 
-if [[ -d /var/lib/getmail ]]; then
-  GETMAILDIR=/var/lib/getmail
-else
-  mkdir -p /tmp/docker-mailserver/getmail
-  GETMAILDIR=/tmp/docker-mailserver/getmail
-fi
-
+GETMAILDIR=/tmp/docker-mailserver/getmail
 for FILE in /etc/getmailrc.d/getmailrc*; do
   getmail --getmaildir "${GETMAILDIR}" --rcfile "${FILE}" --dump | tail -n +6
 done

--- a/target/bin/getmail-cron
+++ b/target/bin/getmail-cron
@@ -1,7 +1,8 @@
 #! /bin/bash
 
+GETMAILDIR=/tmp/docker-mailserver/getmail
 for FILE in /etc/getmailrc.d/getmailrc*; do
   if ! pgrep -f "${FILE}$" &>/dev/null; then
-    getmail --getmaildir /var/lib/getmail --rcfile "${FILE}"
+    getmail --getmaildir "${GETMAILDIR}" --rcfile "${FILE}"
   fi
 done

--- a/target/scripts/startup/setup.d/getmail.sh
+++ b/target/scripts/startup/setup.d/getmail.sh
@@ -31,6 +31,10 @@ function _setup_getmail() {
 EOF
       chmod -R 600 "${GETMAILRC}"
     fi
+
+    # Both the debug command and cron job (that runs getmail) for getmail
+    # expect this location to exist. As does the `/var/mail-state` startup script.
+    mkdir -p /var/lib/getmail
   else
     _log 'debug' 'Getmail is disabled'
   fi

--- a/target/scripts/startup/setup.d/getmail.sh
+++ b/target/scripts/startup/setup.d/getmail.sh
@@ -33,8 +33,9 @@ EOF
     fi
 
     # Both the debug command and cron job (that runs getmail) for getmail
-    # expect this location to exist. As does the `/var/mail-state` startup script.
-    mkdir -p /var/lib/getmail
+    # expect this location to exist.
+    GETMAILDIR=/tmp/docker-mailserver/getmail
+    mkdir -p "${GETMAILDIR}"
   else
     _log 'debug' 'Getmail is disabled'
   fi

--- a/target/scripts/startup/setup.d/mail_state.sh
+++ b/target/scripts/startup/setup.d/mail_state.sh
@@ -23,7 +23,6 @@ function _setup_save_states() {
     [[ ${ENABLE_CLAMAV}       -eq 1 ]] && SERVICEDIRS+=('lib/clamav')
     [[ ${ENABLE_FAIL2BAN}     -eq 1 ]] && SERVICEDIRS+=('lib/fail2ban')
     [[ ${ENABLE_FETCHMAIL}    -eq 1 ]] && SERVICEDIRS+=('lib/fetchmail')
-    [[ ${ENABLE_GETMAIL}      -eq 1 ]] && SERVICEDIRS+=('lib/getmail')
     [[ ${ENABLE_MTA_STS}      -eq 1 ]] && SERVICEDIRS+=('lib/mta-sts')
     [[ ${ENABLE_POSTGREY}     -eq 1 ]] && SERVICEDIRS+=('lib/postgrey')
     [[ ${ENABLE_RSPAMD}       -eq 1 ]] && SERVICEDIRS+=('lib/rspamd')

--- a/target/scripts/startup/setup.d/mail_state.sh
+++ b/target/scripts/startup/setup.d/mail_state.sh
@@ -70,7 +70,10 @@ function _setup_save_states() {
         rm -rf "${SERVICEDIR}"
       elif [[ -d ${SERVICEDIR} ]]; then
         _log 'trace' "Moving contents of ${SERVICEDIR} to ${DEST}"
-        # Empty volume was mounted, or new content from enabling a feature ENV:
+        # An empty volume was mounted, or new content exists from enabling a feature ENV:
+        # Ensure the original directory exists before mv, otherwise with nothing to move
+        # the symlink created afterwards is invalid.
+        mkdir -p "${SERVICEDIR}"
         mv "${SERVICEDIR}" "${DEST}"
         # Apply SELinux security context to match the state directory, so access
         # is not restricted to the current running container:

--- a/target/scripts/startup/setup.d/mail_state.sh
+++ b/target/scripts/startup/setup.d/mail_state.sh
@@ -70,14 +70,13 @@ function _setup_save_states() {
         rm -rf "${SERVICEDIR}"
       elif [[ -d ${SERVICEDIR} ]]; then
         _log 'trace' "Moving contents of ${SERVICEDIR} to ${DEST}"
-        # An empty volume was mounted, or new content exists from enabling a feature ENV:
-        # Ensure the original directory exists before mv, otherwise with nothing to move
-        # the symlink created afterwards is invalid.
-        mkdir -p "${SERVICEDIR}"
+        # An empty volume was mounted, or new content dir now exists from enabling a feature ENV:
         mv "${SERVICEDIR}" "${DEST}"
         # Apply SELinux security context to match the state directory, so access
         # is not restricted to the current running container:
         chcon -R --reference="${STATEDIR}" "${DEST}" 2>/dev/null || true
+      else
+        _log 'error' "${SERVICEDIR} should exist but is missing"
       fi
 
       # Symlink the original path in the container ($SERVICEDIR) to be


### PR DESCRIPTION
# Description

- Log an error when the expected service state directory doesn't exist.
- The location `/var/lib/getmail/` doesn't seem like it should have been introduced. Drop it in favor of `/tmp/docker-mailserver/getmail`. It appears to be for storing remote mail that was retrieved if not configured to send to Dovecot like our docs advise. This location was never valid anyway (_as referenced issue covers_).
- Additional getmail insights are covered in a later comment of mine below.
- ~~Fetchmail debug command force enabled the feature to avoid requiring the ENV. Probably before a release when we moved the `setup` CLI into the container itself. Since the feature setup script called already gates on the feature ENV toggle and outputs a debug log when disabled... don't implicitly enable the feature.~~ (_**EDIT:** Sorry lacking time to support this unrelated change due to a test case reliance on it, reverted_)

<details>
<summary>Original message</summary>

- The Getmail service doesn't have a directory in `/var/lib/` by default, yet `mail-state` is configured to symlink it, and the service in DMS is configured to expect `/var/lib/getmail` exists.
- ~~Handled in `mail-state` logic to ensure it doesn't silently fail.~~ (_**EDIT:** Just realized this won't solve it due to the condition it's in_ 😂 )

It should probably skip the symlink in this case and omit an error to the logs? Quick fix would be to have the Getmail service startup script itself ensure the directory is configured.

</details>

Fixes #4015

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
