### PR TITLE
docs: PROXY protocol advice for Traefik should reference correct entrypoints

### DIFF
--- a/docs/content/examples/tutorials/mailserver-behind-proxy.md
+++ b/docs/content/examples/tutorials/mailserver-behind-proxy.md
@@ -114,15 +114,15 @@ The below guidance is focused on configuring [Traefik][traefik-web], but the adv
           # These are examples, configure the equivalent for any additional ports you proxy.
           # Explicit TLS (STARTTLS):
           - traefik.tcp.routers.mail-smtp.rule=HostSNI(`*`)
-          - traefik.tcp.routers.mail-smtp.entrypoints=smtp
-          - traefik.tcp.routers.mail-smtp.service=smtp
+          - traefik.tcp.routers.mail-smtp.entrypoints=mail-smtp
+          - traefik.tcp.routers.mail-smtp.service=mail-smtp
           - traefik.tcp.services.mail-smtp.loadbalancer.server.port=25
           - traefik.tcp.services.mail-smtp.loadbalancer.proxyProtocol.version=2
 
           # Implicit TLS is no different, except for optional HostSNI support:
           - traefik.tcp.routers.mail-submissions.rule=HostSNI(`*`)
-          - traefik.tcp.routers.mail-submissions.entrypoints=smtp-submissions
-          - traefik.tcp.routers.mail-submissions.service=smtp-submissions
+          - traefik.tcp.routers.mail-submissions.entrypoints=mail-submissions
+          - traefik.tcp.routers.mail-submissions.service=mail-submissions
           - traefik.tcp.services.mail-submissions.loadbalancer.server.port=465
           - traefik.tcp.services.mail-submissions.loadbalancer.proxyProtocol.version=2
           # NOTE: Optionally match by SNI rule, this requires TLS passthrough (not compatible with STARTTLS):


### PR DESCRIPTION
When the entrypoints for traefik are defined there are named mail-*(smtp,...), but it the dms labels when it comes to using these entry point in the TLS section just smtp is used, and for TLS it is used smtp-submissions witch is an invalid entrypoint

# Description

I tried recreating the setup for DMS using traefik as a reverse proxy, but instead of writing the entrypoints in the docker compose file, i used the toml version to do this. Following the docs and translating the cli commands into the toml I got this:

```tml
...............
entryPoints:
  mail-smtp:
    address: ":25"
  mail-submission:
    address: ":587"
  mail-submissions:
    address: ":465"
  mail-iamp:
    address: ":143"
  mail-imaps:
    address: ":993"
  mail-pop3:
    address: ":110"
  mail-pop3s:
    address: ":995"
  mail-managesieve:
    address: ":4190"
...............
```
The code above is created based on this part of the  [docs](https://docker-mailserver.github.io/docker-mailserver/latest/examples/tutorials/mailserver-behind-proxy/#configuration)

The problem arises when in the DMS labels because in the name of the entrypoints used aren't matching what is defined in the traefik configuration.

All i did is to change the name of the entrypoints for TLS and SSL to match what was declared. 



## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have performed a self-review of my code
