### PR TITLE
fix: Ensure main log file is tailed from the start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ All notable changes to this project will be documented in this file. The format 
   - Update logwatch `ignore.conf` to exclude Xapian messages about pending documents ([#4060](https://github.com/docker-mailserver/docker-mailserver/pull/4060))
   - `dovecot-fts-xapian` plugin was updated to `1.7.13`, fixing a regression with indexing ([#4095](https://github.com/docker-mailserver/docker-mailserver/pull/4095))
 - **Internal:**
-  - The main `mail.log` followed to stdout now correctly begins from the first log line ([#4146](https://github.com/docker-mailserver/docker-mailserver/pull/4146))
+  - The main `mail.log` which is piped to stdout via `tail` now correctly begins from the first log line of the active container run. Previously some daemon logs and potential warnings/errors were omitted. ([#4146](https://github.com/docker-mailserver/docker-mailserver/pull/4146))
   - Fixed a regression introduced in v14 where `postfix-main.cf` appended `stderr` output into `/etc/postfix/main.cf`, causing Postfix startup to fail ([#4147](https://github.com/docker-mailserver/docker-mailserver/pull/4147))
 
 ### CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ All notable changes to this project will be documented in this file. The format 
 - **Dovecot:**
   - Update logwatch `ignore.conf` to exclude Xapian messages about pending documents ([#4060](https://github.com/docker-mailserver/docker-mailserver/pull/4060))
   - `dovecot-fts-xapian` plugin was updated to `1.7.13`, fixing a regression with indexing ([#4095](https://github.com/docker-mailserver/docker-mailserver/pull/4095))
+- **Internal:**
+  - The main `mail.log` followed to stdout now correctly begins from the first log line ([#4146](https://github.com/docker-mailserver/docker-mailserver/pull/4146))
 
 ### CI
 

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -199,5 +199,8 @@ _start_daemons
 
 _log 'info' "${HOSTNAME} is up and running"
 
+# NOTE: This file should already exist with log output from rsyslogd:
 touch /var/log/mail/mail.log
-exec tail -Fn 0 /var/log/mail/mail.log
+# Container logs will receive updates to this log file,
+# `-n +0` ensures we output to stdout from the first line of the file.
+exec tail -Fn +0 /var/log/mail/mail.log

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -194,7 +194,7 @@ fi
 # marker to check if container was restarted
 date >/CONTAINER_START
 
-# Container logs will receive updates to this log file:
+# Container logs will receive updates from this log file:
 MAIN_LOGFILE=/var/log/mail/mail.log
 # NOTE: rsyslogd would usually create this later during `_start_daemons`, however it would already exist if the container was restarted.
 touch "${MAIN_LOGFILE}"

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -199,7 +199,7 @@ MAIN_LOGFILE=/var/log/mail/mail.log
 # NOTE: rsyslogd would usually create this later during `_start_daemons`, however it would already exist if the container was restarted.
 touch "${MAIN_LOGFILE}"
 # Ensure `tail` follows the correct position of the log file for this container start (new logs begin once `_start_daemons` is called)
-TAIL_START=$(wc -l < "${MAIN_LOGFILE}")
+TAIL_START=$(( $(wc -l < "${MAIN_LOGFILE}") + 1 ))
 
 [[ ${LOG_LEVEL} =~ (debug|trace) ]] && print-environment
 _start_daemons


### PR DESCRIPTION
# Description

I noticed a difference in log output when troubleshooting a recent issue. Depending on if `ENABLE_AMAVIS` was on/off, earlier logs in this file did not appear. The `touch` doesn't seem relevant as logs from starting up daemons were already present, but in this case only slightly delayed amavis logs were displayed.

Syntax of the `tail` command was slightly off, seems to require a `+` in front of the number given to `-n` 👍 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
