### PR TITLE
tests: Reference the new `testssl` image location

### DIFF
--- a/docs/content/config/security/ssl.md
+++ b/docs/content/config/security/ssl.md
@@ -13,7 +13,7 @@ There are multiple options to enable SSL (via [`SSL_TYPE`][docs-env::ssl-type]):
 After installation, you can test your setup with:
 
 - [`checktls.com`](https://www.checktls.com/TestReceiver)
-- [`testssl.sh`](https://github.com/drwetter/testssl.sh)
+- [`testssl.sh`](https://github.com/testssl/testssl.sh)
 
 !!! warning "Exposure of DNS labels through Certificate Transparency"
 

--- a/test/tests/parallel/set2/tls_cipherlists.bats
+++ b/test/tests/parallel/set2/tls_cipherlists.bats
@@ -25,7 +25,7 @@ function setup_file() {
 
   # Pull `testssl.sh` image in advance to avoid it interfering with the `run` captured output.
   # Only interferes (potential test failure) with `assert_output` not `assert_success`?
-  docker pull drwetter/testssl.sh:3.2
+  docker pull ghcr.io/testssl/testssl.sh:3.2
 
   # Only used in `_should_support_expected_cipherlists()` to set a storage location for `testssl.sh` JSON output:
   # `${BATS_TMPDIR}` maps to `/tmp`: https://bats-core.readthedocs.io/en/v1.8.2/writing-tests.html#special-variables
@@ -166,7 +166,7 @@ function _collect_cipherlists() {
     --volume "${TLS_CONFIG_VOLUME}" \
     --volume "${RESULTS_PATH}:/output" \
     --workdir "/output" \
-    drwetter/testssl.sh:3.2 "${TESTSSL_CMD[@]}"
+    ghcr.io/testssl/testssl.sh:3.2 "${TESTSSL_CMD[@]}"
 
   assert_success
 }

--- a/test/tests/parallel/set2/tls_cipherlists.bats
+++ b/test/tests/parallel/set2/tls_cipherlists.bats
@@ -111,7 +111,7 @@ function _configure_and_run_dms_container() {
 
 function _should_support_expected_cipherlists() {
   # Make a directory with test user ownership. Avoids Docker creating this with root ownership.
-  # TODO: Can switch to filename prefix for JSON output when this is resolved: https://github.com/drwetter/testssl.sh/issues/1845
+  # TODO: Can switch to filename prefix for JSON output when this is resolved: https://github.com/testssl/testssl.sh/issues/1845
   local RESULTS_PATH="${TLS_RESULTS_DIR}/${TEST_VARIANT}"
   mkdir -p "${RESULTS_PATH}"
 
@@ -156,7 +156,7 @@ function _collect_cipherlists() {
   # NOTE: Batch testing ports via `--file` doesn't properly bubble up failure.
   # If the failure for a test is misleading consider testing a single port with:
   # local TESTSSL_CMD=(--quiet --jsonfile-pretty "/output/port_${PORT}.json" --starttls smtp "${TEST_DOMAIN}:${PORT}")
-  # TODO: Can use `jq` to check for failure when this is resolved: https://github.com/drwetter/testssl.sh/issues/1844
+  # TODO: Can use `jq` to check for failure when this is resolved: https://github.com/testssl/testssl.sh/issues/1844
 
   # `--user "<uid>:<gid>"` is a workaround: Avoids `permission denied` write errors for json output, uses `id` to match user uid & gid.
   run docker run --rm \


### PR DESCRIPTION
# Description

The `testssl` project [moved to an organization](https://github.com/testssl/testssl.sh/commit/b708026151bba8d3bb06c35b5117eb9a50419929). Images are now also [published to GHCR](https://github.com/testssl/testssl.sh/pkgs/container/testssl.sh) so we'll use that image going forward.

Probably not worth adding noise to the changelog for this minor change 😅 

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [x] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
