### PR TITLE
fix: DMS state volume must ensure `o+x` permission

### DIFF
--- a/target/scripts/startup/setup.d/mail_state.sh
+++ b/target/scripts/startup/setup.d/mail_state.sh
@@ -95,6 +95,11 @@ function _setup_save_states() {
 function _setup_adjust_state_permissions() {
   [[ ! -d ${DMS_STATE_DIR} ]] && return 0
 
+  # Parent directories must have executable bit set to descend the file tree for access,
+  # as each service running as a non-root user requires this to access their state directory,
+  # `/var/mail-state` must allow all users `+x`:
+  chmod o+x "${DMS_STATE_DIR}"
+
   # This ensures the user and group of the files from the external mount have their
   # numeric ID values in sync. New releases where the installed packages order changes
   # can change the values in the Docker image, causing an ownership mismatch.


### PR DESCRIPTION
# Description

While we expect the volume to have `755` as the default for `/var/mail-state`, some storage services will differ with their default permissions.

Service users that need to access their state directory cannot do so when a parent directory has `root` ownership only and lacks the executable bit for the `other` permission set. This is the source of numerous bug reports in the past that was non-obvious to me for how to resolve due to the errors logged 😓 (_big thanks to @rixwan-sharif for identifying the correct fix_)

More details: https://github.com/docker-mailserver/docker-mailserver/issues/4419#issuecomment-2731196821

Fixes #4419

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
