### PR TITLE
chore: Revise utility install scripts + add Smallstep `step` CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,22 @@ All notable changes to this project will be documented in this file. The format 
 
 > **Note**: Changes and additions listed here are contained in the `:edge` image tag. These changes may not be as stable as released changes.
 
+### Added
+
+- **Internal:**
+  - Added the Smallstep `step` CLI command for future internal usage ([#4376](https://github.com/docker-mailserver/docker-mailserver/pull/4376))
+
 ### Fixes
 
 - **Postfix:**
   - `setup email restrict` generated configs now only prepend to `dms_smtpd_sender_restrictions` ([#4379](https://github.com/docker-mailserver/docker-mailserver/pull/4379))
 - **Internal:**
   - A permissions fix for `/var/log/mail` that was [added in DMS v15]((https://github.com/docker-mailserver/docker-mailserver/pull/4374)) no longer encounters an error when no log files are present during a container restart, such as with a `tmpfs` volume mount ([#4391](https://github.com/docker-mailserver/docker-mailserver/pull/4391))
+
+### Updates
+
+- **Internal:**
+  - Minor improvements to `_install_utils()` in `packages.sh` ([#4376](https://github.com/docker-mailserver/docker-mailserver/pull/4376))
 
 ## [v15.0.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v15.0.0)
 
@@ -33,7 +43,6 @@ All notable changes to this project will be documented in this file. The format 
 - **Internal:**
   - Add password confirmation to several `setup` CLI subcommands ([#4072](https://github.com/docker-mailserver/docker-mailserver/pull/4072))
   - Added a `debug getmail` subcommand to `setup` ([#4346](https://github.com/docker-mailserver/docker-mailserver/pull/4346))
-  - Added Smallstep `step` CLI command ([#4376](https://github.com/docker-mailserver/docker-mailserver/pull/4376))
 
 ### Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file. The format 
 - **Internal:**
   - Add password confirmation to several `setup` CLI subcommands ([#4072](https://github.com/docker-mailserver/docker-mailserver/pull/4072))
   - Added a `debug getmail` subcommand to `setup` ([#4346](https://github.com/docker-mailserver/docker-mailserver/pull/4346))
+  - Added Smallstep `step` CLI command ([#4376](https://github.com/docker-mailserver/docker-mailserver/pull/4376))
 
 ### Updates
 

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -38,13 +38,18 @@ function _pre_installation_steps() {
 
 # Install third-party commands to /usr/local/bin
 function _install_utils() {
-  local ARCH_A=$(uname -m)
+  local ARCH_A
+  ARCH_A=$(uname --machine)
   # Alternate naming convention support: x86_64 (amd64) / aarch64 (arm64)
   # https://en.wikipedia.org/wiki/X86-64#Industry_naming_conventions
   local ARCH_B
   case "${ARCH_A}" in
-    ( 'x86_64' )  ARCH_B='amd64' ;;
+    ( 'x86_64'  ) ARCH_B='amd64' ;;
     ( 'aarch64' ) ARCH_B='arm64' ;;
+    ( * )
+      _log 'error' "Unsupported arch: '${ARCH_A}'"
+      return 1
+      ;;
   esac
 
   # TIP: `*.tar.gz` releases tend to forget to reset UID/GID ownership when archiving.

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -40,16 +40,16 @@ function _install_utils() {
   _log 'debug' 'Installing utils sourced from Github'
   _log 'trace' 'Installing jaq'
   local JAQ_TAG='v2.1.0'
-  curl -sSfL "https://github.com/01mf02/jaq/releases/download/${JAQ_TAG}/jaq-$(uname -m)-unknown-linux-gnu" -o /usr/bin/jaq
-  chmod +x /usr/bin/jaq
+  curl -sSfL "https://github.com/01mf02/jaq/releases/download/${JAQ_TAG}/jaq-$(uname -m)-unknown-linux-gnu" -o /usr/local/bin/jaq
+  chmod +x /usr/local/bin/jaq
 
   _log 'trace' 'Installing swaks'
+  # `perl-doc` is required for `swaks --help` to work:
   apt-get "${QUIET}" install --no-install-recommends perl-doc
   local SWAKS_VERSION='20240103.0'
   local SWAKS_RELEASE="swaks-${SWAKS_VERSION}"
-  curl -sSfL "https://github.com/jetmore/swaks/releases/download/v${SWAKS_VERSION}/${SWAKS_RELEASE}.tar.gz" | tar -xz
-  mv "${SWAKS_RELEASE}/swaks" /usr/local/bin
-  rm -r "${SWAKS_RELEASE}"
+  curl -sSfL "https://github.com/jetmore/swaks/releases/download/v${SWAKS_VERSION}/${SWAKS_RELEASE}.tar.gz" \
+    | tar -xz --directory /usr/local/bin --no-same-owner --strip-components=1 "${SWAKS_RELEASE}/swaks"
 }
 
 function _install_postfix() {

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -37,7 +37,13 @@ function _pre_installation_steps() {
 }
 
 function _install_utils() {
+  # TIP: `*.tar.gz` releases tend to forget to reset UID/GID ownership when archiving.
+  # When extracting with `tar` as `root` the archived UID/GID is kept, unless using `--no-same-owner`.
+  # Likewise when the binary is in a nested location the full archived path
+  # must be provided + `--strip-components` to extract the file to the target directory.
+  # Doing this avoids the need for (`mv` + `rm`) or (`--to-stdout` + `chmod +x`)
   _log 'debug' 'Installing utils sourced from Github'
+
   _log 'trace' 'Installing jaq'
   local JAQ_TAG='v2.1.0'
   curl -sSfL "https://github.com/01mf02/jaq/releases/download/${JAQ_TAG}/jaq-$(uname -m)-unknown-linux-gnu" -o /usr/local/bin/jaq

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -36,7 +36,17 @@ function _pre_installation_steps() {
   apt-get "${QUIET}" install --no-install-recommends "${EARLY_PACKAGES[@]}" 2>/dev/null
 }
 
+# Install third-party commands to /usr/local/bin
 function _install_utils() {
+  local ARCH_A=$(uname -m)
+  # Alternate naming convention support: x86_64 (amd64) / aarch64 (arm64)
+  # https://en.wikipedia.org/wiki/X86-64#Industry_naming_conventions
+  local ARCH_B
+  case "${ARCH_A}" in
+    ( 'x86_64' )  ARCH_B='amd64' ;;
+    ( 'aarch64' ) ARCH_B='arm64' ;;
+  esac
+
   # TIP: `*.tar.gz` releases tend to forget to reset UID/GID ownership when archiving.
   # When extracting with `tar` as `root` the archived UID/GID is kept, unless using `--no-same-owner`.
   # Likewise when the binary is in a nested location the full archived path
@@ -48,6 +58,11 @@ function _install_utils() {
   local JAQ_TAG='v2.1.0'
   curl -sSfL "https://github.com/01mf02/jaq/releases/download/${JAQ_TAG}/jaq-$(uname -m)-unknown-linux-gnu" -o /usr/local/bin/jaq
   chmod +x /usr/local/bin/jaq
+
+  _log 'trace' 'Installing step'
+  local STEP_RELEASE='0.28.2'
+  curl -sSfL "https://github.com/smallstep/cli/releases/download/v${STEP_RELEASE}/step_linux_${STEP_RELEASE}_${ARCH_B}.tar.gz" \
+    | tar -xz --directory /usr/local/bin --no-same-owner --strip-components=2 "step_${STEP_RELEASE}/bin/step"
 
   _log 'trace' 'Installing swaks'
   # `perl-doc` is required for `swaks --help` to work:


### PR DESCRIPTION
# Description

`step` isn't used for anything yet, so no rush for this PR, but it won't introduce any breakage into DMS v15 😅 

---

Changes:
- `jaq` should probably live in `/usr/local/bin` with other third-party sourced binaries.
- `swaks` install properly with just `tar`, no `mv` + `rm` needed.
- Added Smallstep `step` CLI. This serves similar purpose to `openssl` commands, but is generally nicer for usage with generation and inspection of certs/keys. I've talked up using in DMS a few times in the past for our TLS helper and unifying DKIM support (_instead of separate OpenDKIM/Rspamd generators_).
- Including `step` for both AMD64 / ARM64 archs needs the alternate naming convention that it's published to GH releases with.
- Added commentary about the `tar` usage. The ownership is a common one, technically a non-issue when running as `root` 🤷‍♂️ Let me know if it's overkill and you prefer the `mv` + `rm` approach with a additional `chown`.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
