### PR TITLE
docs: Fix broken ref links

### DIFF
--- a/docs/content/config/best-practices/dkim_dmarc_spf.md
+++ b/docs/content/config/best-practices/dkim_dmarc_spf.md
@@ -54,7 +54,7 @@ You'll need to repeat this process if you add any new domains.
 
 You should have:
 
-- At least one [email account setup][docs-accounts-add]
+- At least one [email account setup][docs-accounts]
 - Attached a [volume for config][docs-volumes-config] to persist the generated files to local storage
 
 !!! example "Creating DKIM Keys"

--- a/docs/content/config/debugging.md
+++ b/docs/content/config/debugging.md
@@ -111,7 +111,7 @@ This could be from outdated software, or running a system that isn't able to pro
 - **Container runtime:** Docker and Podman for example have subtle differences. DMS docs are primarily focused on Docker, but we try to document known issues where relevant.
 - **Rootless containers:** Introduces additional differences in behavior or requirements:
     - cgroup v2 is required for supporting rootless containers.
-    - Differences such as for container networking which may further affect support for IPv6 and preserving the client IP (Remote address). Example with Docker rootless are [binding a port to a specific interface][docker-rootless-interface] and the choice of [port forwarding driver][docs-rootless-portdriver].
+    - Differences such as for container networking which may further affect support for IPv6 and preserving the client IP (Remote address). Example with Docker rootless are [binding a port to a specific interface][docker-rootless-interface] and the choice of [port forwarding driver][docs::fail2ban::rootless-portdriver].
 
 [network::docker-userlandproxy]: https://github.com/moby/moby/issues/44721
 [network::docker-nftables]: https://github.com/moby/moby/issues/26824

--- a/docs/content/contributing/general.md
+++ b/docs/content/contributing/general.md
@@ -15,13 +15,20 @@ When refactoring, writing or altering scripts or other files, adhere to these ru
 
 Make sure to select `edge` in the dropdown menu at the top. Navigate to the page you would like to edit and click the edit button in the top right. This allows you to make changes and create a pull-request.
 
-Alternatively you can make the changes locally. For that you'll need to have Docker installed. Navigate into the `docs/` directory. Then run:
+Alternatively you can make the changes locally. For that you'll need to have Docker installed and run:
 
 ```sh
-docker run --rm -it -p 8000:8000 -v "${PWD}:/docs" squidfunk/mkdocs-material
+# From the root directory of the git clone:
+docker run --rm -it -p 8000:8000 -v "./docs:/docs" squidfunk/mkdocs-material
 ```
 
 This serves the documentation on your local machine on port `8000`. Each change will be hot-reloaded onto the page you view, just edit, save and look at the result.
 
+!!! note
+
+    The container logs will inform you of invalid links detected, but a [few are false-positives][gh-dms::mkdocs-link-error-false-positives] due to our usage of linking to specific [content tabs][mkdocs::content-tabs].
+
 [get-docker]: https://docs.docker.com/get-docker/
 [docs-bats-parallel]: https://bats-core.readthedocs.io/en/v1.8.2/usage.html#parallel-execution
+[gh-dms::mkdocs-link-error-false-positives]: https://github.com/docker-mailserver/docker-mailserver/pull/4366
+[mkdocs::content-tabs]: https://squidfunk.github.io/mkdocs-material/reference/content-tabs/#anchor-links


### PR DESCRIPTION
# Description

Spotted a bad ref link (_specifically the [MD052 rule](https://github.com/DavidAnson/markdownlint/blob/main/doc/md052.md), we use ["full" ref links](https://github.com/DavidAnson/markdownlint/issues/918)_), used a linter to search for any others and fixed those too.

```console
# For `jq` to correctly output to new lines from the container stdout, you need `-t` (without `-i`)
# Otherwise output is staggered/indented: https://github.com/jqlang/jq/issues/1414
$ docker run --rm -t -v ./docs:/docs:Z,ro ghcr.io/igorshubovych/markdownlint-cli:latest \
  --disable default --enable MD052 --json '/docs/**/*.md' \
  | jq -r '.[] | "\(.fileName):\(.lineNumber) => \(.errorContext)"'

content/config/best-practices/dkim_dmarc_spf.md:57 => [email account setup][docs-accounts-add]
content/config/debugging.md:114 => [port forwarding driver][docs-rootless-portdriver]
```

Using linters on markdown aren't entirely reliable for our docs due to non-standard mkdocs syntax, notably [admonitions not being recognized](https://github.com/DavidAnson/markdownlint-cli2/issues/243#issuecomment-1827308980) (_thus indented content is treated as code blocks which causes false-positives such as with [MD053](https://github.com/DavidAnson/markdownlint/blob/main/doc/md053.md) for detecting unused ref links_).

---

Additionally added a note about false-positives when we have anchor links directly referencing ~~admonitions~~ [content tabs](https://squidfunk.github.io/mkdocs-material/reference/content-tabs/#anchor-links):

```console
$ docker run --rm -it -v ./docs:/docs:Z -w /docs squidfunk/mkdocs-material

INFO    -  Doc file 'config/advanced/kubernetes.md' contains a link '#deployment', but there is no such anchor on this page.
INFO    -  Doc file 'examples/tutorials/mailserver-behind-proxy.md' contains a link '../../config/advanced/kubernetes.md#using-the-proxy-protocol', but the doc 'config/advanced/kubernetes.md' does not contain an anchor '#using-the-proxy-protocol'.
```

The non-standard syntax doesn't allow us to add anchors (_normally this can be done via mkdocs feature `{ #anchor-name }`_), and I think part of this false-positive is due to support implemented in mkdocs-material via an mkdocs extension.