### PR TITLE
docs(rspamd): Fix Web UI link

### DIFF
--- a/docs/content/config/security/rspamd.md
+++ b/docs/content/config/security/rspamd.md
@@ -139,7 +139,7 @@ To use the web interface you will need to configure a password, [otherwise you w
 
     ---
 
-    **Related:** A minimal Rspamd `compose.yaml` [example with a reverse-proxy for web access][gh-dms:guide::rspamd-web].
+    **Related:** A minimal Rspamd `compose.yaml` [example with a reverse-proxy for web access][gh-dms::guide::rspamd-web].
 
 ### DNS
 


### PR DESCRIPTION
# Description

https://github.com/docker-mailserver/docker-mailserver/pull/4360 had a typo with the new ref link.