### PR TITLE
docs: TLS (Caddy) - Revise advice on `tls internal`

### DIFF
--- a/docs/content/config/security/ssl.md
+++ b/docs/content/config/security/ssl.md
@@ -512,7 +512,7 @@ DSM-generated letsencrypt certificates get auto-renewed every three months.
 
     ```caddyfile title="Caddyfile"
     mail.example.com {
-      tls internal {
+      tls {
         key_type rsa2048
       }
 
@@ -524,8 +524,10 @@ DSM-generated letsencrypt certificates get auto-renewed every three months.
 
     While DMS does not need a webserver to work, this workaround will provision a TLS certificate for DMS to use.
 
-    - [`tls internal`][caddy-docs::tls-internal] will create a local self-signed cert for testing. This targets only the site-address, unlike the global `local_certs` option.
-    - [`key_type`][caddy-docs::key-type] can be used in the `tls` block if you need to enforce RSA as the key type for certificates provisioned. The default is currently ECDSA (P-256).
+    An explicit `tls` directive affects only the site-address block it's used in:
+
+    - Use [`tls internal { ... }`][caddy-docs::tls-internal] if wanting to create a local self-signed cert, which may be useful for testing. This allows opt-in to use self-signed certs unlike the global `local_certs` option.
+    - [`key_type`][caddy-docs::key-type] can be used in the `tls` block if you need to enforce RSA as the key type for certificates provisioned. The default is currently ECDSA (P-256). This may improve compatibility with legacy clients.
 
 ??? example "With `caddy-docker-proxy`"
 

--- a/docs/content/config/security/ssl.md
+++ b/docs/content/config/security/ssl.md
@@ -485,6 +485,8 @@ DSM-generated letsencrypt certificates get auto-renewed every three months.
 
 !!! example
 
+    While DMS does not need a webserver to work, this workaround will provision a TLS certificate for DMS to use by adding a dummy site block to trigger cert provisioning.
+
     ```yaml title="compose.yaml"
     services:
       # Basic Caddy service to provision certs:
@@ -525,12 +527,12 @@ DSM-generated letsencrypt certificates get auto-renewed every three months.
     }
     ```
 
-    While DMS does not need a webserver to work, this workaround will provision a TLS certificate for DMS to use.
+    !!! info
 
-    An explicit `tls` directive affects only the site-address block it's used in:
+        An explicit `tls` directive affects only the site-address block it's used in:
 
-    - Use [`tls internal { ... }`][caddy-docs::tls-internal] if wanting to create a local self-signed cert, which may be useful for testing. This allows opt-in to use self-signed certs unlike the global `local_certs` option.
-    - [`key_type`][caddy-docs::key-type] can be used in the `tls` block if you need to enforce RSA as the key type for certificates provisioned. The default is currently ECDSA (P-256). This may improve compatibility with legacy clients.
+        - Use [`tls internal { ... }`][caddy-docs::tls-internal] if wanting to create a local self-signed cert, which may be useful for testing. This allows opt-in to use self-signed certs unlike the global `local_certs` option.
+        - [`key_type`][caddy-docs::key-type] can be used in the `tls` block if you need to enforce RSA as the key type for certificates provisioned. The default is currently ECDSA (P-256). This may improve compatibility with legacy clients.
 
 ??? example "With `caddy-docker-proxy`"
 


### PR DESCRIPTION
# Description

Suggested recently by this discussion feedback: https://github.com/orgs/docker-mailserver/discussions/4304#discussioncomment-11736709

As the TLS examples for other services default to public CA with LetsEncrypt, the Caddy example was configuring TLS to use self-signed certificates instead. This PR makes it consistent with the other service examples and revises some commentary.

Direct preview link: https://pullrequest-4305--dms-doc-previews.netlify.app/config/security/ssl/#caddy