### PR TITLE
Update mailserver.env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - **Environment Variables:**
   - [ENV can be declared with a `__FILE` suffix](https://docker-mailserver.github.io/docker-mailserver/v15.1/config/environment/) to read a value from a file during initial DMS setup scripts ([#4359](https://github.com/docker-mailserver/docker-mailserver/pull/4359))
+  - Added additional info about `OVERRIDE_HOSTNAME` in `mailserver.env` 
 - **Internal:**
   - [`DMS_CONFIG_POLL`](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/environment/#dms_config_poll) supports adjusting the polling rate (seconds) for the change detection service `check-for-changes.sh` ([#4450](https://github.com/docker-mailserver/docker-mailserver/pull/4450))
 

--- a/mailserver.env
+++ b/mailserver.env
@@ -10,7 +10,10 @@
 # -----------------------------------------------
 
 # empty => uses the `hostname` command to get the mail server's canonical hostname
-# => Specify a fully-qualified domainname to serve mail for.  This is used for many of the config features so if you can't set your hostname (e.g. you're in a container platform that doesn't let you) specify it in this environment variable.
+# => Specify a fully-qualified domainname to serve mail for.  This is used for many of the config features so
+# if you can't set your hostname (e.g. you're in a container platform that doesn't let you) specify it in 
+# this environment variable.
+# **WARNING**: Setting OVERRIDE_HOSTNAME can have difficult to predict side effects.
 OVERRIDE_HOSTNAME=
 
 # REMOVED in version v11.0.0! Use LOG_LEVEL instead.


### PR DESCRIPTION
Changed the description of OVERRIDE_HOSTNAME environment variable, to raise awareness of unforeseen side effects.

# Description


The current documentation of `OVERRIDE_HOSTNAME` in `mailserver.env` doesnt reflect the fact that setting this can lead to unforeseen problems. See explanation at the bottom of this comment https://github.com/docker-mailserver/docker-mailserver/issues/4484#issuecomment-2908101121

When setting up DMS the first time i thought it would be better to set it to make sure all internal services use the correct hostname. When in reality its better not to set this unless you need to.

While at it i reformated the text so it looks more like the rest of the comments in the file.

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
I dont think this is necessary since the documentation already tells to only set this when you cant change the hostname.
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
No tests necessary, since this only changes a comment.
- [ ] New and existing unit tests pass locally with my changes
No tests necessary, since this only changes a comment.
- [X] **I have added information about changes made in this PR to `CHANGELOG.md`**
