### PR TITLE
docs: `mailserver.env` - Remove unsupported SASL auth mechanisms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,6 @@ All notable changes to this project will be documented in this file. The format 
   - Refactored `setup config dkim` (`open-dkim`) ([#4375](https://github.com/docker-mailserver/docker-mailserver/pull/4375))
   - `setup email list` and the default `ENABLE_QUOTAS=1` ENV now better communicates when config is incompatible ([#4453](https://github.com/docker-mailserver/docker-mailserver/pull/4453))
 
-### Fixes
-- **Internal:**
-  - Legacy saslauthd mechanisms (`pam`, `shadow`, `mysql`) removed from ENV ([#4472](https://github.com/docker-mailserver/docker-mailserver/pull/4472))
-
 ## [v15.0.2](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v15.0.2)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ All notable changes to this project will be documented in this file. The format 
   - Refactored `setup config dkim` (`open-dkim`) ([#4375](https://github.com/docker-mailserver/docker-mailserver/pull/4375))
   - `setup email list` and the default `ENABLE_QUOTAS=1` ENV now better communicates when config is incompatible ([#4453](https://github.com/docker-mailserver/docker-mailserver/pull/4453))
 
+### Fixes
+- **Internal:**
+  - Legacy saslauthd mechanisms (`pam`, `shadow`, `mysql`) removed from ENV ([#4472](https://github.com/docker-mailserver/docker-mailserver/pull/4472))
+
 ## [v15.0.2](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v15.0.2)
 
 ### Fixes

--- a/mailserver.env
+++ b/mailserver.env
@@ -531,12 +531,9 @@ POSTGREY_AUTO_WHITELIST_CLIENTS=5
 
 ENABLE_SASLAUTHD=0
 
-# empty => pam
+# empty => ldap
 # `ldap` => authenticate against ldap server
-# `shadow` => authenticate against local user db
-# `mysql` => authenticate against mysql db
 # `rimap` => authenticate against imap server
-# Note: can be a list of mechanisms like pam ldap shadow
 SASLAUTHD_MECHANISMS=
 
 # empty => None


### PR DESCRIPTION
# Description

I tried using `pam`, `shadow`, `mysql` setting for the ENV `SASLAUTHD_MECHANISMS` but I didn't get it to work. After not finding anything in the documentation, I came across #4259.

It seems the options in the ENV file were not removed. 😃 

## Type of change

<!-- Delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [X] If necessary, I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] **I have added information about changes made in this PR to `CHANGELOG.md`**
