### PR TITLE
docs: Remove `restart: always` from `compose.yaml`

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -19,7 +19,6 @@ services:
       - ./docker-data/dms/mail-logs/:/var/log/mail/
       - ./docker-data/dms/config/:/tmp/docker-mailserver/
       - /etc/localtime:/etc/localtime:ro
-    restart: always
     stop_grace_period: 1m
     # Uncomment if using `ENABLE_FAIL2BAN=1`:
     # cap_add:


### PR DESCRIPTION
# Description

This line has been in the `compose.yaml` example [since March 2017](https://github.com/docker-mailserver/docker-mailserver/pull/550). As our docs actively discourage container restarts, and to ensure a fresh container start as an initial troubleshooting step, we should probably drop this line?

DMS is a bit more resilient since v14 release now that it skips initial setup scripts:

https://github.com/docker-mailserver/docker-mailserver/blob/c5f125c973d65d0f51000061952ec378b7449c6e/target/scripts/start-mailserver.sh#L172-L174

Although I'm not sure if that has completely addressed the concern? Should keep this line advising `restart: always` as ok? Or is it better to drop it?

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [x] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
