### PR TITLE
fix: ensure message content is not modified by header filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file. The format 
 
 > **Note**: Changes and additions listed here are contained in the `:edge` image tag. These changes may not be as stable as released changes.
 
+### Fixes
+
+- **Postfix**
+  - ensure message content is not modified by header filter ([#4426](https://github.com/docker-mailserver/docker-mailserver/pull/4426))
+
 ## [v15.0.1](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v15.0.1)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixes
 
 - **Postfix**
-  - ensure message content is not modified by header filter ([#4426](https://github.com/docker-mailserver/docker-mailserver/pull/4426))
+  - ensure message content is not modified by header filter ([#4427](https://github.com/docker-mailserver/docker-mailserver/pull/4427))
 
 ## [v15.0.1](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v15.0.1)
 

--- a/target/postfix/sender_header_filter.pcre
+++ b/target/postfix/sender_header_filter.pcre
@@ -1,5 +1,3 @@
-/^\s*Message-ID:/i                  PREPEND X-MS-Reactions: disallow
-/^\s*Mime-Version: 1.0.*/i          REPLACE MIME-Version: 1.0
 /^\s*Received: from.*127.0.0.1/     IGNORE
 /^\s*Received:.*amavisd-new/        IGNORE
 /^\s*Received:.*with ESMTPSA/       IGNORE
@@ -8,3 +6,6 @@
 /^\s*X-Mailer/                      IGNORE
 /^\s*X-MS-Reactions/                IGNORE
 /^\s*X-Originating-IP/              IGNORE
+
+/^\s*Message-ID:/i                  PREPEND X-MS-Reactions: disallow
+/^\s*Mime-Version: 1.0.*/i          REPLACE MIME-Version: 1.0

--- a/target/postfix/sender_header_filter.pcre
+++ b/target/postfix/sender_header_filter.pcre
@@ -1,11 +1,10 @@
-/^\s*Received:.*with ESMTPSA/       IGNORE
+/^\s*Message-ID:/i                  PREPEND X-MS-Reactions: disallow
+/^\s*Mime-Version: 1.0.*/i          REPLACE MIME-Version: 1.0
+/^\s*Received: from.*127.0.0.1/     IGNORE
 /^\s*Received:.*amavisd-new/        IGNORE
-/^\s*X-Originating-IP:/             IGNORE
-/^\s*X-Mailer:/                     IGNORE
-/^\s*Mime-Version: 1.0.*/           REPLACE MIME-Version: 1.0
+/^\s*Received:.*with ESMTPSA/       IGNORE
 /^\s*User-Agent/                    IGNORE
 /^\s*X-Enigmail/                    IGNORE
 /^\s*X-Mailer/                      IGNORE
+/^\s*X-MS-Reactions/                IGNORE
 /^\s*X-Originating-IP/              IGNORE
-/^\s*Received: from.*127.0.0.1/     IGNORE
-/^Content-Type:/i                   PREPEND X-MS-Reactions: disallow

--- a/test/tests/parallel/set3/container_configuration/hostname.bats
+++ b/test/tests/parallel/set3/container_configuration/hostname.bats
@@ -234,8 +234,9 @@ function _should_have_correct_mail_headers() {
   # but Amavis is changing that. It also changes protocol from SMTP to ESMTP.
   assert_line --index 7 --partial 'Received: from localhost (localhost [127.0.0.1])'
   assert_line --index 8 --partial "by ${EXPECTED_FQDN} (Postfix) with ESMTP id"
-  assert_line --index 14 --partial 'Message-Id:'
-  assert_line --index 14 --partial "@${EXPECTED_FQDN}>"
+  assert_line --index 14 'X-MS-Reactions: disallow'
+  assert_line --index 15 --partial 'Message-Id:'
+  assert_line --index 15 --partial "@${EXPECTED_FQDN}>"
 
   # Mail contents example:
   #


### PR DESCRIPTION
# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->

**I was unable to extend the set of changes from #4425. Hence, it was quicker for me to simply open a new PR.**

CC @mpldr 

---

Replaces #4425. This MR contains a superset of changes to `sender_header_filter.pcre`, also cleaning the file up a bit (sorting it alphabetically).

<!-- Link the issue which will be fixed (if any) here: -->
Fixes issue with GPG, see linked PR.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
