### PR TITLE
fix: `start-mailserver.sh` requires `mail_state.sh` to be sourced on restarts

### DIFF
--- a/target/scripts/start-mailserver.sh
+++ b/target/scripts/start-mailserver.sh
@@ -181,6 +181,9 @@ if [[ -f /CONTAINER_START ]]; then
   # We cannot skip all setup routines because some need to run _after_
   # the initial setup (and hence, they cannot be moved to the check stack).
   _setup_directory_and_file_permissions
+
+  # shellcheck source=./startup/setup.d/mail_state.sh
+  source /usr/local/bin/setup.d/mail_state.sh
   _setup_adjust_state_permissions
 else
   _setup


### PR DESCRIPTION
# Description

Spotted from logs of https://github.com/docker-mailserver/docker-mailserver/issues/4416#issuecomment-2727269499

- Our test suite doesn't have coverage for restart support, so this went unnoticed and wasn't caught in review (https://github.com/docker-mailserver/docker-mailserver/pull/4323#issuecomment-2629559254).
- While the other restart supported method we call is part of `setup-stack.sh`, the other call lives at `setup.d/mail_state.sh`, thus we need to source it to be able to call it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
