### PR TITLE
Fix broken README link for SRS

### DIFF
--- a/mailserver.env
+++ b/mailserver.env
@@ -92,7 +92,7 @@ TLS_LEVEL=
 # 1 => Mail spoofing denied. Each user may only send with their own or their alias addresses. Addresses with extension delimiters(http://www.postfix.org/postconf.5.html#recipient_delimiter) are not able to send messages.
 SPOOF_PROTECTION=
 
-# Enables the Sender Rewriting Scheme. SRS is needed if your mail server acts as forwarder. See [postsrsd](https://github.com/roehling/postsrsd/blob/master/README.md#sender-rewriting-scheme-crash-course) for further explanation.
+# Enables the Sender Rewriting Scheme. SRS is needed if your mail server acts as forwarder. See [postsrsd](https://github.com/roehling/postsrsd/blob/main/README.rst) for further explanation.
 #  - **0** => Disabled
 #  - 1 => Enabled
 ENABLE_SRS=0


### PR DESCRIPTION
Fix broken README link for SRS. Same as in #3906 but for `mailserver.env`.