### PR TITLE
feat: Enable reading env vars from files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 
+- **Environment Variables:**
+  - [ENV can be declared with a `__FILE` suffix](https://docker-mailserver.github.io/docker-mailserver/v15.1/config/environment/) to read a value from a file during initial DMS setup scripts ([#4359](https://github.com/docker-mailserver/docker-mailserver/pull/4359))
 - **Internal:**
   - [`DMS_CONFIG_POLL`](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/environment/#dms_config_poll) supports adjusting the polling rate (seconds) for the change detection service `check-for-changes.sh` ([#4450](https://github.com/docker-mailserver/docker-mailserver/pull/4450))
 
@@ -66,7 +68,6 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 
-- **environment variables** ending in `__FILE` will cause the content of the file addressed by their value to be written in the corresponding variable without the `__FILE` suffix
 - **Internal:**
   - Add password confirmation to several `setup` CLI subcommands ([#4072](https://github.com/docker-mailserver/docker-mailserver/pull/4072))
   - Added a `debug getmail` subcommand to `setup` ([#4346](https://github.com/docker-mailserver/docker-mailserver/pull/4346))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Breaking
 
+- **environment variables** ending in `__FILE` will cause the content of the file addressed by their value to be written in the corresponding variable without the `__FILE` suffix
 - **saslauthd** mechanism support via ENV `SASLAUTHD_MECHANISMS` with `pam`, `shadow`, `mysql` values has been removed. Only `ldap` and `rimap` remain supported ([#4259](https://github.com/docker-mailserver/docker-mailserver/pull/4259))
 - **getmail6** has been refactored: ([#4156](https://github.com/docker-mailserver/docker-mailserver/pull/4156))
   - The [DMS config volume](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/advanced/optional-config/#volumes) now has support for `getmailrc_general.cf` for overriding [common default settings](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/advanced/mail-getmail/#common-options). If you previously mounted this config file directly to `/etc/getmailrc_general` you should switch to our config volume support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Breaking
 
-- **environment variables** ending in `__FILE` will cause the content of the file addressed by their value to be written in the corresponding variable without the `__FILE` suffix
 - **saslauthd** mechanism support via ENV `SASLAUTHD_MECHANISMS` with `pam`, `shadow`, `mysql` values has been removed. Only `ldap` and `rimap` remain supported ([#4259](https://github.com/docker-mailserver/docker-mailserver/pull/4259))
 - **getmail6** has been refactored: ([#4156](https://github.com/docker-mailserver/docker-mailserver/pull/4156))
   - The [DMS config volume](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/advanced/optional-config/#volumes) now has support for `getmailrc_general.cf` for overriding [common default settings](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/advanced/mail-getmail/#common-options). If you previously mounted this config file directly to `/etc/getmailrc_general` you should switch to our config volume support.
@@ -20,6 +19,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 
+- **environment variables** ending in `__FILE` will cause the content of the file addressed by their value to be written in the corresponding variable without the `__FILE` suffix
 - **Internal:**
   - Add password confirmation to several `setup` CLI subcommands ([#4072](https://github.com/docker-mailserver/docker-mailserver/pull/4072))
   - Added a `debug getmail` subcommand to `setup` ([#4346](https://github.com/docker-mailserver/docker-mailserver/pull/4346))

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -8,7 +8,7 @@ title: Environment Variables
 
 !!! tip
 
-    If an environment variable `<VAR>__FILE` is set and points to a valid file, the content of that file will be loaded into `<VAR>`.
+    If an environment variable `<VAR>__FILE` is set with a valid file path as the value, the content of that file will become the value for `<VAR>` (_provided `<VAR>` has not already been set_).
 
 #### General
 

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -6,6 +6,10 @@ title: Environment Variables
 
     Values in **bold** are the default values. If an option doesn't work as documented here, check if you are running the latest image. The current `master` branch corresponds to the image `ghcr.io/docker-mailserver/docker-mailserver:edge`.
 
+!!! tip
+
+    If an environment variable `<VAR>__FILE` is set and points to a valid file, the content of that file will be loaded into `<VAR>`.
+
 #### General
 
 ##### OVERRIDE_HOSTNAME

--- a/target/scripts/startup/variables-stack.sh
+++ b/target/scripts/startup/variables-stack.sh
@@ -261,7 +261,7 @@ function __environment_variables_from_files() {
 
     # Skip if the target ENV is already set:
     if [[ -v TARGET_ENV ]]; then
-      _log 'warn' "Ignoring '${TARGET_ENV_NAME}' since '${ENV_WITH_FILE_REF}' is also set"
+      _log 'warn' "ENV value will not be sourced from '${ENV_WITH_FILE_REF}' since '${TARGET_ENV_NAME}' is already set"
       continue
     fi
 

--- a/target/scripts/startup/variables-stack.sh
+++ b/target/scripts/startup/variables-stack.sh
@@ -249,24 +249,27 @@ function __environment_variables_export() {
 # This function sets any environment variable with a value from a referenced file
 # when an equivalent ENV with a `__FILE` suffix exists with a valid file path as the value.
 function __environment_variables_from_files() {
-  for ENV_WITH_FILE_REF in $(env | grep -Po '^.+?__FILE'); do
+  while read -r ENV_WITH_FILE_REF; do
     # Store the ENV name without the `__FILE` suffix:
-    local TARGET_ENV="${ENV_WITH_FILE_REF/__FILE/}"
+    local TARGET_ENV_NAME="${ENV_WITH_FILE_REF/__FILE/}"
+    local -n TARGET_ENV="${ENV_WITH_FILE_REF/__FILE/}"
     # Store the value of the `__FILE` ENV:
     local FILE_PATH="${!ENV_WITH_FILE_REF}"
 
-    # Skip sourcing form `__FILE` if ENV is already set:
-    if [[ -n "${!TARGET_ENV}" ]]; then
-      _log 'warn' "ENV value will not be sourced from '${ENV_WITH_FILE_REF}' since '${TARGET_ENV}' is already set"
+    # Skip sourcing from `__FILE` if ENV is already set:
+    if [[ -v TARGET_ENV ]]; then
+      _log 'warn' "Ignoring '${TARGET_ENV_NAME}' since '${ENV_WITH_FILE_REF}' is also set"
       continue
     fi
 
-    # Otherwise retrieve the value from file and set the ENV or fail if invalid reference:
-    if [[ -f "${FILE_PATH}" ]]; then
-      _log 'info' "Getting secret ${TARGET_ENV} from ${FILE_PATH}"
-      printf -v "${TARGET_ENV}" '%s' "$(< "${FILE_PATH}")"
-    else
-      _log 'error' "File ${FILE_PATH} does not exist, defined in ${ENV_WITH_FILE_REF}"
+    # Otherwise, retrieve the value from a file and set
+    # the ENV, or fail if the reference is invalid:
+    if [[ ! -f ${FILE_PATH} ]]; then
+      _log 'warn' "File defined for secret '${TARGET_ENV_NAME}' with path '${FILE_PATH}' does not exist"
+      continue
     fi
-  done
+
+    _log 'info' "Getting secret '${TARGET_ENV_NAME}' from '${FILE_PATH}'"
+    TARGET_ENV="$(< "${FILE_PATH}")"
+  done < <(env | grep -Po '^.+?__FILE')
 }

--- a/target/scripts/startup/variables-stack.sh
+++ b/target/scripts/startup/variables-stack.sh
@@ -260,7 +260,7 @@ function __environment_variables_from_files() {
 
     # Skip sourcing form `__FILE` if ENV is already set:
     if [[ -n "${!TARGET_ENV}" ]]; then
-      _log 'warn' "Ignoring ${TARGET_ENV} since ${ENV_WITH_FILE_REF} is also set"
+      _log 'warn' "ENV value will not be sourced from '${ENV_WITH_FILE_REF}' since '${TARGET_ENV}' is already set"
       continue
     fi
 

--- a/target/scripts/startup/variables-stack.sh
+++ b/target/scripts/startup/variables-stack.sh
@@ -258,7 +258,7 @@ function __environment_variables_from_files() {
 
     # Skip sourcing from `__FILE` if ENV is already set:
     if [[ -v TARGET_ENV ]]; then
-      _log 'warn' "Ignoring '${TARGET_ENV_NAME}' since '${ENV_WITH_FILE_REF}' is also set"
+      _log 'warn' "ENV value will not be sourced from '${ENV_WITH_FILE_REF}' since '${TARGET_ENV_NAME}' is already set"
       continue
     fi
 

--- a/target/scripts/startup/variables-stack.sh
+++ b/target/scripts/startup/variables-stack.sh
@@ -263,7 +263,7 @@ function __environment_variables_from_files() {
 
     if [[ -f "${file_path}" ]]; then
       _log 'info' "Getting secret ${env_var} from ${file_path}"
-      export "${env_var}"="$(< "${file_path}")"
+      printf -v "${env_var}" '%s' "$(< "${file_path}")"
     else
       _log 'error' "File ${file_path} does not exist, defined in ${file_env_var}"
     fi

--- a/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
+++ b/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
@@ -1,66 +1,79 @@
 load "${REPOSITORY_ROOT}/test/helper/setup"
 load "${REPOSITORY_ROOT}/test/helper/common"
 
-export CONTAINER1_NAME='dms-test_env-files_success'
-export CONTAINER2_NAME='dms-test_env-files_warning'
-export CONTAINER3_NAME='dms-test_env-files_error'
+# Feature (ENV value sourced from file):
+# - An ENV with a `__FILE` suffix will read a value from a referenced file path to set the actual ENV (assuming it is empty)
+# - Feature implemented at: `variables-stack.sh:__environment_variables_from_files()`
+# - Feature PR: https://github.com/docker-mailserver/docker-mailserver/pull/4359
 
-setup_file() {
+BATS_TEST_NAME_PREFIX='[Configuration] (ENV __FILE support) '
+CONTAINER1_NAME='dms-test_env-files_success'
+CONTAINER2_NAME='dms-test_env-files_warning'
+CONTAINER3_NAME='dms-test_env-files_error'
+
+function setup_file() {
   export CONTAINER_NAME
-  export TEST__FILE
-  export TEST__FILE_SUCCESS
-  export NON_EXISTENT__FILE
+  export FILEPATH_VALID='/tmp/file-with-value'
+  export FILEPATH_INVALID='/path/to/non-existent-file'
 
+  export FILE_WITH_VALUE="${TEST_TMP_CONFIG}/test_secret"
+  echo 1 > "${FILE_WITH_VALUE}"
+
+  # ENV is set via file content (valid file path):
   CONTAINER_NAME=${CONTAINER1_NAME}
   _init_with_defaults
-  TEST__FILE=${TEST_TMP_CONFIG}/test_secret
-  echo 1 > "${TEST__FILE}"
-  TEST__FILE_SUCCESS=${TEST__FILE}
   local CUSTOM_SETUP_ARGUMENTS=(
-    --env ENABLE_POP3__FILE="${TEST__FILE}"
-    -v "${TEST__FILE}:${TEST__FILE}"
+    --env ENABLE_POP3__FILE="${FILEPATH_VALID}"
+    -v "${FILE_WITH_VALUE}:${FILEPATH_VALID}"
   )
   _common_container_setup 'CUSTOM_SETUP_ARGUMENTS'
 
+  # ENV is already set explicitly, logs warning:
   CONTAINER_NAME=${CONTAINER2_NAME}
   _init_with_defaults
-  TEST__FILE=${TEST_TMP_CONFIG}/test_secret
   local CUSTOM_SETUP_ARGUMENTS=(
-    --env TEST="manual-secret"
-    --env TEST__FILE="${TEST__FILE}"
+    --env TEST_ENV="manual-secret"
+    --env TEST_ENV__FILE="${FILEPATH_VALID}"
   )
   _common_container_setup 'CUSTOM_SETUP_ARGUMENTS'
 
+  # ENV is not set by file content (invalid file path):
   CONTAINER_NAME=${CONTAINER3_NAME}
   _init_with_defaults
-  NON_EXISTENT__FILE="/tmp/non_existent_secret"
   local CUSTOM_SETUP_ARGUMENTS=(
-    --env TEST__FILE="${NON_EXISTENT__FILE}"
+    --env TEST__FILE="${FILEPATH_INVALID}"
   )
   _common_container_setup 'CUSTOM_SETUP_ARGUMENTS'
 }
 
-teardown_file() {
-  rm -f "${TEST__FILE_SUCCESS}" "${TEST__FILE_WARNING}"
+function teardown_file() {
+  rm -f "${FILE_WITH_VALUE}"
   docker rm -f "${CONTAINER1_NAME}" "${CONTAINER2_NAME}" "${CONTAINER3_NAME}"
 }
 
-@test "Environment variables are loaded from files" {
-  run docker logs "${CONTAINER1_NAME}"
+@test "ENV can be set from a file" {
+  export CONTAINER_NAME=${CONTAINER1_NAME}
+
+  run docker logs "${CONTAINER_NAME}"
   assert_success
-  assert_line --partial "Getting secret ENABLE_POP3 from ${TEST__FILE_SUCCESS}"
-  _exec_in_container_explicit "${CONTAINER1_NAME}" [ -f /etc/dovecot/protocols.d/pop3d.protocol ]
+  assert_line --partial "Getting secret ENABLE_POP3 from ${FILEPATH_VALID}"
+
+  _run_in_container [ -f /etc/dovecot/protocols.d/pop3d.protocol ]
   assert_success
 }
 
-@test "Existing environment variables take precedence over __FILE variants" {
-  run docker logs "${CONTAINER2_NAME}"
+@test "Non-empty ENV have precedence over their __FILE variant" {
+  export CONTAINER_NAME=${CONTAINER2_NAME}
+
+  run docker logs "${CONTAINER_NAME}"
   assert_success
-  assert_line --partial "Ignoring TEST since TEST__FILE is also set"
+  assert_line --partial "Ignoring TEST_ENV since TEST_ENV__FILE is also set"
 }
 
-@test "Non-existent file triggers an error" {
-  run docker logs "${CONTAINER3_NAME}"
+@test "Referencing a non-existent file logs an error" {
+  export CONTAINER_NAME=${CONTAINER3_NAME}
+
+  run docker logs "${CONTAINER_NAME}"
   assert_success
-  assert_line --partial "File ${NON_EXISTENT__FILE} does not exist"
+  assert_line --partial "File ${FILEPATH_INVALID} does not exist"
 }

--- a/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
+++ b/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
@@ -57,6 +57,7 @@ function teardown_file() {
   assert_success
   assert_line --partial "Getting secret ENABLE_POP3 from ${FILEPATH_VALID}"
 
+  # Verify ENABLE_POP3 was enabled (disabled by default), by checking this file path is valid:
   _run_in_container [ -f /etc/dovecot/protocols.d/pop3d.protocol ]
   assert_success
 }

--- a/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
+++ b/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
@@ -15,13 +15,13 @@ function setup_file() {
   export CONTAINER_NAME
   export FILEPATH_VALID='/tmp/file-with-value'
   export FILEPATH_INVALID='/path/to/non-existent-file'
-
-  export FILE_WITH_VALUE="${TEST_TMP_CONFIG}/test_secret"
-  echo 1 > "${FILE_WITH_VALUE}"
+  export FILE_WITH_VALUE
 
   # ENV is set via file content (valid file path):
   CONTAINER_NAME=${CONTAINER1_NAME}
   _init_with_defaults
+  FILE_WITH_VALUE=${TEST_TMP_CONFIG}/test_secret
+  echo 1 > "${FILE_WITH_VALUE}"
   local CUSTOM_SETUP_ARGUMENTS=(
     --env ENABLE_POP3__FILE="${FILEPATH_VALID}"
     -v "${FILE_WITH_VALUE}:${FILEPATH_VALID}"
@@ -31,6 +31,8 @@ function setup_file() {
   # ENV is already set explicitly, a warning should be logged:
   CONTAINER_NAME=${CONTAINER2_NAME}
   _init_with_defaults
+  FILE_WITH_VALUE=${TEST_TMP_CONFIG}/test_secret
+  echo 1 > "${FILE_WITH_VALUE}"
   local CUSTOM_SETUP_ARGUMENTS=(
     --env ENABLE_POP3="0"
     --env ENABLE_POP3__FILE="${FILEPATH_VALID}"

--- a/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
+++ b/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
@@ -28,12 +28,13 @@ function setup_file() {
   )
   _common_container_setup 'CUSTOM_SETUP_ARGUMENTS'
 
-  # ENV is already set explicitly, logs warning:
+  # ENV is already set explicitly, a warning should be logged:
   CONTAINER_NAME=${CONTAINER2_NAME}
   _init_with_defaults
   local CUSTOM_SETUP_ARGUMENTS=(
-    --env TEST_ENV="manual-secret"
-    --env TEST_ENV__FILE="${FILEPATH_VALID}"
+    --env ENABLE_POP3="0"
+    --env ENABLE_POP3__FILE="${FILEPATH_VALID}"
+    -v "${FILE_WITH_VALUE}:${FILEPATH_VALID}"
   )
   _common_container_setup 'CUSTOM_SETUP_ARGUMENTS'
 

--- a/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
+++ b/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
@@ -45,7 +45,7 @@ function setup_file() {
   CONTAINER_NAME=${CONTAINER3_NAME}
   _init_with_defaults
   local CUSTOM_SETUP_ARGUMENTS=(
-    --env TEST__FILE="${FILEPATH_INVALID}"
+    --env ENABLE_POP3__FILE="${FILEPATH_INVALID}"
   )
   _common_container_setup 'CUSTOM_SETUP_ARGUMENTS'
 }
@@ -85,5 +85,5 @@ function teardown_file() {
   # Relevant log content only available via docker logs:
   run docker logs "${CONTAINER_NAME}"
   assert_success
-  assert_line --partial "File defined for secret 'TEST' with path '${FILEPATH_INVALID}' does not exist"
+  assert_line --partial "File defined for secret 'ENABLE_POP3' with path '${FILEPATH_INVALID}' does not exist"
 }

--- a/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
+++ b/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
@@ -6,57 +6,61 @@ export CONTAINER2_NAME='dms-test_env-files_warning'
 export CONTAINER3_NAME='dms-test_env-files_error'
 
 setup_file() {
+  export CONTAINER_NAME
   export TEST__FILE
-  TEST__FILE=$(mktemp)
-  export NON_EXISTENT__FILE="/tmp/non_existent_secret"
+  export TEST__FILE_SUCCESS
+  export NON_EXISTENT__FILE
 
+  CONTAINER_NAME=${CONTAINER1_NAME}
+  _init_with_defaults
+  TEST__FILE=${TEST_TMP_CONFIG}/test_secret
   echo 1 > "${TEST__FILE}"
-}
-
-teardown_file() {
-  rm -f "${TEST__FILE}"
-  docker rm -f "${CONTAINER1_NAME}" "${CONTAINER2_NAME}" "${CONTAINER3_NAME}"
-}
-
-@test "Environment variables are loaded from files" {
-  export CONTAINER_NAME="${CONTAINER1_NAME}"
+  TEST__FILE_SUCCESS=${TEST__FILE}
   local CUSTOM_SETUP_ARGUMENTS=(
     --env ENABLE_POP3__FILE="${TEST__FILE}"
     -v "${TEST__FILE}:${TEST__FILE}"
   )
-  _init_with_defaults
   _common_container_setup 'CUSTOM_SETUP_ARGUMENTS'
-  run docker logs "${CONTAINER_NAME}"
 
-  assert_success
-  assert_line --partial "Getting secret ENABLE_POP3 from ${TEST__FILE}"
-  _exec_in_container [ -f /etc/dovecot/protocols.d/pop3d.protocol ]
-  assert_success
-}
-
-@test "Existing environment variables take precedence over __FILE variants" {
-  export CONTAINER_NAME="${CONTAINER2_NAME}"
+  CONTAINER_NAME=${CONTAINER2_NAME}
+  _init_with_defaults
+  TEST__FILE=${TEST_TMP_CONFIG}/test_secret
   local CUSTOM_SETUP_ARGUMENTS=(
     --env TEST="manual-secret"
     --env TEST__FILE="${TEST__FILE}"
   )
-  _init_with_defaults
   _common_container_setup 'CUSTOM_SETUP_ARGUMENTS'
-  run docker logs "${CONTAINER_NAME}"
 
+  CONTAINER_NAME=${CONTAINER3_NAME}
+  _init_with_defaults
+  NON_EXISTENT__FILE="/tmp/non_existent_secret"
+  local CUSTOM_SETUP_ARGUMENTS=(
+    --env TEST__FILE="${NON_EXISTENT__FILE}"
+  )
+  _common_container_setup 'CUSTOM_SETUP_ARGUMENTS'
+}
+
+teardown_file() {
+  rm -f "${TEST__FILE_SUCCESS}" "${TEST__FILE_WARNING}"
+  docker rm -f "${CONTAINER1_NAME}" "${CONTAINER2_NAME}" "${CONTAINER3_NAME}"
+}
+
+@test "Environment variables are loaded from files" {
+  run docker logs "${CONTAINER1_NAME}"
+  assert_success
+  assert_line --partial "Getting secret ENABLE_POP3 from ${TEST__FILE_SUCCESS}"
+  _exec_in_container_explicit "${CONTAINER1_NAME}" [ -f /etc/dovecot/protocols.d/pop3d.protocol ]
+  assert_success
+}
+
+@test "Existing environment variables take precedence over __FILE variants" {
+  run docker logs "${CONTAINER2_NAME}"
   assert_success
   assert_line --partial "Ignoring TEST since TEST__FILE is also set"
 }
 
 @test "Non-existent file triggers an error" {
-  export CONTAINER_NAME="${CONTAINER3_NAME}"
-  local CUSTOM_SETUP_ARGUMENTS=(
-    --env TEST__FILE="${NON_EXISTENT__FILE}"
-  )
-  _init_with_defaults
-  _common_container_setup 'CUSTOM_SETUP_ARGUMENTS'
-  run docker logs "${CONTAINER_NAME}"
-
+  run docker logs "${CONTAINER3_NAME}"
   assert_success
   assert_line --partial "File ${NON_EXISTENT__FILE} does not exist"
 }

--- a/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
+++ b/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
@@ -47,7 +47,6 @@ function setup_file() {
 }
 
 function teardown_file() {
-  rm -f "${FILE_WITH_VALUE}"
   docker rm -f "${CONTAINER1_NAME}" "${CONTAINER2_NAME}" "${CONTAINER3_NAME}"
 }
 

--- a/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
+++ b/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
@@ -61,7 +61,7 @@ function teardown_file() {
   # Relevant log content only available via docker logs:
   run docker logs "${CONTAINER_NAME}"
   assert_success
-  assert_line --partial "Getting secret ENABLE_POP3 from ${FILEPATH_VALID}"
+  assert_line --partial "Getting secret 'ENABLE_POP3' from '${FILEPATH_VALID}'"
 
   # Verify ENABLE_POP3 was enabled (disabled by default), by checking this file path is valid:
   _run_in_container [ -f /etc/dovecot/protocols.d/pop3d.protocol ]
@@ -85,5 +85,5 @@ function teardown_file() {
   # Relevant log content only available via docker logs:
   run docker logs "${CONTAINER_NAME}"
   assert_success
-  assert_line --partial "File ${FILEPATH_INVALID} does not exist"
+  assert_line --partial "File defined for secret 'TEST' with path '${FILEPATH_INVALID}' does not exist"
 }

--- a/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
+++ b/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
@@ -1,0 +1,62 @@
+load "${REPOSITORY_ROOT}/test/helper/setup"
+load "${REPOSITORY_ROOT}/test/helper/common"
+
+export CONTAINER1_NAME='dms-test_env-files_success'
+export CONTAINER2_NAME='dms-test_env-files_warning'
+export CONTAINER3_NAME='dms-test_env-files_error'
+
+setup_file() {
+  export TEST__FILE
+  TEST__FILE=$(mktemp)
+  export NON_EXISTENT__FILE="/tmp/non_existent_secret"
+
+  echo 1 > "${TEST__FILE}"
+}
+
+teardown_file() {
+  rm -f "${TEST__FILE}"
+  docker rm -f "${CONTAINER1_NAME}" "${CONTAINER2_NAME}" "${CONTAINER3_NAME}"
+}
+
+@test "Environment variables are loaded from files" {
+  export CONTAINER_NAME="${CONTAINER1_NAME}"
+  local CUSTOM_SETUP_ARGUMENTS=(
+    --env ENABLE_POP3__FILE="${TEST__FILE}"
+    -v "${TEST__FILE}:${TEST__FILE}"
+  )
+  _init_with_defaults
+  _common_container_setup 'CUSTOM_SETUP_ARGUMENTS'
+  run docker logs "${CONTAINER_NAME}"
+
+  assert_success
+  assert_line --partial "Getting secret ENABLE_POP3 from ${TEST__FILE}"
+  _exec_in_container [ -f /etc/dovecot/protocols.d/pop3d.protocol ]
+  assert_success
+}
+
+@test "Existing environment variables take precedence over __FILE variants" {
+  export CONTAINER_NAME="${CONTAINER2_NAME}"
+  local CUSTOM_SETUP_ARGUMENTS=(
+    --env TEST="manual-secret"
+    --env TEST__FILE="${TEST__FILE}"
+  )
+  _init_with_defaults
+  _common_container_setup 'CUSTOM_SETUP_ARGUMENTS'
+  run docker logs "${CONTAINER_NAME}"
+
+  assert_success
+  assert_line --partial "Ignoring TEST since TEST__FILE is also set"
+}
+
+@test "Non-existent file triggers an error" {
+  export CONTAINER_NAME="${CONTAINER3_NAME}"
+  local CUSTOM_SETUP_ARGUMENTS=(
+    --env TEST__FILE="${NON_EXISTENT__FILE}"
+  )
+  _init_with_defaults
+  _common_container_setup 'CUSTOM_SETUP_ARGUMENTS'
+  run docker logs "${CONTAINER_NAME}"
+
+  assert_success
+  assert_line --partial "File ${NON_EXISTENT__FILE} does not exist"
+}

--- a/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
+++ b/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
@@ -68,7 +68,7 @@ function teardown_file() {
 
   run docker logs "${CONTAINER_NAME}"
   assert_success
-  assert_line --partial "Ignoring TEST_ENV since TEST_ENV__FILE is also set"
+  assert_line --partial "ENV value will not be sourced from 'ENABLE_POP3__FILE' since 'ENABLE_POP3' is already set"
 }
 
 @test "Referencing a non-existent file logs an error" {

--- a/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
+++ b/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
@@ -56,6 +56,8 @@ function teardown_file() {
 @test "ENV can be set from a file" {
   export CONTAINER_NAME=${CONTAINER1_NAME}
 
+  # /var/log/mail/mail.log is not equivalent to stdout content,
+  # Relevant log content only available via docker logs:
   run docker logs "${CONTAINER_NAME}"
   assert_success
   assert_line --partial "Getting secret ENABLE_POP3 from ${FILEPATH_VALID}"
@@ -68,6 +70,8 @@ function teardown_file() {
 @test "Non-empty ENV have precedence over their __FILE variant" {
   export CONTAINER_NAME=${CONTAINER2_NAME}
 
+  # /var/log/mail/mail.log is not equivalent to stdout content,
+  # Relevant log content only available via docker logs:
   run docker logs "${CONTAINER_NAME}"
   assert_success
   assert_line --partial "ENV value will not be sourced from 'ENABLE_POP3__FILE' since 'ENABLE_POP3' is already set"
@@ -76,6 +80,8 @@ function teardown_file() {
 @test "Referencing a non-existent file logs an error" {
   export CONTAINER_NAME=${CONTAINER3_NAME}
 
+  # /var/log/mail/mail.log is not equivalent to stdout content,
+  # Relevant log content only available via docker logs:
   run docker logs "${CONTAINER_NAME}"
   assert_success
   assert_line --partial "File ${FILEPATH_INVALID} does not exist"

--- a/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
+++ b/test/tests/parallel/set3/container_configuration/env_vars_from_files.bats
@@ -15,7 +15,8 @@ function setup_file() {
   export CONTAINER_NAME
   export FILEPATH_VALID='/tmp/file-with-value'
   export FILEPATH_INVALID='/path/to/non-existent-file'
-  export FILE_WITH_VALUE
+  # Each `_init_with_defaults` call updates the `TEST_TMP_CONFIG` location to create a container specific file:
+  local FILE_WITH_VALUE
 
   # ENV is set via file content (valid file path):
   CONTAINER_NAME=${CONTAINER1_NAME}


### PR DESCRIPTION
# Description

Fixes #3457.

Allows setting any environment variable via the content of a file, this is especially useful to carry Docker secrets in. This fix takes inspiration from a few similar approaches, namely Bitnami container images (e.g., [OpenLDAP](https://github.com/bitnami/containers/blob/02bcf4b54c8af61c18d5cb557b21dba317e36b48/bitnami/openldap/2.6/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh#L99-L117)) and [Grafana](https://github.com/grafana/grafana/blob/be426858529d9742808cc8ad4ed226379fb770da/packaging/docker/run.sh#L49-L61).

I have marked this as a breaking change since it would change the behavior of setups providing `<VAR>__FILE` env vars where `<VAR>` is an existing configuration variable. However, you may consider that to be negligible.

I've noticed a few Fail2ban tests breaking, but I'm not sure if that's due to my local setup or what. I've ignored them as they seemed unrelated.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary, I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
