### PR TITLE
chore: Add maintenance note for LMTP

### DIFF
--- a/target/scripts/startup/setup.d/postfix.sh
+++ b/target/scripts/startup/setup.d/postfix.sh
@@ -79,6 +79,8 @@ EOF
     if [[ ${ACCOUNT_PROVISIONER} == 'FILE' ]]; then
       postconf 'virtual_mailbox_maps = texthash:/etc/postfix/vmailbox'
     fi
+    # Historical context regarding decision to use LMTP instead of LDA (do not change this):
+    # https://github.com/docker-mailserver/docker-mailserver/issues/4178#issuecomment-2375489302
     postconf 'virtual_transport = lmtp:unix:/var/run/dovecot/lmtp'
   fi
 


### PR DESCRIPTION
# Description

Since [I've covered this topic a few times in the past](https://github.com/docker-mailserver/docker-mailserver/issues/4178#issuecomment-2375489302), it's probably best to add a maintainer comment where LMTP is configured.

- The linked issue was proposing to change to LDA (_which would not have solved their concern_), while it was not known that DMS originally used LDA in 2016.
- This comment will act as a safe guard to caution any future PR reviews where such a change is proposed again.

A changelog entry seems unnecessary, so none added.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
