### PR TITLE
postfix-main-new.cf should only contain stdout from postconf

### DIFF
--- a/target/scripts/startup/setup.d/postfix.sh
+++ b/target/scripts/startup/setup.d/postfix.sh
@@ -129,7 +129,7 @@ function __postfix__setup_override_configuration() {
     # Do not directly output to 'main.cf' as this causes a read-write-conflict.
     # `postconf` output is filtered to skip expected warnings regarding overrides:
     # https://github.com/docker-mailserver/docker-mailserver/pull/3880#discussion_r1510414576
-    postconf -n >/tmp/postfix-main-new.cf 2> >(grep -v 'overriding earlier entry')
+    postconf -n 1>/tmp/postfix-main-new.cf 2> >(grep -v 'overriding earlier entry')
 
     mv /tmp/postfix-main-new.cf /etc/postfix/main.cf
     _adjust_mtime_for_postfix_maincf


### PR DESCRIPTION
# Description

I added a configuration in `postfix-main.cf` referencing a file.
This file was not in place at time of executing `postconf` during startup, as it comes with `user-patches.sh`.
As a result there are errors from `postconf -n` in the main.cf which obviously cannot be parsed.

To avoid errors from `postconf` in the resulting `main.cf` the script should redirect only `stdout` to the new file.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

I did not check any of that boxes because I just changed a single char in a existing line of code.
No commentations, documentation or changelog necessary.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**

