### PR TITLE
fix: Update `dovecot-fts-xapian` to `1.7.13`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ All notable changes to this project will be documented in this file. The format 
 
 #### Fixes
 - **Dovecot:**
-  - `logwatch`  Update logwatch `ignore.conf` to exclude Xapian messages about pending documents
+  - `logwatch`  Update logwatch `ignore.conf` to exclude Xapian messages about pending documents ([#4060](https://github.com/docker-mailserver/docker-mailserver/pull/4060))
+  - `dovecot-fts-xapian` plugin was updated to `1.7.13`, fixing a regression with indexing ([#4095](https://github.com/docker-mailserver/docker-mailserver/pull/4095))
 
 ## [v14.0.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v14.0.0)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,8 @@ EOF
 
 # install fts_xapian plugin
 
-COPY --from=stage-compile dovecot-fts-xapian-1.7.12_1.7.12_*.deb /
-RUN dpkg -i /dovecot-fts-xapian-1.7.12_1.7.12_*.deb && rm /dovecot-fts-xapian-1.7.12_1.7.12_*.deb
+COPY --from=stage-compile dovecot-fts-xapian-*.deb /
+RUN dpkg -i /dovecot-fts-xapian-*.deb && rm /dovecot-fts-xapian-*.deb
 
 COPY target/dovecot/*.inc target/dovecot/*.conf /etc/dovecot/conf.d/
 COPY target/dovecot/dovecot-purge.cron /etc/cron.d/dovecot-purge.disabled

--- a/target/scripts/build/compile.sh
+++ b/target/scripts/build/compile.sh
@@ -16,7 +16,7 @@ function _compile_dovecot_fts_xapian() {
   apt-get "${QUIET}" --no-install-recommends install \
     automake libtool pkg-config libicu-dev libsqlite3-dev libxapian-dev make build-essential dh-make devscripts dovecot-dev
 
-  local XAPIAN_VERSION='1.7.12'
+  local XAPIAN_VERSION='1.7.13'
   curl -sSfL -o dovecot-fts-xapian.tar.gz \
     "https://github.com/grosjo/fts-xapian/releases/download/${XAPIAN_VERSION}/dovecot-fts-xapian-${XAPIAN_VERSION}.tar.gz"
   tar xf dovecot-fts-xapian.tar.gz


### PR DESCRIPTION
# Description

[Reported](https://github.com/docker-mailserver/docker-mailserver/issues/4052#issuecomment-2197237232) with [cause identified as a regression](https://github.com/docker-mailserver/docker-mailserver/issues/4052#issuecomment-2203935503) upstream.

Upstream doesn't seem to maintain a changelog and the release just states "bug fixes", [`1.7.13` was released in May 2024](https://github.com/grosjo/fts-xapian/issues/163#issuecomment-2201553781).

Updating to this release contains a fix to a regression that introduced a bug with indexing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
