### PR TITLE
docs: Add caveat for ENV `DMS_VMAIL_UID` value compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Added
 
 - **Internal:**
-  - Add password confirmation to several `setup.sh` commands ([#4072](https://github.com/docker-mailserver/docker-mailserver/pull/4072))
+  - Add password confirmation to several `setup` CLI subcommands ([#4072](https://github.com/docker-mailserver/docker-mailserver/pull/4072))
 
 ### Updates
 
@@ -22,13 +22,14 @@ All notable changes to this project will be documented in this file. The format 
   - Bump version to [1.1.0](https://github.com/fail2ban/fail2ban/releases/tag/1.1.0). For more information, check the [changelog](https://github.com/fail2ban/fail2ban/blob/1.1.0/ChangeLog).
 - **Documentation:**
   - Rewritten and organized the pages for Account Management and Authentication ([#4122](https://github.com/docker-mailserver/docker-mailserver/pull/4122))
-- **Postfix**
-  - Disable Microsoft reactions to outgoing mail. ([#4120](https://github.com/docker-mailserver/docker-mailserver/pull/4120))
+  - Add caveat for `DMS_VMAIL_UID` not being compatible with `0` / root ([#4143](https://github.com/docker-mailserver/docker-mailserver/pull/4143))
+- **Postfix:**
+  - Disable Microsoft reactions to outgoing mail ([#4120](https://github.com/docker-mailserver/docker-mailserver/pull/4120))
 
 ### Fixes
 
 - **Dovecot:**
-  - `logwatch`  Update logwatch `ignore.conf` to exclude Xapian messages about pending documents ([#4060](https://github.com/docker-mailserver/docker-mailserver/pull/4060))
+  - Update logwatch `ignore.conf` to exclude Xapian messages about pending documents ([#4060](https://github.com/docker-mailserver/docker-mailserver/pull/4060))
   - `dovecot-fts-xapian` plugin was updated to `1.7.13`, fixing a regression with indexing ([#4095](https://github.com/docker-mailserver/docker-mailserver/pull/4095))
 
 ### CI

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -39,6 +39,12 @@ Default: 5000
 
 The User ID assigned to the static vmail user for `/var/mail` (_Mail storage managed by Dovecot_).
 
+!!! warning "Incompatible UID values"
+
+    - A value of [`0` (root) is not compatible][gh-issue::vmail-uid-cannot-be-root].
+    - This feature will attempt to adjust the `uid` for the `docker` user (`/etc/passwd`), hence the error emitted to logs if the UID is already assigned to another user.
+    - The feature appears to work with other UID values that are already assigned in `/etc/passwd`, even though Dovecot by default has a setting for the minimum UID as `500`.
+
 ##### DMS_VMAIL_GID
 
 Default: 5000
@@ -1122,6 +1128,8 @@ Provide the credentials to use with `RELAY_HOST` or `DEFAULT_RELAY_HOST`.
     - Credentials can be explicitly configured for specific relay hosts instead of sender domains:
         - Add the exact relayhost value (`host:port` / `[host]:port`) from the generated `/etc/postfix/relayhost_map`, or `main.cf:relayhost` (`DEFAULT_RELAY_HOST`).
         - `setup relay ...` is missing support, you must instead add these manually to `postfix-sasl-password.cf`.
+
+[gh-issue::vmail-uid-cannot-be-root]: https://github.com/docker-mailserver/docker-mailserver/issues/4098#issuecomment-2257201025
 
 [docs-rspamd]: ./security/rspamd.md
 [docs-tls]: ./security/ssl.md


### PR DESCRIPTION
# Description

This raises awareness of a compatibility issue found when troubleshooting: https://github.com/docker-mailserver/docker-mailserver/issues/4098#issuecomment-2257201025

I've not looked into it further but the actual `docker` user / group usage is a bit unclear (_horrible choice given the project, not an easy thing to search for_). This feature at least seems to work even when the UID fails, but that may be due to `/var/mail` sticky-bit with group and the `chown`, since the `docker` user will still have their GID adjusted. For reference I did document coverage on the `docker` / `5000` user assignment and usage a while back: https://github.com/docker-mailserver/docker-mailserver/issues/3557

Just updating documentation, so the mentioned error log item would still be present if the adjustment fails because a UID was selected that is already associated to another user (`/etc/passwd`).

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
