### PR TITLE
fix: SASLAuth - Drop services for `mysql`, `shadow`, `pam` auth mechanisms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Breaking
 
+- **saslauthd** mechanism support via ENV `SASLAUTHD_MECHANISMS` with `pam`, `shadow`, `mysql` values has been removed. Only `ldap` and `rimap` remain supported.
 - **getmail6** has been refactored: ([#4156](https://github.com/docker-mailserver/docker-mailserver/pull/4156))
   - The [DMS config volume](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/advanced/optional-config/#volumes) now has support for `getmailrc_general.cf` for overriding [common default settings](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/advanced/mail-getmail/#common-options). If you previously mounted this config file directly to `/etc/getmailrc_general` you should switch to our config volume support.
   - IMAP/POP3 example configs added to our [`config-examples`](https://github.com/docker-mailserver/docker-mailserver/tree/v15.0.0/config-examples/getmail).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Breaking
 
-- **saslauthd** mechanism support via ENV `SASLAUTHD_MECHANISMS` with `pam`, `shadow`, `mysql` values has been removed. Only `ldap` and `rimap` remain supported.
+- **saslauthd** mechanism support via ENV `SASLAUTHD_MECHANISMS` with `pam`, `shadow`, `mysql` values has been removed. Only `ldap` and `rimap` remain supported ([#4259](https://github.com/docker-mailserver/docker-mailserver/pull/4259))
 - **getmail6** has been refactored: ([#4156](https://github.com/docker-mailserver/docker-mailserver/pull/4156))
   - The [DMS config volume](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/advanced/optional-config/#volumes) now has support for `getmailrc_general.cf` for overriding [common default settings](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/advanced/mail-getmail/#common-options). If you previously mounted this config file directly to `/etc/getmailrc_general` you should switch to our config volume support.
   - IMAP/POP3 example configs added to our [`config-examples`](https://github.com/docker-mailserver/docker-mailserver/tree/v15.0.0/config-examples/getmail).

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -910,22 +910,26 @@ Note: This postgrey setting needs `ENABLE_POSTGREY=1`
 
 ##### SASLAUTHD_MECHANISMS
 
-- **empty** => pam
-- `ldap` => authenticate against ldap server
-- `shadow` => authenticate against local user db
-- `mysql` => authenticate against mysql db
-- `rimap` => authenticate against imap server
-- NOTE: can be a list of mechanisms like pam ldap shadow
+DMS only implements support for these mechanisms:
+
+- **`ldap`** => Authenticate against an LDAP server
+- `rimap` => Authenticate against an IMAP server
 
 ##### SASLAUTHD_MECH_OPTIONS
 
 - **empty** => None
-- e.g. with SASLAUTHD_MECHANISMS rimap you need to specify the ip-address/servername of the imap server  ==> xxx.xxx.xxx.xxx
+
+!!! info
+
+    With `SASLAUTHD_MECHANISMS=rimap` you need to specify the ip-address / servername of the IMAP server, such as `SASLAUTHD_MECH_OPTIONS=127.0.0.1`.
 
 ##### SASLAUTHD_LDAP_SERVER
 
-- **empty** => same as `LDAP_SERVER_HOST`
-- Note: You must include the desired URI scheme (`ldap://`, `ldaps://`, `ldapi://`).
+- **empty** => Use the same value as `LDAP_SERVER_HOST`
+
+!!! note
+
+    You must include the desired URI scheme (`ldap://`, `ldaps://`, `ldapi://`).
 
 ##### SASLAUTHD_LDAP_START_TLS
 

--- a/target/scripts/startup/variables-stack.sh
+++ b/target/scripts/startup/variables-stack.sh
@@ -182,7 +182,7 @@ function _environment_variables_ldap() {
 function _environment_variables_saslauthd() {
   _log 'debug' 'Setting SASLAUTHD-related environment variables now'
 
-  # This ENV is only used by the supervisor service command:
+  # This ENV is only used by the supervisor service config `saslauth.conf`:
   # NOTE: `pam` is set as the upstream default in `/etc/default/saslauthd`
   VARS[SASLAUTHD_MECHANISMS]="${SASLAUTHD_MECHANISMS:=ldap}"
 }

--- a/target/scripts/startup/variables-stack.sh
+++ b/target/scripts/startup/variables-stack.sh
@@ -182,8 +182,9 @@ function _environment_variables_ldap() {
 function _environment_variables_saslauthd() {
   _log 'debug' 'Setting SASLAUTHD-related environment variables now'
 
-  # Only used by the supervisor service command (upstream default: `/etc/default/saslauthd`)
-  VARS[SASLAUTHD_MECHANISMS]="${SASLAUTHD_MECHANISMS:=pam}"
+  # This ENV is only used by the supervisor service command:
+  # NOTE: `pam` is set as the upstream default in `/etc/default/saslauthd`
+  VARS[SASLAUTHD_MECHANISMS]="${SASLAUTHD_MECHANISMS:=ldap}"
 }
 
 # This function Writes the contents of the `VARS` map (associative array)

--- a/target/supervisor/conf.d/saslauth.conf
+++ b/target/supervisor/conf.d/saslauth.conf
@@ -7,15 +7,6 @@ stderr_logfile=/var/log/supervisor/%(program_name)s.log
 command=/usr/sbin/saslauthd -d -a ldap -O /etc/saslauthd.conf
 pidfile=/var/run/saslauthd/saslauthd.pid
 
-[program:saslauthd_pam]
-startsecs=0
-autostart=false
-autorestart=true
-stdout_logfile=/var/log/supervisor/%(program_name)s.log
-stderr_logfile=/var/log/supervisor/%(program_name)s.log
-command=/usr/sbin/saslauthd -d -a pam -O "%(ENV_SASLAUTHD_MECH_OPTIONS)s"
-pidfile=/var/run/saslauthd/saslauthd.pid
-
 [program:saslauthd_rimap]
 startsecs=0
 autostart=false
@@ -23,13 +14,4 @@ autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 command=/usr/sbin/saslauthd -d -a rimap -r -O "%(ENV_SASLAUTHD_MECH_OPTIONS)s"
-pidfile=/var/run/saslauthd/saslauthd.pid
-
-[program:saslauthd_shadow]
-startsecs=0
-autostart=false
-autorestart=true
-stdout_logfile=/var/log/supervisor/%(program_name)s.log
-stderr_logfile=/var/log/supervisor/%(program_name)s.log
-command=/usr/sbin/saslauthd -d -a shadow -O "%(ENV_SASLAUTHD_MECH_OPTIONS)s"
 pidfile=/var/run/saslauthd/saslauthd.pid

--- a/target/supervisor/conf.d/saslauth.conf
+++ b/target/supervisor/conf.d/saslauth.conf
@@ -7,15 +7,6 @@ stderr_logfile=/var/log/supervisor/%(program_name)s.log
 command=/usr/sbin/saslauthd -d -a ldap -O /etc/saslauthd.conf
 pidfile=/var/run/saslauthd/saslauthd.pid
 
-[program:saslauthd_mysql]
-startsecs=0
-autostart=false
-autorestart=true
-stdout_logfile=/var/log/supervisor/%(program_name)s.log
-stderr_logfile=/var/log/supervisor/%(program_name)s.log
-command=/usr/sbin/saslauthd -d -a mysql -O "%(ENV_SASLAUTHD_MECH_OPTIONS)s"
-pidfile=/var/run/saslauthd/saslauthd.pid
-
 [program:saslauthd_pam]
 startsecs=0
 autostart=false
@@ -42,4 +33,3 @@ stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 command=/usr/sbin/saslauthd -d -a shadow -O "%(ENV_SASLAUTHD_MECH_OPTIONS)s"
 pidfile=/var/run/saslauthd/saslauthd.pid
-


### PR DESCRIPTION
# Description

`SASLAUTHD_MECHANISMS` only has test coverage for `ldap` and `rimap`, which were discussed during the original implementation of the feature.

The other mechanisms were added for the sake of it, but likely don't make much sense with DMS.
- Potentially `pam` would as it appears to be the way to leverage databases like `mysql` for authentication.
- `mysql` has not been a valid value for well over a decade. It's likely never worked in DMS.

Generally `SASLAUTHD` related support is not necessary for users. It was contributed as an alternative SASL auth method for Postfix to use when DMS has Dovecot disabled that would normally be delegated for SASL authentication.

Users interested in MySQL or similar DB access could configure for such directly with Postfix and Dovecot (or just Dovecot due to existing SASL auth config).

There may be potential breakage with `SMTP_ONLY=1` users. I've not considered this as our support/docs for such are lacking. As this is for a breaking release, it should be fine and we can easily bring these back should users raise issues about it.

Docs wise, I don't see how the note about multiple values for mechanisms being supported was valid. Perhaps it was for direct usage of the command but not with how we start the supervisord services.

Fixes #4251

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
