### PR TITLE
fix: Avoid alias being used as regex during dovecot dummy account userdb detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to this project will be documented in this file. The format 
 - **Dovecot:**
   - Update logwatch `ignore.conf` to exclude Xapian messages about pending documents ([#4060](https://github.com/docker-mailserver/docker-mailserver/pull/4060))
   - `dovecot-fts-xapian` plugin was updated to `1.7.13`, fixing a regression with indexing ([#4095](https://github.com/docker-mailserver/docker-mailserver/pull/4095))
+  - The Dovecot Quota support "dummy account" workaround no longer treats the alias as a regex when checking the Dovecot UserDB ([#4222](https://github.com/docker-mailserver/docker-mailserver/pull/4222))
 - **LDAP:**
   - A previous compatibility fix for OAuth2 in v13.3.1 had not applied the actual LDAP config changes. This has been corrected ([#4175](https://github.com/docker-mailserver/docker-mailserver/pull/4175))
 - **Internal:**

--- a/target/scripts/helpers/accounts.sh
+++ b/target/scripts/helpers/accounts.sh
@@ -135,7 +135,7 @@ function _create_dovecot_alias_dummy_accounts() {
       fi
 
       DOVECOT_USERDB_LINE="${ALIAS}:${REAL_ACC[1]}:${DMS_VMAIL_UID}:${DMS_VMAIL_GID}::/var/mail/${REAL_DOMAINNAME}/${REAL_USERNAME}/home::${REAL_ACC[2]:-}"
-      if grep -qi "^${ALIAS}:" "${DOVECOT_USERDB_FILE}"; then
+      if grep -qxF "${DOVECOT_USERDB_LINE}" "${DOVECOT_USERDB_FILE}"; then
         _log 'warn' "Alias '${ALIAS}' will not be added to '${DOVECOT_USERDB_FILE}' twice"
       else
         echo "${DOVECOT_USERDB_LINE}" >>"${DOVECOT_USERDB_FILE}"

--- a/target/scripts/helpers/accounts.sh
+++ b/target/scripts/helpers/accounts.sh
@@ -135,7 +135,8 @@ function _create_dovecot_alias_dummy_accounts() {
       fi
 
       DOVECOT_USERDB_LINE="${ALIAS}:${REAL_ACC[1]}:${DMS_VMAIL_UID}:${DMS_VMAIL_GID}::/var/mail/${REAL_DOMAINNAME}/${REAL_USERNAME}/home::${REAL_ACC[2]:-}"
-      if grep -qxF "${DOVECOT_USERDB_LINE}" "${DOVECOT_USERDB_FILE}"; then
+      # Match a full line with `-xF` to avoid regex patterns introducing false positives matching `ALIAS`:
+      if grep -qixF "${DOVECOT_USERDB_LINE}" "${DOVECOT_USERDB_FILE}"; then
         _log 'warn' "Alias '${ALIAS}' will not be added to '${DOVECOT_USERDB_FILE}' twice"
       else
         echo "${DOVECOT_USERDB_LINE}" >>"${DOVECOT_USERDB_FILE}"

--- a/test/config/postfix-virtual.cf
+++ b/test/config/postfix-virtual.cf
@@ -3,3 +3,7 @@ alias1@localhost.localdomain user1@localhost.localdomain
     # this is also a test comment, :O
 alias2@localhost.localdomain external1@otherdomain.tld
 @localdomain2.com user1@localhost.localdomain
+
+# overlapping names
+prefixtest@otherdomain.tld user2@otherdomain.tld
+test@otherdomain.tld user2@otherdomain.tld

--- a/test/config/postfix-virtual.cf
+++ b/test/config/postfix-virtual.cf
@@ -7,3 +7,5 @@ alias2@localhost.localdomain external1@otherdomain.tld
 # overlapping names
 prefixtest@otherdomain.tld user2@otherdomain.tld
 test@otherdomain.tld user2@otherdomain.tld
+first-name@otherdomain.tld user2@otherdomain.tld
+first.name@otherdomain.tld user2@otherdomain.tld

--- a/test/config/postfix-virtual.cf
+++ b/test/config/postfix-virtual.cf
@@ -4,8 +4,12 @@ alias1@localhost.localdomain user1@localhost.localdomain
 alias2@localhost.localdomain external1@otherdomain.tld
 @localdomain2.com user1@localhost.localdomain
 
-# overlapping names
-prefixtest@otherdomain.tld user2@otherdomain.tld
-test@otherdomain.tld user2@otherdomain.tld
-first-name@otherdomain.tld user2@otherdomain.tld
-first.name@otherdomain.tld user2@otherdomain.tld
+## Dovecot "dummy accounts" for quota support (handled in `helpers/accounts.sh`)
+# Do not filter alias by substring condition (longer prefix must be before substring alias):
+# https://github.com/docker-mailserver/docker-mailserver/issues/2639
+prefixtest@localhost.localdomain user2@otherdomain.tld
+test@localhost.localdomain user2@otherdomain.tld
+# Do not filter alias when input be treated as regex tokens (eg `.`):
+# https://github.com/docker-mailserver/docker-mailserver/issues/4170
+first-name@localhost.localdomain user2@otherdomain.tld
+first.name@localhost.localdomain user2@otherdomain.tld

--- a/test/tests/parallel/set3/mta/account_management.bats
+++ b/test/tests/parallel/set3/mta/account_management.bats
@@ -29,12 +29,23 @@ function teardown_file() { _default_teardown ; }
   assert_line --index 5 'alias1@localhost.localdomain'
   # TODO: Probably not intentional?:
   assert_line --index 6 '@localdomain2.com'
-  _should_output_number_of_lines 7
+  # overlapping names
+  assert_line --index 7 'prefixtest@otherdomain.tld'
+  assert_line --index 8 'test@otherdomain.tld'
+  _should_output_number_of_lines 9
 
   # Relevant log output from scripts/helpers/accounts.sh:_create_dovecot_alias_dummy_accounts():
   # [  DEBUG  ]  Adding alias 'alias1@localhost.localdomain' for user 'user1@localhost.localdomain' to Dovecot's userdb
   # [  DEBUG  ]  Alias 'alias2@localhost.localdomain' is non-local (or mapped to a non-existing account) and will not be added to Dovecot's userdb
   # [  DEBUG  ]  Adding alias '@localdomain2.com' for user 'user1@localhost.localdomain' to Dovecot's userdb
+}
+
+@test "should log aliases' creations" {
+  run docker logs "${CONTAINER_NAME}"
+  assert_success
+  assert_line --partial "Adding alias 'prefixtest@otherdomain.tld' for user 'user2@otherdomain.tld' to Dovecot's userdb"
+  assert_line --partial "Adding alias 'test@otherdomain.tld' for user 'user2@otherdomain.tld' to Dovecot's userdb"
+  refute_line --partial "Alias 'test@otherdomain.tld' will not be added to '/etc/dovecot/userdb' twice"
 }
 
 @test "should have created maildir for 'user1@localhost.localdomain'" {

--- a/test/tests/parallel/set3/mta/account_management.bats
+++ b/test/tests/parallel/set3/mta/account_management.bats
@@ -32,7 +32,9 @@ function teardown_file() { _default_teardown ; }
   # overlapping names
   assert_line --index 7 'prefixtest@otherdomain.tld'
   assert_line --index 8 'test@otherdomain.tld'
-  _should_output_number_of_lines 9
+  assert_line --index 9 'first-name@otherdomain.tld'
+  assert_line --index 10 'first.name@otherdomain.tld'
+  _should_output_number_of_lines 11
 
   # Relevant log output from scripts/helpers/accounts.sh:_create_dovecot_alias_dummy_accounts():
   # [  DEBUG  ]  Adding alias 'alias1@localhost.localdomain' for user 'user1@localhost.localdomain' to Dovecot's userdb
@@ -46,6 +48,10 @@ function teardown_file() { _default_teardown ; }
   assert_line --partial "Adding alias 'prefixtest@otherdomain.tld' for user 'user2@otherdomain.tld' to Dovecot's userdb"
   assert_line --partial "Adding alias 'test@otherdomain.tld' for user 'user2@otherdomain.tld' to Dovecot's userdb"
   refute_line --partial "Alias 'test@otherdomain.tld' will not be added to '/etc/dovecot/userdb' twice"
+
+  assert_line --partial "Adding alias 'first-name@otherdomain.tld' for user 'user2@otherdomain.tld' to Dovecot's userdb"
+  assert_line --partial "Adding alias 'first.name@otherdomain.tld' for user 'user2@otherdomain.tld' to Dovecot's userdb"
+  refute_line --partial "Alias 'first.name@otherdomain.tld' will not be added to '/etc/dovecot/userdb' twice"
 }
 
 @test "should have created maildir for 'user1@localhost.localdomain'" {

--- a/test/tests/parallel/set3/mta/account_management.bats
+++ b/test/tests/parallel/set3/mta/account_management.bats
@@ -29,11 +29,11 @@ function teardown_file() { _default_teardown ; }
   assert_line --index 5 'alias1@localhost.localdomain'
   # TODO: Probably not intentional?:
   assert_line --index 6 '@localdomain2.com'
-  # overlapping names
-  assert_line --index 7 'prefixtest@otherdomain.tld'
-  assert_line --index 8 'test@otherdomain.tld'
-  assert_line --index 9 'first-name@otherdomain.tld'
-  assert_line --index 10 'first.name@otherdomain.tld'
+  # Dovecot "dummy accounts" for quota support, see `test/config/postfix-virtual.cf` for more context
+  assert_line --index 7 'prefixtest@localhost.localdomain'
+  assert_line --index 8 'test@localhost.localdomain'
+  assert_line --index 9 'first-name@localhost.localdomain'
+  assert_line --index 10 'first.name@localhost.localdomain'
   _should_output_number_of_lines 11
 
   # Relevant log output from scripts/helpers/accounts.sh:_create_dovecot_alias_dummy_accounts():
@@ -42,16 +42,17 @@ function teardown_file() { _default_teardown ; }
   # [  DEBUG  ]  Adding alias '@localdomain2.com' for user 'user1@localhost.localdomain' to Dovecot's userdb
 }
 
-@test "should log aliases' creations" {
+# Dovecot "dummy accounts" for quota support, see `test/config/postfix-virtual.cf` for more context
+@test "should create all dovecot dummy accounts" {
   run docker logs "${CONTAINER_NAME}"
   assert_success
-  assert_line --partial "Adding alias 'prefixtest@otherdomain.tld' for user 'user2@otherdomain.tld' to Dovecot's userdb"
-  assert_line --partial "Adding alias 'test@otherdomain.tld' for user 'user2@otherdomain.tld' to Dovecot's userdb"
-  refute_line --partial "Alias 'test@otherdomain.tld' will not be added to '/etc/dovecot/userdb' twice"
+  assert_line --partial "Adding alias 'prefixtest@localhost.localdomain' for user 'user2@otherdomain.tld' to Dovecot's userdb"
+  assert_line --partial "Adding alias 'test@localhost.localdomain' for user 'user2@otherdomain.tld' to Dovecot's userdb"
+  refute_line --partial "Alias 'test@localhost.localdomain' will not be added to '/etc/dovecot/userdb' twice"
 
-  assert_line --partial "Adding alias 'first-name@otherdomain.tld' for user 'user2@otherdomain.tld' to Dovecot's userdb"
-  assert_line --partial "Adding alias 'first.name@otherdomain.tld' for user 'user2@otherdomain.tld' to Dovecot's userdb"
-  refute_line --partial "Alias 'first.name@otherdomain.tld' will not be added to '/etc/dovecot/userdb' twice"
+  assert_line --partial "Adding alias 'first-name@localhost.localdomain' for user 'user2@otherdomain.tld' to Dovecot's userdb"
+  assert_line --partial "Adding alias 'first.name@localhost.localdomain' for user 'user2@otherdomain.tld' to Dovecot's userdb"
+  refute_line --partial "Alias 'first.name@localhost.localdomain' will not be added to '/etc/dovecot/userdb' twice"
 }
 
 @test "should have created maildir for 'user1@localhost.localdomain'" {


### PR DESCRIPTION
# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #4170 and test coverage of #2640.

This is my first PR, let me know if I missed something. And regarding the CHANGELOG, would the following line be ok?
```
Fixes
- Dovecot:
   - Fix dummy account creation (PR number)
```

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary, I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
