### PR TITLE
chore: Prevent Microsoft MUAs from sending reactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ All notable changes to this project will be documented in this file. The format 
   - Bump version to [1.1.0](https://github.com/fail2ban/fail2ban/releases/tag/1.1.0). For more information, check the [changelog](https://github.com/fail2ban/fail2ban/blob/1.1.0/ChangeLog).
 - **Documentation:**
   - Rewritten and organized the pages for Account Management and Authentication ([#4122](https://github.com/docker-mailserver/docker-mailserver/pull/4122))
-
+- **Postfix**
+  - Disable Microsoft reactions to outgoing mail. ([#4120](https://github.com/docker-mailserver/docker-mailserver/pull/4120))
 
 #### Fixes
 

--- a/target/postfix/sender_header_filter.pcre
+++ b/target/postfix/sender_header_filter.pcre
@@ -8,4 +8,4 @@
 /^\s*X-Mailer/                      IGNORE
 /^\s*X-Originating-IP/              IGNORE
 /^\s*Received: from.*127.0.0.1/     IGNORE
-
+/^Content-Type:/i                   PREPEND X-MS-Reactions: disallow


### PR DESCRIPTION
# Description

Microsoft added a way to "react" to emails which is turned into
> [Image] <Name> liked this message.

No MUA except Microsoft's latest ones displays these properly and they are not providing significant value to an Email-exchange.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
