### PR TITLE
chore: `demo-setups/relay-compose.yaml` should use network alias

### DIFF
--- a/demo-setups/relay-compose.yaml
+++ b/demo-setups/relay-compose.yaml
@@ -41,17 +41,13 @@ services:
     hostname: smtp.relay-service.test
     environment:
       # WORKAROUND: Bypass security checks from the mail-client (dms-sender container)
-      # (avoids needing valid DNS for this example)
+      # (avoids needing expected DNS records to run this example)
       - PERMIT_DOCKER=connected-networks
       # TLS is required when relaying to dms-relay via ports 587 / 465
       # (dms-relay will then relay the mail to dms-destination over port 25)
       - SSL_TYPE=manual
       - SSL_KEY_PATH=/tmp/tls/key.pem
       - SSL_CERT_PATH=/tmp/tls/cert.pem
-    # WORKAROUND: `links` is required due to lack of properly configured DNS.
-    # (resolves destination.test to the IP of the dms-destination container)
-    links:
-      - "dms-destination:destination.test"
     configs:
       - source: dms-accounts-relay
         target: /tmp/docker-mailserver/postfix-accounts.cf
@@ -64,8 +60,14 @@ services:
   dms-destination:
     image: mailserver/docker-mailserver:latest # :14.0
     hostname: mail.destination.test
-    # Same workaround for purposes of the example, with the target recipient provisioned to accept mail
+    # WORKAROUND: dms-relay must be able to resolve DNS for `@destination.test` to the IP of this container:
+    # Normally a MX record would direct mail to the MTA (eg: `mail.destination.test`)
+    networks:
+      default:
+        aliases:
+          - destination.test
     environment:
+      # WORKAROUND: Same workaround as needed for dms-relay
       - PERMIT_DOCKER=connected-networks
     configs:
       - source: dms-accounts-destination
@@ -75,6 +77,13 @@ services:
 # NOTE: This feature requires Docker Compose v2.23.1 (Nov 2023) or newer:
 # https://github.com/compose-spec/compose-spec/pull/446
 configs:
+  # `postfix-main.cf`, a single line change to make all outbound SMTP connections over implicit TLS instead of the default explicit TLS (StartTLS).
+  # NOTE: If you need to only selectively relay mail, you would need to instead adjust this on the relay service in `/etc/postfix/master.cf`,
+  # However DMS presently modifies this when using the DMS Relay Host feature support, which may override `postfix-master.cf` or `user-patches.sh` due to `check-for-changes.sh`.
+  dms-main:
+    content: |
+      smtp_tls_wrappermode=yes
+
   # DMS expects an account to be configured to run, this example provides accounts already created.
   # Login credentials:
   # user: "john.doe@example.test" password: "secret"
@@ -93,13 +102,6 @@ configs:
   dms-accounts-destination:
     content: |
       jane.doe@destination.test|{SHA512-CRYPT}$$6$$o65y1ZXC4ooOPLwZ$$7TF1nYowEtNJpH6BwJBgdj2pPAxaCvhIKQA6ww5zdHm/AA7aemY9eoHC91DOgYNaKj1HLxSeWNDdvrp6mbtUY.
-
-  # This is `postfix-main.cf`, single line change to make all outbound SMTP connections over port 465 instead of 25 (default)
-  # If you selectively relay mail, you would need to adjust this on the relay service in `/etc/postfix/master.cf`,
-  # However DMS presently modifies this when using the DMS Relay Host feature support, which may override `postfix-master.cf` or `user-patches.sh` due to `check-for-changes.sh`.
-  dms-main:
-    content: |
-      smtp_tls_wrappermode=yes
 
   # TLS files:
   # - Use an ECDSA cert that's been signed by a self-signed CA for TLS cert verification.


### PR DESCRIPTION
# Description

Prefer using a network alias on the desired container which all containers in the same network can route through vs `links` mapping which is less flexible (_two containers cannot have `links` that map between each other_).

Other changes are just shifting a config snippet above the account config snippets and minor revisions to commentary.
