### PR TITLE
feat: basic support for SNI via Traefik

### DIFF
--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -191,6 +191,12 @@ In the majority of cases, you want `letsencrypt` or `manual`.
 
 Please read [the SSL page in the documentation][docs-tls] for more information.
 
+##### SSL_SNI_DOMAINS
+
+Comma separated list of domains.
+
+Certificates will be exported for each domain from traefik `acme.json` and added to Postfix and Dovecot for SNI support.
+
 ##### TLS_LEVEL
 
 - **empty** => modern

--- a/mailserver.env
+++ b/mailserver.env
@@ -240,6 +240,9 @@ SMTP_ONLY=
 # self-signed => Enables self-signed certificates
 SSL_TYPE=
 
+# Provide a comma separated list of domains to additionally export the certificate from acme.json
+SSL_SNI_DOMAINS=
+
 # These are only supported with `SSL_TYPE=manual`.
 # Provide the path to your cert and key files that you've mounted access to within the container.
 SSL_CERT_PATH=

--- a/target/scripts/helpers/ssl.sh
+++ b/target/scripts/helpers/ssl.sh
@@ -127,6 +127,44 @@ function _setup_ssl() {
       fi
 
       _log 'trace' "letsencrypt (acme.json) extracted certificate using ${EXTRACTED_DOMAIN[0]}: '${EXTRACTED_DOMAIN[1]}'"
+
+      # Extracting certificates for SNI support
+      if [[ -n ${SSL_SNI_DOMAINS} ]] ; then
+        # add empty dovecot & postfix config
+        echo -n "" > /etc/dovecot/conf.d/20-sni.conf
+        echo -n "" > /etc/postfix/sni.map
+
+        # add tls_server_sni_maps yo main.cf if not exist
+        local SNI_MAPS="tls_server_sni_maps = hash:/etc/postfix/sni.map"
+        grep -qxF -- "${SNI_MAPS}" "/etc/postfix/main.cf" || echo "${SNI_MAPS}" >> /etc/postfix/main.cf
+
+        for SNI_DOMAIN in ${SSL_SNI_DOMAINS//,/ }
+        do
+          if _extract_certs_from_acme "${SNI_DOMAIN}"; then
+            local PRIVATE_KEY="/etc/letsencrypt/live/${SNI_DOMAIN}/key.pem"
+            local CERT_CHAIN="/etc/letsencrypt/live/${SNI_DOMAIN}/fullchain.pem"
+
+            # add certificate to postfix
+            echo "${SNI_DOMAIN} ${PRIVATE_KEY} ${CERT_CHAIN}" >> /etc/postfix/sni.map
+
+            # add certificate to dovecot
+            {
+              echo "local_name ${SNI_DOMAIN} {"
+              echo "  ssl_cert = <${CERT_CHAIN}"
+              echo "  ssl_key = <${PRIVATE_KEY}"
+              echo "}"
+            } >> /etc/dovecot/conf.d/20-sni.conf
+
+            _log 'trace' "SNI: extracted domain: ${SNI_DOMAIN}"
+          else
+            _log 'warn' "SNI: letsencrypt (acme.json) failed to extract domain: ${SNI_DOMAIN}"
+          fi
+        done
+
+        # create postfix SNI table
+        postmap -F hash:/etc/postfix/sni.map
+        _log 'trace' "SNI: creating postfix db (sni.map.db)"
+      fi
     fi
   }
 


### PR DESCRIPTION
# Description

My attempt to implement a support for SNI in Dovecot and Postfix. The configuration is intended for use with traefik

The idea is to provide a separate certificate for each domain trying to connect to the server (mail.domain2.com) instead of using a single main server (mail.domain.com)

TODO: add explanation in docs and a guide

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
