### PR TITLE
docs(k8s): Advise `externalTrafficPolicy: Local` if no PROXY protocol configured

### DIFF
--- a/docs/content/config/advanced/kubernetes.md
+++ b/docs/content/config/advanced/kubernetes.md
@@ -140,6 +140,7 @@ If using our Helm chart is not viable for you, here is some guidance to start wi
                 app: mailserver
 
             spec:
+              externalTrafficPolicy: Local # most likely required in all scenarii, else every incoming request would be identified as the External IP, which will get banned by Fail2Ban eventually 
               type: LoadBalancer
 
               selector:

--- a/docs/content/config/advanced/kubernetes.md
+++ b/docs/content/config/advanced/kubernetes.md
@@ -140,7 +140,9 @@ If using our Helm chart is not viable for you, here is some guidance to start wi
                 app: mailserver
 
             spec:
-              externalTrafficPolicy: Local # most likely required in all scenarii, else every incoming request would be identified as the External IP, which will get banned by Fail2Ban eventually 
+              # `Local` is most likely required, otherwise every incoming request would be identified by the external IP,
+              # which will get banned by Fail2Ban when monitored services are not configured for PROXY protocol
+              externalTrafficPolicy: Local
               type: LoadBalancer
 
               selector:


### PR DESCRIPTION
If not using `externalTrafficPolicy: Local` in service declaration, all incoming requests will most likely be branded as proxied by the `externalIp` by which the mail services are accessed; this is undesired. As a side effect, any `externalIp` will eventually get banned by Fail2Ban, which helped my diagnosis this misconfiguration.

I have no idea how well this enforced parameter plays along with "PROXY protocol" configuration.