### PR TITLE
docs: Document fix for PROXY protocol with `postscreen`

### DIFF
--- a/docs/content/examples/tutorials/mailserver-behind-proxy.md
+++ b/docs/content/examples/tutorials/mailserver-behind-proxy.md
@@ -259,6 +259,12 @@ The below guidance is focused on configuring [Traefik][traefik-web], but the adv
     postconf -P 12525/inet/postscreen_upstream_proxy_protocol=haproxy 12525/inet/syslog_name=smtp-proxyprotocol
     ```
 
+    Supporting port 25 with an additional PROXY protocol port will also require a `postfix-main.cf` override line for `postscreen` to work correctly:
+
+    ```cf  title="docker-data/dms/config/postfix-main.cf"
+    postscreen_cache_map = proxy:btree:$data_directory/postscreen_cache
+    ```
+
     ---
 
     Dovecot is mostly the same as before:


### PR DESCRIPTION
# Description

Port 25 is managed by the Postfix service `postscreen`. By default it expects and exclusive lock. When more than one SMTP inbound service is running (_an additional PROXY protocol port_), this is a problem that can be resolved by configuring `postscreen` to use `proxy:` table for cache access instead.

Credit and thanks to @pdehne for troubleshooting a configuration I missed, and sharing the solution: https://github.com/docker-mailserver/docker-mailserver/issues/4058#issuecomment-2159610114

Fixes #4058

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

