### PR TITLE
CI: Remove reviewer assignment from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "docker-mailserver/maintainers"
     labels:
       - "area/ci"
       - "kind/update"
@@ -15,8 +13,6 @@ updates:
     directory: /
     schedule:
       interval: "weekly"
-    reviewers:
-      - "docker-mailserver/maintainers"
     labels:
       - "area/ci"
       - "kind/update"


### PR DESCRIPTION
# Description

Due to the recent changes in the organizational structure (teams), Dependabot [currently does not find the team because the name changed](https://github.com/docker-mailserver/docker-mailserver/pull/4086#issuecomment-2186511147). I deem it appropriate to remove the assignment altogether because currently the @docker-mailserver/core-maintainers teams consists of only one person, and active maintainers will merge the MR anyway.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code