### PR TITLE
fix: typo in volume pathname

### DIFF
--- a/docs/content/config/security/ssl.md
+++ b/docs/content/config/security/ssl.md
@@ -240,7 +240,7 @@ After completing the steps above, your certificate should be ready to use.
         image: certbot/dns-cloudflare:latest
         command: renew --dns-cloudflare --dns-cloudflare-credentials /run/secrets/cloudflare-api-token
         volumes:
-          - ./docker-data/certbot/certs/:/etc/letsencrtypt/
+          - ./docker-data/certbot/certs/:/etc/letsencrypt/
           - ./docker-data/certbot/logs/:/var/log/letsencrypt/
         secrets:
           - cloudflare-api-token


### PR DESCRIPTION
# Description

Fix typo in docker volume pathname to make example renew code to work.

Fixes #


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
