### PR TITLE
fix: `setup email list` should only work with `ACCOUNT_PROVISIONER=FILE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file. The format 
   - Added a compatibility note for a Dovecot + Solr 9.8 breaking change ([#4433](https://github.com/docker-mailserver/docker-mailserver/pull/4433))
 - **Internal:**
   - Refactored `setup config dkim` (`open-dkim`) ([#4375](https://github.com/docker-mailserver/docker-mailserver/pull/4375))
+  - `setup email list` and the default `ENABLE_QUOTAS=1` ENV now better communicate when config is incompatible ([#4453](https://github.com/docker-mailserver/docker-mailserver/pull/4453))
 
 ## [v15.0.2](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v15.0.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file. The format 
   - Added a compatibility note for a Dovecot + Solr 9.8 breaking change ([#4433](https://github.com/docker-mailserver/docker-mailserver/pull/4433))
 - **Internal:**
   - Refactored `setup config dkim` (`open-dkim`) ([#4375](https://github.com/docker-mailserver/docker-mailserver/pull/4375))
-  - `setup email list` and the default `ENABLE_QUOTAS=1` ENV now better communicate when config is incompatible ([#4453](https://github.com/docker-mailserver/docker-mailserver/pull/4453))
+  - `setup email list` and the default `ENABLE_QUOTAS=1` ENV now better communicates when config is incompatible ([#4453](https://github.com/docker-mailserver/docker-mailserver/pull/4453))
 
 ## [v15.0.2](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v15.0.2)
 

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -247,6 +247,12 @@ Set the mailbox size limit for all users. If set to zero, the size will be unlim
 
 See [mailbox quota][docs-accounts-quota].
 
+!!! info "Compatibility"
+
+    This feature is presently only compatible with `ACCOUNT_PROVISIONER=FILE`.
+
+    When using a different provisioner (or `SMTP_ONLY=1`) this ENV will instead default to `0`.
+
 ##### POSTFIX_MESSAGE_SIZE_LIMIT
 
 Set the message size limit for all users. If set to zero, the size will be unlimited (not recommended!). Size is in bytes.

--- a/target/bin/listmailuser
+++ b/target/bin/listmailuser
@@ -8,6 +8,10 @@ source /usr/local/bin/helpers/index.sh
 source /etc/dms-settings 2>/dev/null
 
 function _main() {
+  if [[ ${ACCOUNT_PROVISIONER} != 'FILE' ]]; then
+    _exit_with_error "This command is only compatible with 'ACCOUNT_PROVISIONER=FILE'"
+  fi
+
   local DATABASE_ACCOUNTS='/tmp/docker-mailserver/postfix-accounts.cf'
   local DATABASE_VIRTUAL='/tmp/docker-mailserver/postfix-virtual.cf'
 

--- a/target/scripts/startup/variables-stack.sh
+++ b/target/scripts/startup/variables-stack.sh
@@ -116,8 +116,8 @@ function __environment_variables_general_setup() {
 
   # The Dovecot Quotas feature is presently only supported with the default FILE account provisioner,
   # Enforce disabling the feature, unless it's been explicitly set via ENV (to avoid mismatch between explicit ENV and sourcing from /etc/dms-settings)
-  if [[ ${ACCOUNT_PROVISIONER} != 'FILE' ]] || [[ ${SMTP_ONLY} -eq 1 ]] || [[ ${ENABLE_QUOTAS} -ne 1 ]]; then
-    _log 'debug' "The 'ENABLE_QUOTAS' feature is enabled by default but is not compatible with your config. Disabling"
+  if [[ ${ACCOUNT_PROVISIONER} != 'FILE' || ${SMTP_ONLY} -eq 1 ]] && [[ ${ENABLE_QUOTAS:-1} -eq 1 ]]; then
+    _log 'debug' "The 'ENABLE_QUOTAS' feature is enabled (by default) but is not compatible with your config. Disabling"
     VARS[ENABLE_QUOTAS]="${ENABLE_QUOTAS:=0}"
   else
     VARS[ENABLE_QUOTAS]="${ENABLE_QUOTAS:=1}"

--- a/target/scripts/startup/variables-stack.sh
+++ b/target/scripts/startup/variables-stack.sh
@@ -116,7 +116,7 @@ function __environment_variables_general_setup() {
 
   # The Dovecot Quotas feature is presently only supported with the default FILE account provisioner,
   # Enforce disabling the feature, unless it's been explicitly set via ENV (to avoid mismatch between explicit ENV and sourcing from /etc/dms-settings)
-  if [[ ${ACCOUNT_PROVISIONER} != 'FILE' ]] || [[ ${SMTP_ONLY} -eq 1 ]] || [[ ${ENABLE_QUOTAS} -neq 1 ]]; then
+  if [[ ${ACCOUNT_PROVISIONER} != 'FILE' ]] || [[ ${SMTP_ONLY} -eq 1 ]] || [[ ${ENABLE_QUOTAS} -ne 1 ]]; then
     _log 'debug' "The 'ENABLE_QUOTAS' feature is enabled by default but is not compatible with your config. Disabling"
     VARS[ENABLE_QUOTAS]="${ENABLE_QUOTAS:=0}"
   else

--- a/target/scripts/startup/variables-stack.sh
+++ b/target/scripts/startup/variables-stack.sh
@@ -106,7 +106,6 @@ function __environment_variables_general_setup() {
   VARS[ENABLE_POP3]="${ENABLE_POP3:=0}"
   VARS[ENABLE_IMAP]="${ENABLE_IMAP:=1}"
   VARS[ENABLE_POSTGREY]="${ENABLE_POSTGREY:=0}"
-  VARS[ENABLE_QUOTAS]="${ENABLE_QUOTAS:=1}"
   VARS[ENABLE_RSPAMD]="${ENABLE_RSPAMD:=0}"
   VARS[ENABLE_RSPAMD_REDIS]="${ENABLE_RSPAMD_REDIS:=${ENABLE_RSPAMD}}"
   VARS[ENABLE_SASLAUTHD]="${ENABLE_SASLAUTHD:=0}"
@@ -114,6 +113,15 @@ function __environment_variables_general_setup() {
   VARS[ENABLE_SPAMASSASSIN_KAM]="${ENABLE_SPAMASSASSIN_KAM:=0}"
   VARS[ENABLE_SRS]="${ENABLE_SRS:=0}"
   VARS[ENABLE_UPDATE_CHECK]="${ENABLE_UPDATE_CHECK:=1}"
+
+  # The Dovecot Quotas feature is presently only supported with the default FILE account provisioner,
+  # Enforce disabling the feature, unless it's been explicitly set via ENV (to avoid mismatch between explicit ENV and sourcing from /etc/dms-settings)
+  if [[ ${ACCOUNT_PROVISIONER} != 'FILE' ]] || [[ ${SMTP_ONLY} -eq 1 ]] || [[ ${ENABLE_QUOTAS} -neq 1 ]]; then
+    _log 'debug' "The 'ENABLE_QUOTAS' feature is enabled by default but is not compatible with your config. Disabling"
+    VARS[ENABLE_QUOTAS]="${ENABLE_QUOTAS:=0}"
+  else
+    VARS[ENABLE_QUOTAS]="${ENABLE_QUOTAS:=1}"
+  fi
 
   _log 'trace' 'Setting IP, DNS and SSL environment variables'
 

--- a/target/scripts/startup/variables-stack.sh
+++ b/target/scripts/startup/variables-stack.sh
@@ -62,7 +62,7 @@ function __environment_variables_general_setup() {
   VARS[DMS_VMAIL_UID]="${DMS_VMAIL_UID:=5000}"
   VARS[DMS_VMAIL_GID]="${DMS_VMAIL_GID:=5000}"
 
-  # user-customizable are last
+  # user-customizable are next
 
   _log 'trace' 'Setting anti-spam & anti-virus environment variables'
 
@@ -113,15 +113,6 @@ function __environment_variables_general_setup() {
   VARS[ENABLE_SPAMASSASSIN_KAM]="${ENABLE_SPAMASSASSIN_KAM:=0}"
   VARS[ENABLE_SRS]="${ENABLE_SRS:=0}"
   VARS[ENABLE_UPDATE_CHECK]="${ENABLE_UPDATE_CHECK:=1}"
-
-  # The Dovecot Quotas feature is presently only supported with the default FILE account provisioner,
-  # Enforce disabling the feature, unless it's been explicitly set via ENV (to avoid mismatch between explicit ENV and sourcing from /etc/dms-settings)
-  if [[ ${ACCOUNT_PROVISIONER} != 'FILE' || ${SMTP_ONLY} -eq 1 ]] && [[ ${ENABLE_QUOTAS:-1} -eq 1 ]]; then
-    _log 'debug' "The 'ENABLE_QUOTAS' feature is enabled (by default) but is not compatible with your config. Disabling"
-    VARS[ENABLE_QUOTAS]="${ENABLE_QUOTAS:=0}"
-  else
-    VARS[ENABLE_QUOTAS]="${ENABLE_QUOTAS:=1}"
-  fi
 
   _log 'trace' 'Setting IP, DNS and SSL environment variables'
 
@@ -175,6 +166,18 @@ function __environment_variables_general_setup() {
   VARS[SUPERVISOR_LOGLEVEL]="${SUPERVISOR_LOGLEVEL:=warn}"
   VARS[TZ]="${TZ:=}"
   VARS[UPDATE_CHECK_INTERVAL]="${UPDATE_CHECK_INTERVAL:=1d}"
+
+  _log 'trace' 'Setting environment variables that require other variables to be set first'
+
+  # The Dovecot Quotas feature is presently only supported with the default FILE account provisioner,
+  # Enforce disabling the feature, unless it's been explicitly set via ENV (to avoid mismatch between
+  # explicit ENV and sourcing from /etc/dms-settings)
+  if [[ ${ACCOUNT_PROVISIONER} != 'FILE' || ${SMTP_ONLY} -eq 1 ]] && [[ ${ENABLE_QUOTAS:-1} -eq 1 ]]; then
+    _log 'debug' "The 'ENABLE_QUOTAS' feature is enabled (by default) but is not compatible with your config. Disabling"
+    VARS[ENABLE_QUOTAS]="${ENABLE_QUOTAS:=0}"
+  else
+    VARS[ENABLE_QUOTAS]="${ENABLE_QUOTAS:=1}"
+  fi
 }
 
 function __environment_variables_log_level() {


### PR DESCRIPTION
# Description

This addresses https://github.com/orgs/docker-mailserver/discussions/4452#discussioncomment-12918479

It should provide a better UX than a bunch of unhelpful errors like the user experienced.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
