### PR TITLE
fix: revert `__declare_readonly` overcomplication

### DIFF
--- a/target/scripts/startup/setup.d/mail_state.sh
+++ b/target/scripts/startup/setup.d/mail_state.sh
@@ -5,7 +5,7 @@ DMS_STATE_DIR='/var/mail-state'
 # Consolidate all states into a single directory
 # (/var/mail-state) to allow persistence using docker volumes
 function _setup_save_states() {
-  if [[ ! -d ${DMS_STATE_DIR:?DMS_STATE_DIR is not set} ]]; then
+  if [[ ! -d ${DMS_STATE_DIR} ]]; then
     _log 'debug' "'${DMS_STATE_DIR}' is not present - not consolidating state"
     return 0
   fi
@@ -93,7 +93,7 @@ function _setup_save_states() {
 # These corrections are to fix changes to UID/GID values between upgrades,
 # or when ownership/permissions were altered externally on the host (eg: migration or system scripts)
 function _setup_adjust_state_permissions() {
-  [[ ! -d ${DMS_STATE_DIR:?DMS_STATE_DIR is not set} ]] && return 0
+  [[ ! -d ${DMS_STATE_DIR} ]] && return 0
 
   # This ensures the user and group of the files from the external mount have their
   # numeric ID values in sync. New releases where the installed packages order changes

--- a/target/scripts/startup/setup.d/mail_state.sh
+++ b/target/scripts/startup/setup.d/mail_state.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+DMS_STATE_DIR='/var/mail-state'
+
 # Consolidate all states into a single directory
 # (/var/mail-state) to allow persistence using docker volumes
 function _setup_save_states() {

--- a/target/scripts/startup/variables-stack.sh
+++ b/target/scripts/startup/variables-stack.sh
@@ -16,17 +16,6 @@ function _early_variables_setup() {
   __environment_variables_export
 }
 
-# Declare a variable as readonly if it is not already set.
-function __declare_readonly() {
-  local VARIABLE_NAME=${1:?Variable name required when declaring a variable as readonly}
-  local VARIABLE_VALUE=${2:?Variable value required when declaring a variable as readonly}
-
-  if [[ ! -v ${VARIABLE_NAME} ]]; then
-    readonly "${VARIABLE_NAME}=${VARIABLE_VALUE}"
-    VARS[${VARIABLE_NAME}]="${VARIABLE_VALUE}"
-  fi
-}
-
 # This function handles variables that are deprecated. This allows a
 # smooth transition period, without the need of removing a variable
 # completely with a single version.
@@ -72,10 +61,6 @@ function __environment_variables_general_setup() {
   VARS[REPORT_SENDER]="${REPORT_SENDER:=mailserver-report@${HOSTNAME}}"
   VARS[DMS_VMAIL_UID]="${DMS_VMAIL_UID:=5000}"
   VARS[DMS_VMAIL_GID]="${DMS_VMAIL_GID:=5000}"
-
-  # internal variables are next
-
-  __declare_readonly 'DMS_STATE_DIR' '/var/mail-state'
 
   # user-customizable are last
 


### PR DESCRIPTION
# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->
Removes `__declare_readonly` again which was introduced in #4323.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes https://github.com/docker-mailserver/docker-mailserver/pull/4323#issuecomment-2660618801

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
