### PR TITLE
fix: Support `chmod` on `/var/log/mail/*` when dir is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file. The format 
 
 > **Note**: Changes and additions listed here are contained in the `:edge` image tag. These changes may not be as stable as released changes.
 
+### Updates
+
+**Internal:**
+  - Improved permission updating command to prevent errors when no logs are present ([#4391](https://github.com/docker-mailserver/docker-mailserver/pull/4391))
+
 ## [v15.0.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v15.0.0)
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ All notable changes to this project will be documented in this file. The format 
 
 > **Note**: Changes and additions listed here are contained in the `:edge` image tag. These changes may not be as stable as released changes.
 
-### Updates
+### Fixes
 
-**Internal:**
-  - Improved permission updating command to prevent errors when no logs are present ([#4391](https://github.com/docker-mailserver/docker-mailserver/pull/4391))
+- **Postfix:**
+  - `setup email restrict` generated configs now only prepend to `dms_smtpd_sender_restrictions` ([#4379](https://github.com/docker-mailserver/docker-mailserver/pull/4379))
+- **Internal:**
+  - A permissions fix for `/var/log/mail` that was [added in DMS v15]((https://github.com/docker-mailserver/docker-mailserver/pull/4374)) no longer encounters an error when no log files are present during a container restart, such as with a `tmpfs` volume mount ([#4391](https://github.com/docker-mailserver/docker-mailserver/pull/4391))
 
 ## [v15.0.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v15.0.0)
 

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -144,5 +144,5 @@ function __log_fixes() {
   # Volume permissions should be corrected:
   # https://github.com/docker-mailserver/docker-mailserver-helm/issues/137
   chmod 755 /var/log/mail/
-  chmod 640 /var/log/mail/*
+  find /var/log/mail/ -type f -exec chmod 640 {} +
 }


### PR DESCRIPTION
# Description

To prevent SSD wear from logs, I mount `/var/log/mail/` to tmpfs in my setup. I collect logs from standard output using Loki.

As a result, the `/var/log/mail` directory is empty whenever the container restarts. Attempting to change permissions on this directory using shell expansion leads to errors like:
```
chmod: missing operand after ‘640’
Try 'chmod --help' for more information.
```

Using `find` avoids running `chmod` if there is nothing to modify, preventing these errors. It's also more convenient than shell expansion, which can cause errors like "too many arguments".

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
