### PR TITLE
fix: Ensure `/var/log/mail` permissions + ownership are correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ All notable changes to this project will be documented in this file. The format 
   - The main `mail.log` (_which is piped to stdout via `tail`_) now correctly begins from the first log line of the active container run. Previously some daemon logs and potential warnings/errors were omitted ([#4146](https://github.com/docker-mailserver/docker-mailserver/pull/4146))
   - `start-mailserver.sh` removed unused `shopt -s inherit_errexit` ([#4161](https://github.com/docker-mailserver/docker-mailserver/pull/4161))
   - Fixed a regression introduced in DMS v14 where `postfix-main.cf` appended `stderr` output into `/etc/postfix/main.cf`, causing Postfix startup to fail ([#4147](https://github.com/docker-mailserver/docker-mailserver/pull/4147))
-  - Fixed a regression introduced in DMS v14 to better support running `start-mailserver.sh` with container restarts, which now only skip calling `_setup()` ([#4323](https://github.com/docker-mailserver/docker-mailserver/pull/4323#issuecomment-2629559254))
+  - Fixed a regression introduced in DMS v14 to better support running `start-mailserver.sh` with container restarts, which now only skip calling `_setup()` ([#4323](https://github.com/docker-mailserver/docker-mailserver/pull/4323#issuecomment-2629559254), [#4374](https://github.com/docker-mailserver/docker-mailserver/pull/4374))
   - The command `swaks --help` is now functional ([#4282](https://github.com/docker-mailserver/docker-mailserver/pull/4282))
 - **Rspamd:**
   - DKIM private key path checking is now performed only on paths that do not contain `$` ([#4201](https://github.com/docker-mailserver/docker-mailserver/pull/4201))

--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -43,7 +43,6 @@ function _register_functions() {
   # ? >> Setup
 
   _register_setup_function '_setup_vmail_id'
-  _register_setup_function '_setup_logs_general'
   _register_setup_function '_setup_timezone'
 
   if [[ ${SMTP_ONLY} -ne 1 ]]; then

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -125,19 +125,22 @@ function __log_fixes() {
   # when file system folders are mounted into the container.
   # Set the expected values and create missing folders/files just in case.
   mkdir -p /var/log/{mail,supervisor}
-  
+
   # TODO: Remove these lines in a future release once concerns are resolved:
   # https://github.com/docker-mailserver/docker-mailserver/pull/4370#issuecomment-2661762043
   chown syslog:root /var/log/mail
-  # TODO: Consider assigning /var/log/mail a writable non-root group for other processes like ClamAV?
-  # - Check if ClamAV is capable of creating files itself when they're missing?
-  # - Alternatively a symlink to /var/log/mail from the original intended location would allow write access
-  #   as a user to the symlink location, while keeping ownership as root at /var/log/mail
-  # - `LogSyslog false` for clamd.conf + freshclam.conf could possibly be enabled instead of log files?
-  #   However without better filtering in place (once Vector is adopted), this should be avoided.
-  touch /var/log/mail/{clamav,freshclam}.log
-  chown clamav:adm /var/log/mail/{clamav,freshclam}.log
-  
+
+  if [[ ${ENABLE_CLAMAV} -eq 1 ]]; then
+    # TODO: Consider assigning /var/log/mail a writable non-root group for other processes like ClamAV?
+    # - Check if ClamAV is capable of creating files itself when they're missing?
+    # - Alternatively a symlink to /var/log/mail from the original intended location would allow write access
+    #   as a user to the symlink location, while keeping ownership as root at /var/log/mail
+    # - `LogSyslog false` for clamd.conf + freshclam.conf could possibly be enabled instead of log files?
+    #   However without better filtering in place (once Vector is adopted), this should be avoided.
+    touch /var/log/mail/{clamav,freshclam}.log
+    chown clamav:adm /var/log/mail/{clamav,freshclam}.log
+  fi
+
   # Volume permissions should be corrected:
   # https://github.com/docker-mailserver/docker-mailserver-helm/issues/137
   chmod 755 /var/log/mail/

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -82,6 +82,8 @@ function _setup_timezone() {
   fi
 }
 
+# Misc checks and fixes migrated here until next refactor:
+# NOTE: `start-mailserver.sh` runs this along with `mail-state.sh` during container restarts
 function _setup_directory_and_file_permissions() {
   _log 'trace' 'Removing leftover PID files from a stop/start'
   find /var/run/ -not -name 'supervisord.pid' -name '*.pid' -delete
@@ -101,6 +103,8 @@ function _setup_directory_and_file_permissions() {
     _log 'debug' "Ensuring '${RSPAMD_DMS_DKIM_D}' is owned by '_rspamd:_rspamd'"
     chown -R _rspamd:_rspamd "${RSPAMD_DMS_DKIM_D}"
   fi
+
+  __log_fixes
 }
 
 function _setup_run_user_patches() {
@@ -112,4 +116,30 @@ function _setup_run_user_patches() {
   else
     _log 'trace' "No optional '${USER_PATCHES}' provided"
   fi
+}
+
+function __log_fixes() {
+  _log 'debug' 'Ensuring /var/log/mail owneership + permissions are correct'
+
+  # File/folder permissions are fine when using docker volumes, but may be wrong
+  # when file system folders are mounted into the container.
+  # Set the expected values and create missing folders/files just in case.
+  mkdir -p /var/log/{mail,supervisor}
+  
+  # TODO: Remove these lines in a future release once concerns are resolved:
+  # https://github.com/docker-mailserver/docker-mailserver/pull/4370#issuecomment-2661762043
+  chown syslog:root /var/log/mail
+  # TODO: Consider assigning /var/log/mail a writable non-root group for other processes like ClamAV?
+  # - Check if ClamAV is capable of creating files itself when they're missing?
+  # - Alternatively a symlink to /var/log/mail from the original intended location would allow write access
+  #   as a user to the symlink location, while keeping ownership as root at /var/log/mail
+  # - `LogSyslog false` for clamd.conf + freshclam.conf could possibly be enabled instead of log files?
+  #   However without better filtering in place (once Vector is adopted), this should be avoided.
+  touch /var/log/mail/{clamav,freshclam}.log
+  chown clamav:adm /var/log/mail/{clamav,freshclam}.log
+  
+  # Volume permissions should be corrected:
+  # https://github.com/docker-mailserver/docker-mailserver-helm/issues/137
+  chmod 755 /var/log/mail/
+  chmod 640 /var/log/mail/*
 }

--- a/target/scripts/startup/setup.d/log.sh
+++ b/target/scripts/startup/setup.d/log.sh
@@ -1,15 +1,5 @@
 #!/bin/bash
 
-function _setup_logs_general() {
-  _log 'debug' 'Setting up general log files'
-
-  # File/folder permissions are fine when using docker volumes, but may be wrong
-  # when file system folders are mounted into the container.
-  # Set the expected values and create missing folders/files just in case.
-  mkdir -p /var/log/{mail,supervisor}
-  chown syslog:root /var/log/mail
-}
-
 function _setup_logrotate() {
   _log 'debug' 'Setting up logrotate'
 

--- a/target/scripts/startup/setup.d/security/misc.sh
+++ b/target/scripts/startup/setup.d/security/misc.sh
@@ -155,13 +155,6 @@ function __setup__security__clamav() {
   if [[ ${ENABLE_CLAMAV} -eq 1 ]]; then
     _log 'debug' 'Enabling and configuring ClamAV'
 
-    local FILE
-    for FILE in /var/log/mail/{clamav,freshclam}.log; do
-      touch "${FILE}"
-      chown clamav:adm "${FILE}"
-      chmod 640 "${FILE}"
-    done
-
     if [[ ${CLAMAV_MESSAGE_SIZE_LIMIT} != '25M' ]]; then
       _log 'trace' "Setting ClamAV message scan size limit to '${CLAMAV_MESSAGE_SIZE_LIMIT}'"
 


### PR DESCRIPTION
# Description

This is an [interim fix](https://github.com/docker-mailserver/docker-mailserver/pull/4370#issuecomment-2661678014) for DMS v15 until a [proper fix](https://github.com/docker-mailserver/docker-mailserver/pull/4370#issuecomment-2661762043) can more confidently be implemented.

Changes:
- Migrates what was [originally contributed in Oct 2019](https://github.com/docker-mailserver/docker-mailserver/commit/37e0082cd7998924564c542cc24e5ac72c7ef6c2) to `setup-stack.sh` for container restart support.
- Ensures permissions of `/var/log/mail/` and it's contents are corrected if a volume mount differs.

History for these changes is messy (_as documented in the "proper fix" link_), but looks like it shouldn't really be necessary going forward (_new permissions fix may be relevant to avoid the `logrotate` failure scenario_).

### Workaround for volume mounts that are too relaxed

In the kubernetes helm project, a [user reports their `/var/log/mail` mount with `777` permissions](https://github.com/docker-mailserver/docker-mailserver-helm/issues/137) which appears to impact `logrotate` service as a result:

> ```
> /etc/cron.daily/logrotate:
> error: skipping "/var/log/mail/mail.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
> error: skipping "/var/log/mail/rspamd.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
> run-parts: /etc/cron.daily/logrotate exited with return code 1
> ```

According to that linked discussion, correcting that mount permissions for a specific mount in the Helm chart is problematic? 🤷‍♂️ 

---

### Chance of regression low

In addition these are runtime corrections intended for volume mounts, thus is intended as part of the [DMS v15 improved restart support](https://github.com/docker-mailserver/docker-mailserver/pull/4323).

Prior to this PR these changes would have occurred much earlier during startup:

https://github.com/docker-mailserver/docker-mailserver/blob/02942947559d3c0048bb3ebe62ccd1ec2272758a/target/scripts/start-mailserver.sh#L46

There is a slight chance that shifting the changes to apply at the end of `_setup()` introduces a regression, but it should be unlikely:

https://github.com/docker-mailserver/docker-mailserver/blob/02942947559d3c0048bb3ebe62ccd1ec2272758a/target/scripts/start-mailserver.sh#L122-L124

Restart support calls same two methods + (_rsyslog daemon starts with `/var/log/mail/mail.log`_):

https://github.com/docker-mailserver/docker-mailserver/blob/02942947559d3c0048bb3ebe62ccd1ec2272758a/target/scripts/start-mailserver.sh#L167-L196

DMS v15 is to release with the two separate call sites shown above as no maintainer presently has the time to investigate [test failures](https://github.com/docker-mailserver/docker-mailserver/pull/4323#discussion_r1925969281) introduced when moving methods those into a unified location.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [?] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
