### PR TITLE
docs: `bind-smtp-network-interface.md` - Add bridge network config advice

### DIFF
--- a/docs/content/examples/use-cases/bind-smtp-network-interface.md
+++ b/docs/content/examples/use-cases/bind-smtp-network-interface.md
@@ -61,7 +61,7 @@ to the respective IP-address on the server you want to use.
         Sometimes containers use the first IP address from Docker host for outgoing traffic and verifications of rDNS (PTR) can occur for that IP address. 
         To force container to use specific IP address from host you can use following configuration in compose.yml
         
-        ```title="compose.yml"
+        ```title="compose.yaml"
         networks:
           default:
             driver_opts:

--- a/docs/content/examples/use-cases/bind-smtp-network-interface.md
+++ b/docs/content/examples/use-cases/bind-smtp-network-interface.md
@@ -66,3 +66,26 @@ to the respective IP-address on the server you want to use.
 [gh-pr::3465::comment-restrictions]: https://github.com/docker-mailserver/docker-mailserver/pull/3465#discussion_r1458114528
 [gh-pr::3465::alternative-solution]: https://github.com/docker-mailserver/docker-mailserver/pull/3465#issuecomment-1678107233
 [gh-src::postfix-master-cf::relay-transport]: https://github.com/docker-mailserver/docker-mailserver/blob/9cdbef2b369fb4fb0f1b4e534da8703daf92abc9/target/postfix/master.cf#L65
+
+!!! note "Docker compose config for making docker-mailserver use specific outbound IP"
+```
+services:
+  mailserver:
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    container_name: mailserver
+    # Provide the FQDN of your mail server here (Your DNS MX record should point to this value)
+    hostname: REDACTED
+    env_file: mailserver.env
+    networks:
+      - mailnet
+...SNIP unrelated
+
+networks:
+  mailnet:
+    name: mailnet
+    driver: bridge
+    driver_opts:
+      com.docker.network.bridge.host_binding_ipv4: 203.RED.ACT.ED
+      com.docker.network.host_ipv4: 203.RED.ACT.ED
+```
+

--- a/docs/content/examples/use-cases/bind-smtp-network-interface.md
+++ b/docs/content/examples/use-cases/bind-smtp-network-interface.md
@@ -62,12 +62,6 @@ to the respective IP-address on the server you want to use.
         To force container to use specific IP address from host you can use following configuration in compose.yml
         
         ```title="compose.yml"
-        services:
-          mailserver:
-            ...
-            networks:
-              - mailnet
-            ...
         networks:
           default:
             driver_opts:

--- a/docs/content/examples/use-cases/bind-smtp-network-interface.md
+++ b/docs/content/examples/use-cases/bind-smtp-network-interface.md
@@ -55,6 +55,27 @@ to the respective IP-address on the server you want to use.
         ```
 
         If that avoids the concern with `smtp-amavis`, you may still need to additionally override for the [`relay` transport][gh-src::postfix-master-cf::relay-transport] as well if you have configured DMS to relay mail.
+        
+    === "Multiple IP hosts"
+    
+        Sometimes containers use the first IP address from Docker host for outgoing traffic and verifications of rDNS (PTR) can occur for that IP address. 
+        To force container to use specific IP address from host you can use following configuration in compose.yml
+        
+        ```title="compose.yml"
+        services:
+          mailserver:
+            ...
+            networks:
+              - mailnet
+            ...
+        networks:
+          mailnet:
+            name: mailnet
+            driver: bridge
+            driver_opts:
+              com.docker.network.bridge.host_binding_ipv4: 198.51.100.42
+              com.docker.network.host_ipv4: 198.51.100.42
+        ```
 
 !!! note "IP addresses for documentation"
 
@@ -67,25 +88,4 @@ to the respective IP-address on the server you want to use.
 [gh-pr::3465::alternative-solution]: https://github.com/docker-mailserver/docker-mailserver/pull/3465#issuecomment-1678107233
 [gh-src::postfix-master-cf::relay-transport]: https://github.com/docker-mailserver/docker-mailserver/blob/9cdbef2b369fb4fb0f1b4e534da8703daf92abc9/target/postfix/master.cf#L65
 
-!!! note "Docker compose config for making docker-mailserver use specific outbound IP"
-```
-services:
-  mailserver:
-    image: ghcr.io/docker-mailserver/docker-mailserver:latest
-    container_name: mailserver
-    # Provide the FQDN of your mail server here (Your DNS MX record should point to this value)
-    hostname: REDACTED
-    env_file: mailserver.env
-    networks:
-      - mailnet
-...SNIP unrelated
-
-networks:
-  mailnet:
-    name: mailnet
-    driver: bridge
-    driver_opts:
-      com.docker.network.bridge.host_binding_ipv4: 203.RED.ACT.ED
-      com.docker.network.host_ipv4: 203.RED.ACT.ED
-```
 

--- a/docs/content/examples/use-cases/bind-smtp-network-interface.md
+++ b/docs/content/examples/use-cases/bind-smtp-network-interface.md
@@ -21,10 +21,6 @@ This can be configured by [overriding the default Postfix configurations][docs::
 In `postfix-main.cf` you'll have to set the [`smtp_bind_address`][postfix-docs::smtp-bind-address-ipv4] and [`smtp_bind_address6`][postfix-docs::smtp-bind-address-ipv6]
 to the respective IP-address on the server you want to use.
 
-[docs::overrides-postfix]: ../../config/advanced/override-defaults/postfix.md
-[postfix-docs::smtp-bind-address-ipv4]: https://www.postfix.org/postconf.5.html#smtp_bind_address
-[postfix-docs::smtp-bind-address-ipv6]: https://www.postfix.org/postconf.5.html#smtp_bind_address6
-
 !!! example
 
     === "Contributed solution"
@@ -60,36 +56,41 @@ to the respective IP-address on the server you want to use.
     
         When your DMS container is using a bridge network, you'll instead need to restrict which IP address inbound and outbound traffic is routed through via the bridged interface.
         
-        For inbound traffic, you may configure this at whatever scope is most appropriate for you:
+        For **inbound** traffic, you may configure this at whatever scope is most appropriate for you:
+
         - **Daemon:** Change the default bind address configured in `/etc/docker/daemon.json` (default `0.0.0.0`)
-        - **Network:** Assign the [`host_binding_ipv4` bridge driver option](https://docs.docker.com/engine/network/drivers/bridge/#default-host-binding-address) as shown in the below `compose.yaml` snippet.
+        - **Network:** Assign the [`host_binding_ipv4` bridge driver option][inbound-ip::docker-docs] as shown in the below `compose.yaml` snippet.
         - **Container:** Provide an explicit IP address when publishing a port.
         
-        For outbound traffic, the bridge network will use the default route.
+        For **outbound** traffic, the bridge network will use the default route. You can change this by either:
 
-        - [Manually route](https://github.com/moby/moby/issues/30053#issuecomment-1077041045) (Agnostic)
-        - Docker networking supports a driver option `host_ipv4` to force the SNAT (source IP) that the container will route through.
-            - This must belong to a valid network interface to be routed through it.
-            - IPv6 support via `host_ipv6` [requires at least Docker v25](https://github.com/moby/moby/issues/46469).
-            
+        - [Manually routing networks][outbound-ip::route-manually] on the host.
+        - Use the [`host_ipv4` driver option][outbind-ip::host-ipv4] for Docker networks to force the SNAT (source IP) that the bridged network will route outbound traffic through.
+            - This IP address must belong to a network interface to be routed through it.
+            - IPv6 support via `host_ipv6` [requires at least Docker v25][outbind-ip::host-ipv6].
+
+        ---
+
         Here is a `compose.yaml` snippet that applies the inbound + outbound settings to the default bridge network Docker Compose creates (_if it already exists, you will need to ensure it's re-created to apply the updated settings_):
         
         ```yaml title="compose.yaml"
         networks:
           default:
             driver_opts:
-              # Set a specific IP to default bind container ports to instead of `0.0.0.0`:
-              # https://docs.docker.com/engine/network/drivers/bridge/#default-host-binding-address
+              # Inbound IP (sets the host IP that published ports receive traffic from):
               com.docker.network.bridge.host_binding_ipv4: 198.51.100.42
-              # Force a specific source IP (SNAT):
-              # https://github.com/moby/libnetwork/pull/2454
+              # Outbound IP (sets the host IP that external hosts will receive connections from):
               com.docker.network.host_ipv4: 198.51.100.42
         ```
 
 !!! note "IP addresses for documentation"
 
-    IP addresses shown in above examples are placeholders, they are IP addresses reserved for documentation by IANA (_[RFC-5737 (IPv4)][rfc-5737] and [RFC-3849 (IPv6)][rfc-3849]_). Replace them with the IP addresses you want DMS to send mail through.
-    
+    IP addresses shown in above examples (`198.51.100.42` + `2001:DB8::42`) are placeholders, they are IP addresses reserved for documentation by IANA (_[RFC-5737 (IPv4)][rfc-5737] and [RFC-3849 (IPv6)][rfc-3849]_). Replace them with the IP addresses you want DMS to send mail through.
+
+[docs::overrides-postfix]: ../../config/advanced/override-defaults/postfix.md
+[postfix-docs::smtp-bind-address-ipv4]: https://www.postfix.org/postconf.5.html#smtp_bind_address
+[postfix-docs::smtp-bind-address-ipv6]: https://www.postfix.org/postconf.5.html#smtp_bind_address6
+
 [rfc-5737]: https://datatracker.ietf.org/doc/html/rfc5737
 [rfc-3849]: https://datatracker.ietf.org/doc/html/rfc3849
 
@@ -97,3 +98,7 @@ to the respective IP-address on the server you want to use.
 [gh-pr::3465::alternative-solution]: https://github.com/docker-mailserver/docker-mailserver/pull/3465#issuecomment-1678107233
 [gh-src::postfix-master-cf::relay-transport]: https://github.com/docker-mailserver/docker-mailserver/blob/9cdbef2b369fb4fb0f1b4e534da8703daf92abc9/target/postfix/master.cf#L65
 
+[inbound-ip::docker-docs]: https://docs.docker.com/engine/network/drivers/bridge/#default-host-binding-address
+[outbound-ip::route-manually]: https://github.com/moby/moby/issues/30053#issuecomment-1077041045
+[outbind-ip::host-ipv4]: https://github.com/moby/libnetwork/pull/2454
+[outbind-ip::host-ipv6]: https://github.com/moby/moby/issues/46469

--- a/docs/content/examples/use-cases/bind-smtp-network-interface.md
+++ b/docs/content/examples/use-cases/bind-smtp-network-interface.md
@@ -58,9 +58,9 @@ to the respective IP-address on the server you want to use.
         
         For **inbound** traffic, you may configure this at whatever scope is most appropriate for you:
 
-        - **Daemon:** Change the default bind address configured in `/etc/docker/daemon.json` (default `0.0.0.0`)
-        - **Network:** Assign the [`host_binding_ipv4` bridge driver option][inbound-ip::docker-docs] as shown in the below `compose.yaml` snippet.
-        - **Container:** Provide an explicit IP address when publishing a port.
+        - **Daemon:** Change the [default bind address][inbound-ip::docker-docs::daemon] configured in `/etc/docker/daemon.json` (default `0.0.0.0`)
+        - **Network:** Assign the [`host_binding_ipv4` bridge driver option][inbound-ip::docker-docs::network] as shown in the below `compose.yaml` snippet.
+        - **Container:** Provide an explicit host IP address when [publishing a port][inbound-ip::docker-docs::container].
         
         For **outbound** traffic, the bridge network will use the default route. You can change this by either:
 
@@ -98,7 +98,9 @@ to the respective IP-address on the server you want to use.
 [gh-pr::3465::alternative-solution]: https://github.com/docker-mailserver/docker-mailserver/pull/3465#issuecomment-1678107233
 [gh-src::postfix-master-cf::relay-transport]: https://github.com/docker-mailserver/docker-mailserver/blob/9cdbef2b369fb4fb0f1b4e534da8703daf92abc9/target/postfix/master.cf#L65
 
-[inbound-ip::docker-docs]: https://docs.docker.com/engine/network/drivers/bridge/#default-host-binding-address
+[inbound-ip::docker-docs::daemon]: https://docs.docker.com/reference/cli/dockerd/#default-network-options
+[inbound-ip::docker-docs::network]: https://docs.docker.com/engine/network/drivers/bridge/#default-host-binding-address
+[inbound-ip::docker-docs::container]: https://docs.docker.com/reference/compose-file/services/#ports
 [outbound-ip::route-manually]: https://github.com/moby/moby/issues/30053#issuecomment-1077041045
 [outbind-ip::host-ipv4]: https://github.com/moby/libnetwork/pull/2454
 [outbind-ip::host-ipv6]: https://github.com/moby/moby/issues/46469

--- a/docs/content/examples/use-cases/bind-smtp-network-interface.md
+++ b/docs/content/examples/use-cases/bind-smtp-network-interface.md
@@ -59,7 +59,7 @@ to the respective IP-address on the server you want to use.
     === "Multiple IP hosts"
     
         Sometimes containers use the first IP address from Docker host for outgoing traffic and verifications of rDNS (PTR) can occur for that IP address. 
-        To force container to use specific IP address from host you can use following configuration in compose.yml
+        To force container to use specific IP address from host you can use following configuration in compose.yaml
         
         ```title="compose.yaml"
         networks:

--- a/docs/content/examples/use-cases/bind-smtp-network-interface.md
+++ b/docs/content/examples/use-cases/bind-smtp-network-interface.md
@@ -69,11 +69,14 @@ to the respective IP-address on the server you want to use.
               - mailnet
             ...
         networks:
-          mailnet:
-            name: mailnet
-            driver: bridge
+          default:
             driver_opts:
+              # Set a specific IP to default bind container ports to instead of `0.0.0.0`:
+              # https://docs.docker.com/engine/network/drivers/bridge/#default-host-binding-address
               com.docker.network.bridge.host_binding_ipv4: 198.51.100.42
+              # Force a specific source IP (SNAT):
+              # https://github.com/moby/libnetwork/pull/2454
+              # https://github.com/moby/moby/issues/30053#issuecomment-1077041045
               com.docker.network.host_ipv4: 198.51.100.42
         ```
 


### PR DESCRIPTION
# Description

Added info how to setup docker to use the same interface for outgoing traffic. Problem was that I was using single VPS for sites and mailserver. I got the additional IP address but all outgoing traffic from mailserver was going through the original IP. This network config makes the container use specified IP for outgoing traffic too. 

Problem manifested as the mail-tester.com saw the original VPS IP address and failed on rDNS checks even when setup with suggestions from this part of page.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Documentation update

## Checklist

- [] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
