### PR TITLE
docs: `docker-build.md` - Update `DOVECOT_COMMUNITY_REPO` default

### DIFF
--- a/docs/content/examples/tutorials/docker-build.md
+++ b/docs/content/examples/tutorials/docker-build.md
@@ -32,7 +32,7 @@ We make use of build features that require a recent version of Docker. v23.0 or 
 
 The `Dockerfile` includes several build [`ARG`][docker-docs::builder-arg] instructions that can be configured:
 
-- `DOVECOT_COMMUNITY_REPO`: Install Dovecot from the community repo instead of from Debian (default = 1) 
+- `DOVECOT_COMMUNITY_REPO`: Install Dovecot from the community repo instead of from Debian (default = 0) 
 - `DMS_RELEASE`: The image version (default = edge)
 - `VCS_REVISION`: The git commit hash used for the build (default = unknown)
 


### PR DESCRIPTION
# Description

`DOVECOT_COMMUNITY_REPO` default changed from `1` to `0` with v14:

https://github.com/docker-mailserver/docker-mailserver/blob/4778f15fdaf5e94aee364396166fdc2821066c46/Dockerfile#L7

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
