### PR TITLE
docs: Update `compose.yaml` for `dovecot-solr` guide

### DIFF
--- a/docs/content/examples/tutorials/dovecot-solr.md
+++ b/docs/content/examples/tutorials/dovecot-solr.md
@@ -43,11 +43,12 @@ As the official DMS image does not provide `dovecot-solr`, you'll need to includ
         services:
           mailserver:
             hostname: mail.example.com
-            # Do not use `image` anymore, unless referring to the tagged image build below
+            # The `image` setting now represents the tag for the local build configured below:
+            image: local/dms:14.0
+            # Local build (no need to try pull `image` remotely):
+            pull_policy: build
             # Add this `build` section to your real `compose.yaml` for your DMS service:
             build:
-              tags:
-                - local/dms:14.0
               dockerfile_inline: |
                 FROM docker.io/mailserver/docker-mailserver:14.0
                 RUN apt-get update && apt-get install dovecot-solr


### PR DESCRIPTION
# Description

The `image` field is used for the default tag, if it's not specified Compose will infer one in addition to any extra `tags` provided.

Better to use `image` for the tag assignment, and a clear `pull_policy` to prevent trying to pull a remote image of the same name.