### PR TITLE
Update logwatch ignore.conf to exclude Xapian messages about pending documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file. The format 
 - **Fail2ban**:
   - Bump version to [1.1.0](https://github.com/fail2ban/fail2ban/releases/tag/1.1.0). For more information, check the [changelog](https://github.com/fail2ban/fail2ban/blob/1.1.0/ChangeLog).
 
+#### Fixes
+- **Dovecot:**
+  - `logwatch`  Update logwatch ignore.conf to exclude Xapian messages about pending documents
+
 ## [v14.0.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v14.0.0)
 
 The most noteworthy change of this release is the update of the container's base image from Debian 11 ("Bullseye") to Debian 12 ("Bookworm"). This update alone involves breaking changes and requires a careful update!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file. The format 
 
 #### Fixes
 - **Dovecot:**
-  - `logwatch`  Update logwatch ignore.conf to exclude Xapian messages about pending documents
+  - `logwatch`  Update logwatch `ignore.conf` to exclude Xapian messages about pending documents
 
 ## [v14.0.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v14.0.0)
 

--- a/target/logwatch/ignore.conf
+++ b/target/logwatch/ignore.conf
@@ -1,2 +1,3 @@
 # ignore output from dovecot-fts-xapian about successfully indexed messages
 dovecot: indexer-worker\([^\)]+\).*Indexed
+dovecot: indexer-worker\([^\)]+\).*FTS Xapian: Waiting for all pending documents to be processed


### PR DESCRIPTION
Update logwatch ignore.conf to exclude Xapian messages about pending documents since it adds unnecessary noise to the logwatch summary emails.


- [ X ] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my code
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ X ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ X ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ X ] New and existing unit tests pass locally with my changes
- [ X ] **I have added information about changes made in this PR to `CHANGELOG.md`**
