### PR TITLE
Add LOGIN_TRUSTED_NETWORKS option for Dovecot configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - **Internal:**
   - [`DMS_CONFIG_POLL`](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/environment/#dms_config_poll) supports adjusting the polling rate (seconds) for the change detection service `check-for-changes.sh` ([#4450](https://github.com/docker-mailserver/docker-mailserver/pull/4450))
+  - [`LOGIN_TRUSTED_NETWORKS`](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/environment/#login_trusted_networks) allows specifying trusted networks for Dovecot login connections, enabling the client to tell the server what the original client's IP address was
 
 ### Updates
 

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -320,6 +320,13 @@ Note: More details at <http://www.postfix.org/postconf.5.html#inet_protocols>
 
 Note: More information at <https://dovecot.org/doc/dovecot-example.conf>
 
+##### LOGIN_TRUSTED_NETWORKS
+
+Specify trusted networks for Dovecot login connections. This setting allows the client connection to tell the server what the original client's IP address was.
+
+- **empty** => No trusted networks configured
+- Example: "10.0.0.0/8 192.168.0.0/16"
+
 ##### MOVE_SPAM_TO_JUNK
 
 - 0 => Spam messages will be delivered to the inbox.

--- a/mailserver.env
+++ b/mailserver.env
@@ -379,6 +379,12 @@ ENABLE_MTA_STS=0
 # Note: More information at https://dovecot.org/doc/dovecot-example.conf
 DOVECOT_INET_PROTOCOLS=all
 
+# Specify trusted networks for Dovecot login connections
+# This setting allows the client connection to tell the server what the original client's IP address was
+# empty => No trusted networks configured
+# Example: "10.0.0.0/8 192.168.0.0/16"
+LOGIN_TRUSTED_NETWORKS=
+
 # -----------------------------------------------
 # --- SpamAssassin Section ----------------------
 # -----------------------------------------------

--- a/target/scripts/startup/setup.d/dovecot.sh
+++ b/target/scripts/startup/setup.d/dovecot.sh
@@ -11,6 +11,9 @@ function _setup_dovecot() {
   mv /etc/dovecot/protocols.d/imapd.protocol /etc/dovecot/protocols.d/imapd.protocol.disab
   mv /etc/dovecot/protocols.d/managesieved.protocol /etc/dovecot/protocols.d/managesieved.protocol.disab
 
+  # Setup login_trusted_networks if specified
+  _setup_dovecot_login_trusted_networks
+
   # NOTE: While Postfix will deliver to Dovecot via LMTP (Previously LDA until DMS v2),
   # LDA may be used via other services like Getmail being configured to use /usr/lib/dovecot/deliver
   # when mail does not need to go through Postfix.
@@ -235,6 +238,16 @@ function _setup_dovecot_inet_protocols() {
   fi
 
   sedfile -i "s|^#listen =.*|listen = ${PROTOCOL}|g" /etc/dovecot/dovecot.conf
+}
+
+function _setup_dovecot_login_trusted_networks() {
+  [[ -z ${LOGIN_TRUSTED_NETWORKS} ]] && return 0
+
+  _log 'debug' 'Setting up Dovecot login_trusted_networks'
+  _log 'trace' "Adding trusted networks: ${LOGIN_TRUSTED_NETWORKS}"
+
+  # Uncomment and set login_trusted_networks in dovecot.conf
+  sedfile -i "s|^#login_trusted_networks =.*|login_trusted_networks = ${LOGIN_TRUSTED_NETWORKS}|g" /etc/dovecot/dovecot.conf
 }
 
 function _setup_dovecot_dhparam() {


### PR DESCRIPTION
# Description

Add LOGIN_TRUSTED_NETWORKS option for Dovecot configuration.

Currently I need to add this option to the dovecot local config manually after creating the volume, but I would prefer if this was something that can be setup using the environment variables like the rest of the settings.

Personally I use it to display the correct client IP when requests come from Roundcube.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
