### PR TITLE
fix: Ensure DMS config volume can be accessed by non-root users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project will be documented in this file. The format 
 - **Internal:**
   - [`DMS_CONFIG_POLL`](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/environment/#dms_config_poll) supports adjusting the polling rate (seconds) for the change detection service `check-for-changes.sh` ([#4450](https://github.com/docker-mailserver/docker-mailserver/pull/4450))
 
+### Fixes
+
+- **Internal:**
+  - The DMS _Config Volume_ (`/tmp/docker-mailserver`) will now ensure it's file tree is accessible for services when the volume was created with missing executable bit ([#4487](https://github.com/docker-mailserver/docker-mailserver/pull/4487))
+
 ### Updates
 
 - **Documentation:**

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -104,6 +104,12 @@ function _setup_directory_and_file_permissions() {
     chown -R _rspamd:_rspamd "${RSPAMD_DMS_DKIM_D}"
   fi
 
+  # Parent directories must have the executable bit set to descend the file tree for access,
+  # as each service in the container running as a non-root user requires this to access any subpath,
+  # `/tmp/docker-mailserver` must allow all users `+x` (notably required for `_rspamd` user read access):
+  local DMS_CONFIG_DIR=/tmp/docker-mailserver
+  chmod +x "${DMS_CONFIG_DIR}"
+
   __log_fixes
 }
 


### PR DESCRIPTION
# Description

This is similar to a [recent fix for the DMS state volume](https://github.com/docker-mailserver/docker-mailserver/pull/4420), where a non-root user needs access but the host directory mounted has mistakenly been too aggressive with permissions for the directory (_one known example is [AWS ECS (EC2) using EBS volumes](https://github.com/docker-mailserver/docker-mailserver/issues/4419#issuecomment-2731430310)_).

It appears that Rspamd support with DKIM at least [expects this due to running operations as the `_rspamd` user](https://github.com/docker-mailserver/docker-mailserver/issues/4485#issuecomment-2902642469) to read content from the DMS config volume. In future this concern shouldn't be the case, as the root user during setup could make internal copies that anything running as `_rspamd` should instead interact with.

However since this is [not always an obvious failure](https://github.com/docker-mailserver/docker-mailserver/pull/4420) (_various unresolved reports in the past were tripped up by this for the state volume_), the fix is probably worth adding? (_makes me wonder if similar is prone to our other volumes too then_ 🤔)

**NOTE:** While we only need `chmod o+x`, we can use `chmod +x` here as [unlike other permissions like `+w` it appears to apply `+x` to `ugo` by default](https://github.com/docker-mailserver/docker-mailserver/pull/4420#discussion_r1999878806).

Fixes: #4485

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
