### PR TITLE
chore: Migrate dovecot config from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,6 @@ RUN dpkg -i /dovecot-fts-xapian-*.deb && rm /dovecot-fts-xapian-*.deb
 COPY target/dovecot/*.inc target/dovecot/*.conf /etc/dovecot/conf.d/
 COPY target/dovecot/dovecot-purge.cron /etc/cron.d/dovecot-purge.disabled
 RUN chmod 0 /etc/cron.d/dovecot-purge.disabled
-WORKDIR /usr/share/dovecot
 
 # -----------------------------------------------
 # --- Rspamd ------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,15 +90,6 @@ COPY target/dovecot/dovecot-purge.cron /etc/cron.d/dovecot-purge.disabled
 RUN chmod 0 /etc/cron.d/dovecot-purge.disabled
 WORKDIR /usr/share/dovecot
 
-# hadolint ignore=SC2016,SC2086,SC2069
-RUN <<EOF
-  sedfile -i -e 's/include_try \/usr\/share\/dovecot\/protocols\.d/include_try \/etc\/dovecot\/protocols\.d/g' /etc/dovecot/dovecot.conf
-  sedfile -i -e 's/#mail_plugins = \$mail_plugins/mail_plugins = \$mail_plugins sieve/g' /etc/dovecot/conf.d/15-lda.conf
-  sedfile -i -e 's/^.*lda_mailbox_autocreate.*/lda_mailbox_autocreate = yes/g' /etc/dovecot/conf.d/15-lda.conf
-  sedfile -i -e 's/^.*lda_mailbox_autosubscribe.*/lda_mailbox_autosubscribe = yes/g' /etc/dovecot/conf.d/15-lda.conf
-  sedfile -i -e 's/^.*postmaster_address.*/postmaster_address = '${POSTMASTER_ADDRESS:="postmaster@domain.com"}'/g' /etc/dovecot/conf.d/15-lda.conf
-EOF
-
 # -----------------------------------------------
 # --- Rspamd ------------------------------------
 # -----------------------------------------------

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -89,7 +89,6 @@ function _register_functions() {
   _register_setup_function '_setup_ssl'
   _register_setup_function '_setup_docker_permit'
   _register_setup_function '_setup_mailname'
-  _register_setup_function '_setup_dovecot_hostname'
 
   _register_setup_function '_setup_postfix_early'
 

--- a/target/scripts/startup/setup.d/dovecot.sh
+++ b/target/scripts/startup/setup.d/dovecot.sh
@@ -49,7 +49,7 @@ function _setup_dovecot() {
     -e 's|^#?(lda_mailbox_autocreate =).*|\1 yes|' \
     -e 's|^#?(lda_mailbox_autosubscribe =).*|\1 yes|' \
     -e "s|^#?(postmaster_address =).*|\1 ${POSTMASTER_ADDRESS}|" \
-    -e "s|^#?(hostname =).*|\1 ${HOSTNAME}|"
+    -e "s|^#?(hostname =).*|\1 ${HOSTNAME}|" \
     /etc/dovecot/conf.d/15-lda.conf
 
   if ! grep -q -E '^stats_writer_socket_path=' /etc/dovecot/dovecot.conf; then


### PR DESCRIPTION
# Description

I noticed the `postmaster_address` line looked odd in the Dockerfile, and that we actually run it properly in our startup scripts (_it's been in scripts [for over 5 years](https://github.com/docker-mailserver/docker-mailserver/blame/189e5376cc91af4f8a6b1e0db7b8f20e53a932a1/target/scripts/start-mailserver.sh#L542)_). That motivated this PR.

The protocol line was likewise migrated to be grouped with the related script lines with some minor revision.

The other 3 lines from the Dockerfile were all LDA specific which we haven't used since prior to DMS v2 (2016?), actually no I think we switched from Courier to Dovecot for v2, and then there was a switch from LDA to LMTP when around when LDAP support was contributed (_2016H2 or 2017 IIRC, **EDIT:** [LDA to LMTP in Oct 2016](https://github.com/docker-mailserver/docker-mailserver/pull/360)_). Anyway LDA is still technically relevant for supporting Getmail at least I think, and anything else that might call `/usr/lib/dovecot/deliver` to give mail to Dovecot directly.

I've included some extensive commentary inline since these settings at least for `hostname` and `postmaster_address` don't seem to be specific to LDA, that's just where they were placed in the Dovecot example configs we've copied. Dovecot 2.4 has removed those, so this will at least keep awareness of the original source until a maintainer/contributor addresses the TODO and we've migrated to 2.4 in a future base image update.

No changelog entry as this did not seem like a change that is user facing, it's effectively just shifting some commands around. I have altered the sed expressions into what should be easier to grok, along with only doing a single write/update to the file. I've manually tested the sed command to ensure it still works as intended :+1:
