### PR TITLE
fix: ensure message content is not modified by header filter

### DIFF
--- a/target/postfix/sender_header_filter.pcre
+++ b/target/postfix/sender_header_filter.pcre
@@ -8,4 +8,5 @@
 /^\s*X-Mailer/                      IGNORE
 /^\s*X-Originating-IP/              IGNORE
 /^\s*Received: from.*127.0.0.1/     IGNORE
-/^Content-Type:/i                   PREPEND X-MS-Reactions: disallow
+/^X-MS-Reactions:/                  IGNORE
+/^Message-Id:/i                     PREPEND X-MS-Reactions: disallow


### PR DESCRIPTION
Due to an oversight, one of the header filters has potentially modified the message body, leading to broken cryptographic signatures.

Switch to the Message-Id instead of the Content-Type header, which is usually only present in the global header.


Reported-by: Cole Young <cole@young.sh>
Fixes: 009237cc ("chore: Prevent Microsoft MUAs from sending reactions (#4120)")