### PR TITLE
feat: Configurable poll rate for `check-for-changes.sh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file. The format 
 
 > **Note**: Changes and additions listed here are contained in the `:edge` image tag. These changes may not be as stable as released changes.
 
+### Added
+
+- **Environment Variables:**
+  - `CHECK_FOR_CHANGES_INTERVAL_SEC` makes it possible to configure execution interval of the ``check-for-changes.sh`` script. ([#4450](https://github.com/docker-mailserver/docker-mailserver/pull/4450))
+    - Default value is set to ``20`` (was originally ``2``) to improve idle server load.
+
 ### Updates
 
 - **Documentation:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 
-- **Environment Variables:**
-  - `CHECK_FOR_CHANGES_INTERVAL_SEC` makes it possible to configure execution interval of the ``check-for-changes.sh`` script. ([#4450](https://github.com/docker-mailserver/docker-mailserver/pull/4450))
-    - Default value is set to ``20`` (was originally ``2``) to improve idle server load.
+- **Internal:**
+  - [`DMS_CONFIG_POLL`](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/environment/#dms_config_poll) supports adjusting the polling rate (seconds) for the change detection service `check-for-changes.sh` ([#4450](https://github.com/docker-mailserver/docker-mailserver/pull/4450))
 
 ### Updates
 

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -360,11 +360,22 @@ Default: empty (no prefix will be added to e-mails)
 
     Add trailing white-space by quote wrapping the value: `SPAM_SUBJECT='[SPAM] '`
 
-##### CHECK_FOR_CHANGES_INTERVAL_SEC
+##### DMS_CONFIG_POLL
 
-Defines how often the background check for changes (e.g. if the configuration changed or a new certificate needs to be applied) should be executed.
+Defines how often DMS polls [monitored config files][gh::monitored-configs] for changes in the DMS Config Volume. This also includes TLS certificates and is often relied on for applying changes managed via `setup` CLI commands.
 
-Default: ``20``
+- **`2`** => How often (in seconds) [change detection][gh::check-for-changes] is performed.
+
+!!! note "Decreasing the frequency of polling for changes"
+
+    Raising the value will delay how soon a change is detected which may impact UX expectations for responsiveness, but reduces resource usage when changes are rare.
+
+!!! info
+
+    When using `ACCOUNT_PROVISIONER=LDAP`, the change detection feature is presently disabled.
+
+[gh::check-for-changes]: https://github.com/docker-mailserver/docker-mailserver/blob/v15.0.0/target/scripts/check-for-changes.sh#L37
+[gh::monitored-configs]: https://github.com/docker-mailserver/docker-mailserver/blob/v15.0.0/target/scripts/helpers/change-detection.sh#L30-L42
 
 #### Rspamd
 

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -360,6 +360,12 @@ Default: empty (no prefix will be added to e-mails)
 
     Add trailing white-space by quote wrapping the value: `SPAM_SUBJECT='[SPAM] '`
 
+##### CHECK_FOR_CHANGES_INTERVAL_SEC
+
+Defines how often the background check for changes (e.g. if the configuration changed or a new certificate needs to be applied) should be executed.
+
+Default: ``20``
+
 #### Rspamd
 
 ##### ENABLE_RSPAMD

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -211,7 +211,7 @@ function _rspamd_changes() {
 
 while true; do
   _check_for_changes
-  sleep ${CHECK_FOR_CHANGES_INTERVAL_SEC:-20}
+  sleep ${DMS_CONFIG_POLL:-2}
 done
 
 exit 0

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -211,7 +211,7 @@ function _rspamd_changes() {
 
 while true; do
   _check_for_changes
-  sleep 2
+  sleep ${CHECK_FOR_CHANGES_INTERVAL_SEC:-20}
 done
 
 exit 0

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -211,7 +211,7 @@ function _rspamd_changes() {
 
 while true; do
   _check_for_changes
-  sleep ${DMS_CONFIG_POLL:-2}
+  sleep "${DMS_CONFIG_POLL:-2}"
 done
 
 exit 0

--- a/target/scripts/startup/variables-stack.sh
+++ b/target/scripts/startup/variables-stack.sh
@@ -149,6 +149,7 @@ function __environment_variables_general_setup() {
   _log 'trace' 'Setting miscellaneous environment variables'
 
   VARS[ACCOUNT_PROVISIONER]="${ACCOUNT_PROVISIONER:=FILE}"
+  VARS[DMS_CONFIG_POLL]="${DMS_CONFIG_POLL:=2}"
   VARS[FETCHMAIL_PARALLEL]="${FETCHMAIL_PARALLEL:=0}"
   VARS[FETCHMAIL_POLL]="${FETCHMAIL_POLL:=300}"
   VARS[GETMAIL_POLL]="${GETMAIL_POLL:=5}"


### PR DESCRIPTION
# Description

Makes the ``check-for-changes.sh`` execution interval configurable (see issue for details).

Picked a default value of ``20`` because
* it roughly halfs the idle load 
* it's still reactive enough when changes occur

Fixes #4414 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
