### PR TITLE
fix: ensure message content is not modified by header filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file. The format 
 
 > **Note**: Changes and additions listed here are contained in the `:edge` image tag. These changes may not be as stable as released changes.
 
+### Fixes
+
+- **Postfix**
+  - Avoid modifying the message body when filtering sender headers. This regression was introduced from [#4120](https://github.com/docker-mailserver/docker-mailserver/pull/4120) as part of DMS v15.0.0 ([#4429](https://github.com/docker-mailserver/docker-mailserver/pull/4429))
+
 ## [v15.0.1](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v15.0.1)
 
 ### Added

--- a/target/postfix/sender_header_filter.pcre
+++ b/target/postfix/sender_header_filter.pcre
@@ -8,4 +8,5 @@
 /^\s*X-Mailer/                      IGNORE
 /^\s*X-Originating-IP/              IGNORE
 /^\s*Received: from.*127.0.0.1/     IGNORE
-/^Content-Type:/i                   PREPEND X-MS-Reactions: disallow
+/^\s*X-MS-Reactions:/               IGNORE
+/^\s*Message-Id:/i                  PREPEND X-MS-Reactions: disallow

--- a/test/tests/parallel/set3/container_configuration/hostname.bats
+++ b/test/tests/parallel/set3/container_configuration/hostname.bats
@@ -234,8 +234,9 @@ function _should_have_correct_mail_headers() {
   # but Amavis is changing that. It also changes protocol from SMTP to ESMTP.
   assert_line --index 7 --partial 'Received: from localhost (localhost [127.0.0.1])'
   assert_line --index 8 --partial "by ${EXPECTED_FQDN} (Postfix) with ESMTP id"
-  assert_line --index 14 --partial 'Message-Id:'
-  assert_line --index 14 --partial "@${EXPECTED_FQDN}>"
+  assert_line --index 14 'X-MS-Reactions: disallow'
+  assert_line --index 15 --partial 'Message-Id:'
+  assert_line --index 15 --partial "@${EXPECTED_FQDN}>"
 
   # Mail contents example:
   #


### PR DESCRIPTION
Due to an oversight, one of the header filters has potentially modified the message body, leading to broken cryptographic signatures.

Switch to the Message-Id instead of the Content-Type header, which is usually only present in the global header.



Reported-by: Cole Young <cole@young.sh>
Fixes: 009237cc ("chore: Prevent Microsoft MUAs from sending reactions (#4120)")
