### PR TITLE
fix: `setup email restrict` configs should only prepend once

### DIFF
--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -68,9 +68,10 @@ smtpd_forbid_bare_newline = yes
 # smtpd_forbid_bare_newline_exclusions = $mynetworks
 
 # Custom defined parameters for DMS:
-# reject_unknown_sender_domain: https://github.com/docker-mailserver/docker-mailserver/issues/3716#issuecomment-1868033234
+# Custom sender restrictions overview: https://github.com/docker-mailserver/docker-mailserver/pull/4379#issuecomment-2670365917
+# `reject_unknown_sender_domain`: https://github.com/docker-mailserver/docker-mailserver/issues/3716#issuecomment-1868033234
 dms_smtpd_sender_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unknown_sender_domain
-# Submission ports 587 and 465 support for SPOOF_PROTECTION=1
+# `SPOOF_PROTECTION=1` support requires prepending `reject_authenticated_sender_login_mismatch`
 mua_sender_restrictions = reject_authenticated_sender_login_mismatch, $dms_smtpd_sender_restrictions
 
 # Postscreen settings to drop zombies/open relays/spam early

--- a/target/scripts/startup/setup.d/postfix.sh
+++ b/target/scripts/startup/setup.d/postfix.sh
@@ -93,13 +93,17 @@ EOF
 function _setup_postfix_late() {
   _log 'debug' 'Configuring Postfix (late setup)'
 
+  # These two config files are `access` database tables managed via `setup email restrict`:
+  # NOTE: Prepends to existing restrictions, thus has priority over other permit/reject policies that follow.
+  # https://www.postfix.org/postconf.5.html#smtpd_sender_restrictions
+  # https://www.postfix.org/access.5.html
   __postfix__log 'trace' 'Configuring user access'
   if [[ -f /tmp/docker-mailserver/postfix-send-access.cf ]]; then
-    sed -i -E 's|(smtpd_sender_restrictions =)|\1 check_sender_access texthash:/tmp/docker-mailserver/postfix-send-access.cf,|' /etc/postfix/main.cf
+    sed -i -E 's|^#?(smtpd_sender_restrictions =)|\1 check_sender_access texthash:/tmp/docker-mailserver/postfix-send-access.cf,|' /etc/postfix/main.cf
   fi
 
   if [[ -f /tmp/docker-mailserver/postfix-receive-access.cf ]]; then
-    sed -i -E 's|(smtpd_recipient_restrictions =)|\1 check_recipient_access texthash:/tmp/docker-mailserver/postfix-receive-access.cf,|' /etc/postfix/main.cf
+    sed -i -E 's|^#?(smtpd_recipient_restrictions =)|\1 check_recipient_access texthash:/tmp/docker-mailserver/postfix-receive-access.cf,|' /etc/postfix/main.cf
   fi
 
   __postfix__log 'trace' 'Configuring relay host'

--- a/target/scripts/startup/setup.d/postfix.sh
+++ b/target/scripts/startup/setup.d/postfix.sh
@@ -99,11 +99,11 @@ function _setup_postfix_late() {
   # https://www.postfix.org/access.5.html
   __postfix__log 'trace' 'Configuring user access'
   if [[ -f /tmp/docker-mailserver/postfix-send-access.cf ]]; then
-    sed -i -E 's|^#?(smtpd_sender_restrictions =)|\1 check_sender_access texthash:/tmp/docker-mailserver/postfix-send-access.cf,|' /etc/postfix/main.cf
+    sed -i -E 's|^(dms_smtpd_sender_restrictions =)|\1 check_sender_access texthash:/tmp/docker-mailserver/postfix-send-access.cf,|' /etc/postfix/main.cf
   fi
 
   if [[ -f /tmp/docker-mailserver/postfix-receive-access.cf ]]; then
-    sed -i -E 's|^#?(smtpd_recipient_restrictions =)|\1 check_recipient_access texthash:/tmp/docker-mailserver/postfix-receive-access.cf,|' /etc/postfix/main.cf
+    sed -i -E 's|^(dms_smtpd_recipient_restrictions =)|\1 check_recipient_access texthash:/tmp/docker-mailserver/postfix-receive-access.cf,|' /etc/postfix/main.cf
   fi
 
   __postfix__log 'trace' 'Configuring relay host'


### PR DESCRIPTION
# Description

I've noticed that `/etc/postfix/main.cf` has these checks prepended twice, as the Postfix parameter we update also has the `sed` call match our own `dms_` prefix variant (_introduced in_ https://github.com/docker-mailserver/docker-mailserver/pull/3127).

**No known bugs, nor should this fix change anything** other than removing the duplicates prepended to `smtpd_sender_restrictions`, only `dms_smtpd_sender_restrictions` will be configured with these restrictions.

---

## Quick reference for maintainers

To configure how the sender addresses of mail is restricted, DMS has a few similar settings due to:
- `smtpd_sender_restrictions = $dms_smtpd_sender_restrictions` (`main.cf`)
- `-o smtpd_sender_restrictions=$mua_sender_restrictions` (`master.cf`)

That translates to the following:
- `smtpd_sender_restrictions` is now only from port 25 (inbound)
- `$mua_sender_restrictions` is only for ports 587 + 465
- `$dms_smtpd_sender_restrictions` is used by all 3 `smtpd` ports (25, 587, 465).

To keep the same behaviour DMS already has for `setup email restrict` on all ports, we now only prepend to `dms_smtpd_sender_restrictions`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
