### PR TITLE
ci: Upgrade `mkdocs-material` to 9.6

### DIFF
--- a/.github/workflows/scripts/docs/build-docs.sh
+++ b/.github/workflows/scripts/docs/build-docs.sh
@@ -11,7 +11,7 @@ docker run \
   --user "$(id -u):$(id -g)" \
   --volume "./:/docs" \
   --name "build-docs" \
-  squidfunk/mkdocs-material:9.5 build --strict
+  squidfunk/mkdocs-material:9.6 build --strict
 
 # Remove unnecessary build artifacts: https://github.com/squidfunk/mkdocs-material/issues/2519
 # site/ is the build output folder.


### PR DESCRIPTION
# Description

Upgrade our CI docs container to the recent [`9.6` series](https://github.com/squidfunk/mkdocs-material/releases/tag/9.6.0) which fixes a navigation link bug (_see linked release notes_).
