### PR TITLE
add sasldb authentication as another way to secure mailserver usage

### DIFF
--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -921,6 +921,7 @@ Note: This postgrey setting needs `ENABLE_POSTGREY=1`
 - `shadow` => authenticate against local user db
 - `mysql` => authenticate against mysql db
 - `rimap` => authenticate against imap server
+- `cyrus` => authenticate aganinst sasl2db
 - NOTE: can be a list of mechanisms like pam ldap shadow
 
 ##### SASLAUTHD_MECH_OPTIONS

--- a/mailserver.env
+++ b/mailserver.env
@@ -536,6 +536,7 @@ ENABLE_SASLAUTHD=0
 # `shadow` => authenticate against local user db
 # `mysql` => authenticate against mysql db
 # `rimap` => authenticate against imap server
+# `cyrus` => authenticate aganinst sasl2db
 # Note: can be a list of mechanisms like pam ldap shadow
 SASLAUTHD_MECHANISMS=
 

--- a/target/scripts/startup/daemons-stack.sh
+++ b/target/scripts/startup/daemons-stack.sh
@@ -45,7 +45,10 @@ function _start_daemon_rsyslog        { _default_start_daemon 'rsyslog'        ;
 function _start_daemon_update_check   { _default_start_daemon 'update-check'   ; }
 
 function _start_daemon_saslauthd() {
-  _default_start_daemon "saslauthd_${SASLAUTHD_MECHANISMS}"
+  #if one of ldap|shadow|mysql|rimap , start the daemon
+  if [[ ${SASLAUTHD_MECHANISMS} =~ (ldap|shadow|mysql|rimap) ]]; then
+    _default_start_daemon "saslauthd_${SASLAUTHD_MECHANISMS}"
+  fi
 }
 
 function _start_daemon_postfix() {

--- a/target/scripts/startup/setup.d/postfix.sh
+++ b/target/scripts/startup/setup.d/postfix.sh
@@ -19,12 +19,9 @@ function _setup_postfix_early() {
     postconf "inet_protocols = ${POSTFIX_INET_PROTOCOLS}"
   fi
 
-  __postfix__log 'trace' "Configuring SASLauthd"
-  if [[ ${ENABLE_SASLAUTHD} -eq 1 ]] && [[ ! -f /etc/postfix/sasl/smtpd.conf ]]; then
-    cat >/etc/postfix/sasl/smtpd.conf << EOF
-pwcheck_method: saslauthd
-mech_list: plain login
-EOF
+  if [[ -n ${DEFAULT_DESTINATION_RATE_DELAY} ]]; then
+    __postfix__log 'trace' "Configure destination rate to ${DEFAULT_DESTINATION_RATE_DELAY}"
+    postconf "default_destination_rate_delay = ${DEFAULT_DESTINATION_RATE_DELAY}"
   fi
 
   # User has explicitly requested to disable SASL auth:

--- a/target/scripts/startup/setup.d/saslauthd.sh
+++ b/target/scripts/startup/setup.d/saslauthd.sh
@@ -1,17 +1,63 @@
 #!/bin/bash
 
 function _setup_saslauthd() {
-  _log 'debug' 'Setting up SASLAUTHD'
 
-  # NOTE: It's unlikely this file would already exist,
-  # Unlike Dovecot/Postfix LDAP support, this file has no ENV replacement
-  # nor does it copy from the DMS config volume to this internal location.
-  if [[ ${ACCOUNT_PROVISIONER} == 'LDAP' ]] \
-  && [[ ! -f /etc/saslauthd.conf ]]; then
-    _log 'trace' 'Creating /etc/saslauthd.conf'
+  __postfix__log 'trace' "Configuring SASLauthd cyrus if requested"
+  gpasswd -a postfix sasl >/dev/null
+  # cyrus uses a plugin not a saslauth service.
+  if [[ "${SASLAUTHD_MECHANISMS:-''}" == cyrus ]]; then
+    _log 'debug' 'Setting up SASLAUTHD for cyrus'
+    CPATH="/etc/postfix/sasl"
+    CFILE="smtpd"
 
-    # Create a config based on ENV
-    sed '/^.*: $/d'> /etc/saslauthd.conf << EOF
+    #smtpd_sasl_auth_enable / smtpd_sasl_type / smtpd_sasl_path = private/auth smtpd_sasl_security_options = noanonymous, noplaintext
+    #smtpd_sasl_tls_security_options = noanonymous
+    __postfix__log 'trace' 'Setting up cyrus smtp auth'
+    postconf "smtpd_sasl_auth_enable = yes"
+    # Cyrus SASL configuration file name: smtpd.conf
+    postconf "smtpd_sasl_path = ${CFILE}"
+    #cyrus/dovecot auth for smtp.
+    postconf "smtpd_sasl_type = cyrus"
+    #change master.cf as postconf -e is not editing it.
+    sed -i -n "s[^  -o smtpd_sasl_type=.*|^  -o smtpd_sasl_type=\${smtpd_sasl_type}/g" /etc/postfix/master.cf
+
+    # location where Cyrus SASL searches
+    postconf "cyrus_sasl_config_path = ${CPATH}"
+
+    __postfix__log 'trace' 'Setting up sasl auth plugin for smtpd'
+    mkdir -p "${CPATH}"
+    echo -e "pwcheck_method: auxprop\nauxprop_plugin: sasldb\nmech_list: PLAIN LOGIN" >"${CPATH}/${CFILE}.conf"
+
+    __postfix__log 'trace' 'Setting up sasl db with users'
+    IFS=' ' read -r -a u <<<"${SMTP_USERNAMES}"
+    IFS=' ' read -r -a p <<<"${SMTP_PASSWORDS}"
+    #mapfile -t aCurrent < <(sasldblisteners2)
+    if [[ 0 -eq ${#u[*]} ]]; then
+      _log 'error' "Cyrus SASL Authentification (SASLAUTHD_MECHANISMS=cyrus) required but no user/password given (SMPT_USERNAMES/SMTP_PASSWORDS)"
+      return
+    fi
+    dom=$(hostname -f)
+    dom=${dom#*.}
+    for ((i = 0; i < ${#u[*]}; i++)); do
+      _log 'debug' "adding email username: ${u[${i}]}@${dom} / password: ${p[${i}]}"
+      setup email "add ${u[${i}]}@${dom}" "${p[${i}]}"
+      _log 'debug' "adding sasldb2 username: ${u[${i}]} / password: ${p[${i}]}"
+      echo "${p[${i}]}" | saslpasswd2 -c -u "$(postconf -h mydomain)" "${u[${i}]}"
+      #testsaslauthd -u ${u[${i}]} -p ${p[${i}]}
+    done
+    _log 'debug' "$(sasldblistusers2)"
+  else
+    _log 'debug' 'Setting up SASLAUTHD'
+
+    # NOTE: It's unlikely this file would already exist,
+    # Unlike Dovecot/Postfix LDAP support, this file has no ENV replacement
+    # nor does it copy from the DMS config volume to this internal location.
+    if [[ ${ACCOUNT_PROVISIONER} == 'LDAP' ]] &&
+      [[ ! -f /etc/saslauthd.conf ]]; then
+      _log 'trace' 'Creating /etc/saslauthd.conf'
+
+      # Create a config based on ENV
+      sed '/^.*: $/d' >/etc/saslauthd.conf <<EOF
 ldap_servers: ${SASLAUTHD_LDAP_SERVER:=${LDAP_SERVER_HOST}}
 ldap_auth_method: ${SASLAUTHD_LDAP_AUTH_METHOD:=bind}
 ldap_bind_dn: ${SASLAUTHD_LDAP_BIND_DN:=${LDAP_BIND_DN}}
@@ -27,18 +73,16 @@ ldap_mech: ${SASLAUTHD_LDAP_MECH}
 ldap_referrals: yes
 log_level: 10
 EOF
+    fi
+    sed -i \
+      -e "/^[^#].*smtpd_sasl_type.*/s/^/#/g" \
+      -e "/^[^#].*smtpd_sasl_path.*/s/^/#/g" \
+      /etc/postfix/master.cf
+
+    sed -i \
+      -e "/smtpd_sasl_path =.*/d" \
+      -e "/smtpd_sasl_type =.*/d" \
+      -e "/dovecot_destination_recipient_limit =.*/d" \
+      /etc/postfix/main.cf
   fi
-
-  sed -i \
-    -e "/^[^#].*smtpd_sasl_type.*/s/^/#/g" \
-    -e "/^[^#].*smtpd_sasl_path.*/s/^/#/g" \
-    /etc/postfix/master.cf
-
-  sed -i \
-    -e "/smtpd_sasl_path =.*/d" \
-    -e "/smtpd_sasl_type =.*/d" \
-    -e "/dovecot_destination_recipient_limit =.*/d" \
-    /etc/postfix/main.cf
-
-  gpasswd -a postfix sasl >/dev/null
 }

--- a/target/scripts/startup/variables-stack.sh
+++ b/target/scripts/startup/variables-stack.sh
@@ -157,6 +157,8 @@ function __environment_variables_general_setup() {
   VARS[SUPERVISOR_LOGLEVEL]="${SUPERVISOR_LOGLEVEL:=warn}"
   VARS[TZ]="${TZ:=}"
   VARS[UPDATE_CHECK_INTERVAL]="${UPDATE_CHECK_INTERVAL:=1d}"
+  VARS[DEFAULT_DESTINATION_RATE_DELAY]="${DEFAULT_DESTINATION_RATE_DELAY:=0s}"
+
 }
 
 function _environment_variables_oauth2() {


### PR DESCRIPTION
# Description

Add authentification to smtp when not using ldap, shadow or rimap.
sasldb is a plugin for cyrus, so i'm afraid not compatible with dovecot.

there is many operations to execute to have sasldb authentication. The idea is to implement more easily this feature.
The use case is a postfix as relay available on local lan, not limited to a docker network.
an env var was added as remote postfix will have rules that detect as a spammer, the container sending to quickly mails.
default value is the current one: 0s (no throttle)

setup.sh was not changed.
SMTP_USERNAMES and SMTP_PASSWORDS env vars are required as list of users /password to create.
sasldb entries and email accounts will be provisioned.

this PR add a feature and does not fix a bug.
all lints tests are ok.
I failed to implement and run bats tests.
I'm not an postfix expert so side effects may occur.
I will be adding  a new section to the docs: SASLDB authentication if you think it's needed

## Type of change

<!-- Delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
