### PR TITLE
docs: Add minimal `compose.yaml` examples that demonstrate specific features

### DIFF
--- a/demo-setups/fetchmail-compose.yaml
+++ b/demo-setups/fetchmail-compose.yaml
@@ -18,7 +18,7 @@ services:
     #ports:
     #  - "465:465"  # ESMTP (implicit TLS)
     #  - "993:993"  # IMAP4 (implicit TLS)
-    # You'd normally use volumes here, for simplicity of the example, all config is contained within `compose.yaml`:
+    # You'd normally use `volumes` here but for simplicity of the example, all config is contained within `compose.yaml`:
     configs:
       - source: dms-accounts-fetch
         target: /tmp/docker-mailserver/postfix-accounts.cf

--- a/demo-setups/fetchmail-compose.yaml
+++ b/demo-setups/fetchmail-compose.yaml
@@ -26,7 +26,7 @@ services:
         target: /tmp/docker-mailserver/fetchmail.cf
 
   dms-remote:
-    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest # :14.0
     hostname: mail.remote.test
     environment:
       # Allows for us send a test mail easily by trusting any mail client run within this container (`swaks`):

--- a/demo-setups/fetchmail-compose.yaml
+++ b/demo-setups/fetchmail-compose.yaml
@@ -1,0 +1,57 @@
+More information: https://github.com/orgs/docker-mailserver/discussions/3994#discussioncomment-9290570
+services:
+  dms-fetch:
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    hostname: mail.example.test
+    environment:
+      ENABLE_FETCHMAIL: 1
+      # We change this setting to 10 for quicker testing:
+      FETCHMAIL_POLL: 10
+    # Link the DNS lookup `remote.test` to resolve to the `dms-remote` container IP (for `@remote.test` address):
+    # This is only for this example, since no real DNS service is configured, this is a Docker internal DNS feature:
+    links:
+      - "dms-remote:remote.test"
+    # NOTE: Optional, You only need to publish ports if you want to verify via your own mail client.
+    #ports:
+    #  - "465:465"  # ESMTP (implicit TLS)
+    #  - "993:993"  # IMAP4 (implicit TLS)
+    # You'd normally use volumes here, for simplicity of the example, all config is contained within `compose.yaml`:
+    configs:
+      - source: dms-accounts-fetch
+        target: /tmp/docker-mailserver/postfix-accounts.cf
+      - source: fetchmail
+        target: /tmp/docker-mailserver/fetchmail.cf
+
+  dms-remote:
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    hostname: mail.remote.test
+    environment:
+      # Allows for us send a test mail easily by trusting any mail client run within this container (`swaks`):
+      PERMIT_DOCKER: container
+      # Alternatively, trust and accept any mail received from clients in same subnet of dms-fetch:
+      #PERMIT_DOCKER: connected-networks
+    configs:
+      - source: dms-accounts-remote
+        target: /tmp/docker-mailserver/postfix-accounts.cf
+
+# Using the Docker Compose `configs.content` feature instead of volume mounting separate files.
+# NOTE: This feature requires Docker Compose v2.23.1 (Nov 2023) or newer:
+# https://github.com/compose-spec/compose-spec/pull/446
+configs:
+  fetchmail:
+    content: |
+      poll 'mail.remote.test' proto imap
+        user 'jane.doe@remote.test'
+        pass 'secret'
+        is 'john.doe@example.test'
+        no sslcertck
+
+  # DMS requires an account to complete setup, configure one for each instance:
+  # NOTE: Both accounts are configured with the same password (SHA512-CRYPT hashed), `secret`.
+  dms-accounts-fetch:
+    content: |
+      john.doe@example.test|{SHA512-CRYPT}$$6$$sbgFRCmQ.KWS5ryb$$EsWrlYosiadgdUOxCBHY0DQ3qFbeudDhNMqHs6jZt.8gmxUwiLVy738knqkHD4zj4amkb296HFqQ3yDq4UXt8.
+
+  dms-accounts-remote:
+    content: |
+      jane.doe@remote.test|{SHA512-CRYPT}$$6$$sbgFRCmQ.KWS5ryb$$EsWrlYosiadgdUOxCBHY0DQ3qFbeudDhNMqHs6jZt.8gmxUwiLVy738knqkHD4zj4amkb296HFqQ3yDq4UXt8.

--- a/demo-setups/fetchmail-compose.yaml
+++ b/demo-setups/fetchmail-compose.yaml
@@ -4,7 +4,7 @@
 
 services:
   dms-fetch:
-    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest # :14.0
     hostname: mail.example.test
     environment:
       ENABLE_FETCHMAIL: 1

--- a/demo-setups/fetchmail-compose.yaml
+++ b/demo-setups/fetchmail-compose.yaml
@@ -1,4 +1,6 @@
-# More information: https://github.com/orgs/docker-mailserver/discussions/3994#discussioncomment-9290570
+# Docs: https://docker-mailserver.github.io/docker-mailserver/v14.0/config/advanced/mail-fetchmail
+# Additional context, with CLI commands for verification:
+# https://github.com/orgs/docker-mailserver/discussions/3994#discussioncomment-9290570
 
 services:
   dms-fetch:

--- a/demo-setups/fetchmail-compose.yaml
+++ b/demo-setups/fetchmail-compose.yaml
@@ -1,4 +1,4 @@
-More information: https://github.com/orgs/docker-mailserver/discussions/3994#discussioncomment-9290570
+# More information: https://github.com/orgs/docker-mailserver/discussions/3994#discussioncomment-9290570
 services:
   dms-fetch:
     image: ghcr.io/docker-mailserver/docker-mailserver:latest

--- a/demo-setups/fetchmail-compose.yaml
+++ b/demo-setups/fetchmail-compose.yaml
@@ -1,4 +1,5 @@
 # More information: https://github.com/orgs/docker-mailserver/discussions/3994#discussioncomment-9290570
+
 services:
   dms-fetch:
     image: ghcr.io/docker-mailserver/docker-mailserver:latest

--- a/demo-setups/relay-compose.yaml
+++ b/demo-setups/relay-compose.yaml
@@ -1,0 +1,143 @@
+# More information: https://github.com/docker-mailserver/docker-mailserver/issues/4136#issuecomment-2253693490
+
+services:
+  # This would represent your actual DMS container:
+  dms-sender:
+    image: mailserver/docker-mailserver:14.0
+    hostname: mail.example.test
+    environment:
+      # All outbound mail will be relayed through this host
+      # (change the port to 587 if you do not want the postfix-main.cf override)
+      - DEFAULT_RELAY_HOST=[smtp.relay-service.test]:465
+      # Your relay host credentials.
+      # (since the relay in the example is DMS, the relay account username is a full email address)
+      - RELAY_USER=relay-user@relay-service.test
+      - RELAY_PASSWORD=secret
+      # The mail client (swaks) needs to connect with TLS:
+      - SSL_TYPE=manual
+      - SSL_KEY_PATH=/tmp/tls/key.pem
+      - SSL_CERT_PATH=/tmp/tls/cert.pem
+    # You would usually have `volumes` instead of this `configs`:
+    configs:
+      - source: dms-main
+        target: /tmp/docker-mailserver/postfix-main.cf
+      - source: dms-accounts
+        target: /tmp/docker-mailserver/postfix-accounts.cf
+      # Authenticating on port 587 or 465 enforces TLS requirement:
+      - source: tls-cert
+        target: /tmp/tls/cert.pem
+      - source: tls-key
+        target: /tmp/tls/key.pem
+      # This is only needed if you want to verify the TLS cert chain with swaks
+      # (normally with public CA providers like LetsEncrypt this file is already available to a mail client)
+      - source: tls-ca-cert
+        target: /tmp/tls/ca-cert.pem
+
+  # Pretend this is your third-party relay service:
+  dms-relay:
+    image: mailserver/docker-mailserver:14.0
+    hostname: smtp.relay-service.test
+    environment:
+      # WORKAROUND: Bypass security checks from the mail-client (dms-sender container)
+      # (avoids needing valid DNS for this example)
+      - PERMIT_DOCKER=connected-networks
+      # TLS is required when relaying to dms-relay via ports 587 / 465
+      # (dms-relay will then relay the mail to dms-destination over port 25)
+      - SSL_TYPE=manual
+      - SSL_KEY_PATH=/tmp/tls/key.pem
+      - SSL_CERT_PATH=/tmp/tls/cert.pem
+    # WORKAROUND: `links` is required due to lack of properly configured DNS.
+    # (resolves destination.test to the IP of the dms-destination container)
+    links:
+      - "dms-destination:destination.test"
+    configs:
+      - source: dms-accounts-relay
+        target: /tmp/docker-mailserver/postfix-accounts.cf
+      - source: tls-cert
+        target: /tmp/tls/cert.pem
+      - source: tls-key
+        target: /tmp/tls/key.pem
+
+  # Pretend this is another mail server that your target recipient belongs to (like Gmail):
+  dms-destination:
+    image: mailserver/docker-mailserver:14.0
+    hostname: mail.destination.test
+    # Same workaround for purposes of the example, with the target recipient provisioned to accept mail
+    environment:
+      - PERMIT_DOCKER=connected-networks
+    configs:
+      - source: dms-accounts-destination
+        target: /tmp/docker-mailserver/postfix-accounts.cf
+
+# Using the Docker Compose `configs.content` feature instead of volume mounting separate files.
+# NOTE: This feature requires Docker Compose v2.23.1 (Nov 2023) or newer:
+# https://github.com/compose-spec/compose-spec/pull/446
+configs:
+  # DMS expects an account to be configured to run, this example provides accounts already created.
+  # Login credentials:
+  # user: "john.doe@example.test" password: "secret"
+  # user: "relay-user@relay-service.test" password: "secret"
+  # user: "jane.doe@destination.test" password: "secret"
+  dms-accounts:
+    # NOTE: `$` needed to be repeated to escape it,
+    # which opts out of the `compose.yaml` variable interpolation feature.
+    content: |
+      john.doe@example.test|{SHA512-CRYPT}$$6$$sbgFRCmQ.KWS5ryb$$EsWrlYosiadgdUOxCBHY0DQ3qFbeudDhNMqHs6jZt.8gmxUwiLVy738knqkHD4zj4amkb296HFqQ3yDq4UXt8.
+
+  dms-accounts-relay:
+    content: |
+      relay-user@relay-service.test|{SHA512-CRYPT}$$6$$o65y1ZXC4ooOPLwZ$$7TF1nYowEtNJpH6BwJBgdj2pPAxaCvhIKQA6ww5zdHm/AA7aemY9eoHC91DOgYNaKj1HLxSeWNDdvrp6mbtUY.
+
+  dms-accounts-destination:
+    content: |
+      jane.doe@destination.test|{SHA512-CRYPT}$$6$$o65y1ZXC4ooOPLwZ$$7TF1nYowEtNJpH6BwJBgdj2pPAxaCvhIKQA6ww5zdHm/AA7aemY9eoHC91DOgYNaKj1HLxSeWNDdvrp6mbtUY.
+
+  # This is `postfix-main.cf`, single line change to make all outbound SMTP connections over port 465 instead of 25 (default)
+  # If you selectively relay mail, you would need to adjust this on the relay service in `/etc/postfix/master.cf`,
+  # However DMS presently modifies this when using the DMS Relay Host feature support, which may override `postfix-master.cf` or `user-patches.sh` due to `check-for-changes.sh`.
+  dms-main:
+    content: |
+      smtp_tls_wrappermode=yes
+
+  # TLS files:
+  # - Use an ECDSA cert that's been signed by a self-signed CA for TLS cert verification.
+  # - This cert is only valid for mail.example.test, mail.destination.test, smtp.relay-service.test
+
+  # `swaks` run in the container will need to reference this CA cert file for successful verficiation (optional).
+  tls-ca-cert:
+    content: |
+      -----BEGIN CERTIFICATE-----
+      MIIBfTCCASKgAwIBAgIRAMAZttlRlkcuSun0yV0z4RwwCgYIKoZIzj0EAwIwHDEa
+      MBgGA1UEAxMRU21hbGxzdGVwIFJvb3QgQ0EwHhcNMjEwMTAxMDAwMDAwWhcNMzEw
+      MTAxMDAwMDAwWjAcMRowGAYDVQQDExFTbWFsbHN0ZXAgUm9vdCBDQTBZMBMGByqG
+      SM49AgEGCCqGSM49AwEHA0IABJX2hCtoK3+bM5I3rmyApXLJ1gOcVhtoSSwM8XXR
+      SEl25Kkc0n6mINuMK8UrBkiBUgexf6CYayx3xVr9TmMkg4KjRTBDMA4GA1UdDwEB
+      /wQEAwIBBjASBgNVHRMBAf8ECDAGAQH/AgEBMB0GA1UdDgQWBBQD8sBrApbyYyqU
+      y+/TlwGynx2V5jAKBggqhkjOPQQDAgNJADBGAiEAi8N2eOETI+6hY3+G+kzNMd3K
+      Sd3Ke8b++/nlwr5Fb/sCIQDYAjpKp/MpTDWICeHC2tcB5ptxoTdWkTBuG4rKcktA
+      0w==
+      -----END CERTIFICATE-----
+
+  tls-key:
+    content: |
+      -----BEGIN EC PRIVATE KEY-----
+      MHcCAQEEIOc6wqZmSDmT336K4O26dMk1RCVc0+cmnsO2eK4P5K5yoAoGCCqGSM49
+      AwEHoUQDQgAEFOWNgekKKvUZE89vJ7henUYxODYIvCiHitRc2ylwttjqt1KUY1cp
+      q3jof2fhURHfBUH3dHPXLHig5V9Jw5gqeg==
+      -----END EC PRIVATE KEY-----
+
+  tls-cert:
+    content: |
+      -----BEGIN CERTIFICATE-----
+      MIIB9DCCAZqgAwIBAgIQE53a/y2c//YXRsz2kLm6gDAKBggqhkjOPQQDAjAcMRow
+      GAYDVQQDExFTbWFsbHN0ZXAgUm9vdCBDQTAeFw0yMTAxMDEwMDAwMDBaFw0zMTAx
+      MDEwMDAwMDBaMBkxFzAVBgNVBAMTDlNtYWxsc3RlcCBMZWFmMFkwEwYHKoZIzj0C
+      AQYIKoZIzj0DAQcDQgAEFOWNgekKKvUZE89vJ7henUYxODYIvCiHitRc2ylwttjq
+      t1KUY1cpq3jof2fhURHfBUH3dHPXLHig5V9Jw5gqeqOBwDCBvTAOBgNVHQ8BAf8E
+      BAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB0GA1UdDgQWBBSz
+      w74g+O6dcBbwienD70D8A9ESmDAfBgNVHSMEGDAWgBQD8sBrApbyYyqUy+/TlwGy
+      nx2V5jBMBgNVHREERTBDghFtYWlsLmV4YW1wbGUudGVzdIIVbWFpbC5kZXN0aW5h
+      dGlvbi50ZXN0ghdzbXRwLnJlbGF5LXNlcnZpY2UudGVzdDAKBggqhkjOPQQDAgNI
+      ADBFAiEAoety5oClZtuBMkvlUIWRmWlyg1VIOZ544LSEbplsIhcCIHb6awMwNdXP
+      m/xHjFkuwH1+UjDDRW53Ih7KZoLrQ6Cp
+      -----END CERTIFICATE-----

--- a/demo-setups/relay-compose.yaml
+++ b/demo-setups/relay-compose.yaml
@@ -1,4 +1,6 @@
-# More information: https://github.com/docker-mailserver/docker-mailserver/issues/4136#issuecomment-2253693490
+# Docs: https://docker-mailserver.github.io/docker-mailserver/v14.0/config/advanced/mail-forwarding/relay-hosts/
+# Additional context, with CLI commands for verification:
+# https://github.com/docker-mailserver/docker-mailserver/issues/4136#issuecomment-2253693490
 
 services:
   # This would represent your actual DMS container:

--- a/demo-setups/relay-compose.yaml
+++ b/demo-setups/relay-compose.yaml
@@ -3,7 +3,7 @@
 services:
   # This would represent your actual DMS container:
   dms-sender:
-    image: mailserver/docker-mailserver:14.0
+    image: mailserver/docker-mailserver:latest # :14.0
     hostname: mail.example.test
     environment:
       # All outbound mail will be relayed through this host

--- a/demo-setups/relay-compose.yaml
+++ b/demo-setups/relay-compose.yaml
@@ -60,7 +60,7 @@ services:
 
   # Pretend this is another mail server that your target recipient belongs to (like Gmail):
   dms-destination:
-    image: mailserver/docker-mailserver:14.0
+    image: mailserver/docker-mailserver:latest # :14.0
     hostname: mail.destination.test
     # Same workaround for purposes of the example, with the target recipient provisioned to accept mail
     environment:

--- a/demo-setups/relay-compose.yaml
+++ b/demo-setups/relay-compose.yaml
@@ -35,7 +35,7 @@ services:
 
   # Pretend this is your third-party relay service:
   dms-relay:
-    image: mailserver/docker-mailserver:14.0
+    image: mailserver/docker-mailserver:latest # :14.0
     hostname: smtp.relay-service.test
     environment:
       # WORKAROUND: Bypass security checks from the mail-client (dms-sender container)


### PR DESCRIPTION
# Description

**NOTE:** This PR description below was added by @polarathene 

Add some of the self-contained `compose.yaml` examples that @polarathene has provided in past issues to support troubleshooting and demonstrate a feature working completely locally.

These are not intended to mirror production deployments, they sometimes take a different approach not suited for real deployments to better support quick setup
- Using non-persistent configs instead of volumes.
- Skipping proper DNS records, postfix security checks, and TLS when it can be avoided.
- Often oriented to using `swaks` as the mail client within a container and staying within the same docker network, rather than interacting with a host mail client. Hence the original issue context for related CLI commands/information.

Our users often aren't aware that they can run DMS like this as easily. They can use multiple instances of DMS to learn how features work or troubleshoot without needing to worry about external third-party services, LetsEncrypt + real domain DNS and VPS, etc.

Reference: https://github.com/docker-mailserver/docker-mailserver/issues/4136#issuecomment-2254115610

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
