### PR TITLE
Make deletion of mailbox data opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. The format 
   - **DMS v14 mistakenly** relocated the _getmail state directory_ to the _DMS Config Volume_ as a `getmail/` subdirectory.
     - This has been corrected to `/var/lib/getmail` (_if you have mounted a DMS State Volume to `/var/mail-state`, `/var/lib/getmail` will be symlinked to `/var/mail-state/lib-getmail`_).
     - To preserve this state when upgrading to DMS v15, **you must manually migrate `getmail/` from the _DMS Config Volume_ to `lib-getmail/` in the _DMS State Volume_.**
+  - `setup email delete <EMAIL ADDRESS>` now requires explicit confirmation if the mailbox data should be deleted.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file. The format 
   - **DMS v14 mistakenly** relocated the _getmail state directory_ to the _DMS Config Volume_ as a `getmail/` subdirectory.
     - This has been corrected to `/var/lib/getmail` (_if you have mounted a DMS State Volume to `/var/mail-state`, `/var/lib/getmail` will be symlinked to `/var/mail-state/lib-getmail`_).
     - To preserve this state when upgrading to DMS v15, **you must manually migrate `getmail/` from the _DMS Config Volume_ to `lib-getmail/` in the _DMS State Volume_.**
-  - `setup email delete <EMAIL ADDRESS>` now requires explicit confirmation if the mailbox data should be deleted.
+  - `setup email delete <EMAIL ADDRESS>` now requires explicit confirmation if the mailbox data should be deleted ([#4365](https://github.com/docker-mailserver/docker-mailserver/pull/4365)).
 
 ### Added
 

--- a/target/bin/delmailuser
+++ b/target/bin/delmailuser
@@ -35,7 +35,7 @@ function _main() {
     _manage_accounts_delete "${MAIL_ACCOUNT}" \
       || _exit_with_error "'${MAIL_ACCOUNT}' could not be deleted"
 
-    _log 'info' "'${MAIL_ACCOUNT}' and associated data deleted"
+    _log 'info' "'${MAIL_ACCOUNT}' and associated data (aliases, quotas) deleted"
   done
 }
 
@@ -47,14 +47,14 @@ ${ORANGE}USAGE${RESET}
 
 ${ORANGE}OPTIONS${RESET}
     -y
-        Skip prompt by approving to ${LWHITE}delete all mail storage${RESET} for the account(s).
+        Skip prompt by approving to ${LWHITE}delete all mail data${RESET} for the account(s).
 
     ${BLUE}Generic Program Information${RESET}
         help       Print the usage information.
 
 ${ORANGE}DESCRIPTION${RESET}
     Delete a mail account, including associated data (aliases, quotas) and
-    optionally the mailbox storage for that account.
+    optionally the mailbox data for that account.
 
 ${ORANGE}EXAMPLES${RESET}
     ${LWHITE}./setup.sh email del user@example.com${RESET}
@@ -91,7 +91,7 @@ function _parse_options() {
 function _maildel_request_if_missing() {
   if [[ ${MAILDEL} -eq 0 ]]; then
     local MAILDEL_CHOSEN
-    read -r -p "Do you want to delete the mailbox as well (removing all mails)? [Y/n] " MAILDEL_CHOSEN
+    read -r -p "Do you want to delete the mailbox data as well (removing all mails)? [y/N] " MAILDEL_CHOSEN
 
     # Delete mailbox data only if the user provides explicit confirmation.
     [[ ${MAILDEL_CHOSEN,,} == "y" ]] && MAILDEL=1
@@ -105,10 +105,10 @@ function _remove_maildir() {
   local DOMAIN_PART="${MAIL_ACCOUNT#*@}"
   local MAIL_ACCOUNT_STORAGE_DIR="/var/mail/${DOMAIN_PART}/${LOCAL_PART}"
 
-  [[ ! -d ${MAIL_ACCOUNT_STORAGE_DIR} ]] && _exit_with_error "Mailbox directory '${MAIL_ACCOUNT_STORAGE_DIR}' does not exist"
+  [[ ! -d ${MAIL_ACCOUNT_STORAGE_DIR} ]] && _exit_with_error "Mailbox data directory '${MAIL_ACCOUNT_STORAGE_DIR}' does not exist"
 
-  _log 'info' "Deleting Mailbox: '${MAIL_ACCOUNT_STORAGE_DIR}'"
-  rm -R "${MAIL_ACCOUNT_STORAGE_DIR}" || _exit_with_error 'Mailbox could not be deleted'
+  _log 'info' "Deleting mailbox data: '${MAIL_ACCOUNT_STORAGE_DIR}'"
+  rm -R "${MAIL_ACCOUNT_STORAGE_DIR}" || _exit_with_error 'Mailbox data could not be deleted'
   # Remove parent directory too if it's empty:
   rmdir "/var/mail/${DOMAIN_PART}" &>/dev/null
 }

--- a/target/bin/delmailuser
+++ b/target/bin/delmailuser
@@ -19,7 +19,11 @@ function _main() {
   for MAIL_ACCOUNT in "${@}"; do
     _account_should_already_exist
 
-    [[ ${MAILDEL} -eq 1 ]] && _remove_maildir "${MAIL_ACCOUNT}"
+    if [[ ${MAILDEL} -eq 1 ]]; then
+      _remove_maildir "${MAIL_ACCOUNT}"
+    else
+      _log 'info' "The mailbox data will not be deleted."
+    fi
 
     _manage_virtual_aliases_delete '_' "${MAIL_ACCOUNT}" \
       || _exit_with_error "Aliases for '${MAIL_ACCOUNT}' could not be deleted"
@@ -89,10 +93,8 @@ function _maildel_request_if_missing() {
     local MAILDEL_CHOSEN
     read -r -p "Do you want to delete the mailbox as well (removing all mails)? [Y/n] " MAILDEL_CHOSEN
 
-    # TODO: Why would MAILDEL be set to true if MAILDEL_CHOSEN is empty?
-    if [[ ${MAILDEL_CHOSEN} =~ (y|Y|yes|Yes) ]] || [[ -z ${MAILDEL_CHOSEN} ]]; then
-      MAILDEL=1
-    fi
+    # Delete mailbox data only if the user provides explicit confirmation.
+    [[ ${MAILDEL_CHOSEN,,} == "y" ]] && MAILDEL=1
   fi
 }
 


### PR DESCRIPTION
# Description

- Delete the mailbox data only if the user provides explicit confirmation.
- Make it more clear to the user, when the mailbox data is deleted or not.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #4338

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
