### PR TITLE
docs: Revise docs for the `OVERRIDE_HOSTNAME` ENV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - **Environment Variables:**
   - [ENV can be declared with a `__FILE` suffix](https://docker-mailserver.github.io/docker-mailserver/v15.1/config/environment/) to read a value from a file during initial DMS setup scripts ([#4359](https://github.com/docker-mailserver/docker-mailserver/pull/4359))
-  - Added additional info about `OVERRIDE_HOSTNAME` in `mailserver.env` 
+  - Added additional info about `OVERRIDE_HOSTNAME` in `mailserver.env` ([#4492](https://github.com/docker-mailserver/docker-mailserver/pull/4492))
 - **Internal:**
   - [`DMS_CONFIG_POLL`](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/environment/#dms_config_poll) supports adjusting the polling rate (seconds) for the change detection service `check-for-changes.sh` ([#4450](https://github.com/docker-mailserver/docker-mailserver/pull/4450))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - **Environment Variables:**
   - [ENV can be declared with a `__FILE` suffix](https://docker-mailserver.github.io/docker-mailserver/v15.1/config/environment/) to read a value from a file during initial DMS setup scripts ([#4359](https://github.com/docker-mailserver/docker-mailserver/pull/4359))
-  - Added additional info about `OVERRIDE_HOSTNAME` in `mailserver.env` ([#4492](https://github.com/docker-mailserver/docker-mailserver/pull/4492))
+  - Improved docs for the ENV `OVERRIDE_HOSTNAME` ([#4492](https://github.com/docker-mailserver/docker-mailserver/pull/4492))
 - **Internal:**
   - [`DMS_CONFIG_POLL`](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/environment/#dms_config_poll) supports adjusting the polling rate (seconds) for the change detection service `check-for-changes.sh` ([#4450](https://github.com/docker-mailserver/docker-mailserver/pull/4450))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - **Environment Variables:**
   - [ENV can be declared with a `__FILE` suffix](https://docker-mailserver.github.io/docker-mailserver/v15.1/config/environment/) to read a value from a file during initial DMS setup scripts ([#4359](https://github.com/docker-mailserver/docker-mailserver/pull/4359))
+  - Added additional info about `OVERRIDE_HOSTNAME` in `mailserver.env` 
 - **Internal:**
   - [`DMS_CONFIG_POLL`](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/environment/#dms_config_poll) supports adjusting the polling rate (seconds) for the change detection service `check-for-changes.sh` ([#4450](https://github.com/docker-mailserver/docker-mailserver/pull/4450))
 

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -19,6 +19,12 @@ If you can't set your hostname (_eg: you're in a container platform that doesn't
 - **empty** => Uses the `hostname -f` command to get canonical hostname for DMS to use.
 - => Specify an FQDN (fully-qualified domain name) to serve mail for. The hostname is required for DMS to function correctly.
 
+!!! warning
+
+    `OVERRIDE_HOSTNAME` is not a complete replacement for adjusting the containers configured hostname. It is a best effort workaround for supporting deployment environments like kubernetes.
+
+    Typically this feature is only useful when software supports configuring settings to use a value that'd otherwise default to the hostname. Some software like [Fetchmail are known to be incompatible][gh-issue::hostname-compatibility] as they retrieve the hostname via querying the kernel.
+
 ##### LOG_LEVEL
 
 Set the log level for DMS. This is mostly relevant for container startup scripts and change detection event feedback.
@@ -1183,3 +1189,4 @@ Provide the credentials to use with `RELAY_HOST` or `DEFAULT_RELAY_HOST`.
 [postfix-config::relayhost_maps]: https://www.postfix.org/postconf.5.html#sender_dependent_relayhost_maps
 [postfix-config::sasl_passwd]: https://www.postfix.org/postconf.5.html#smtp_sasl_password_maps
 [gh-issue::tls-legacy-workaround]: https://github.com/docker-mailserver/docker-mailserver/pull/2945#issuecomment-1949907964
+[gh-issue::hostname-compatibility]: https://github.com/docker-mailserver/docker-mailserver-helm/issues/168#issuecomment-2911782106

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -14,16 +14,22 @@ title: Environment Variables
 
 ##### OVERRIDE_HOSTNAME
 
-If you can't set your hostname (_eg: you're in a container platform that doesn't let you_) specify it via this environment variable. It will have priority over `docker run --hostname`, or the equivalent `hostname:` field in `compose.yaml`.
+If you cannot set your DMS FQDN as your hostname (_eg: you're in a container runtime lacks the equivalent of Docker's `--hostname`_), specify it via this environment variable.
 
-- **empty** => Uses the `hostname -f` command to get canonical hostname for DMS to use.
+- **empty** => Internally uses the `hostname --fqdn` command to get the canonical hostname assigned to the DMS container.
 - => Specify an FQDN (fully-qualified domain name) to serve mail for. The hostname is required for DMS to function correctly.
 
-!!! warning
+!!! info
 
-    `OVERRIDE_HOSTNAME` is not a complete replacement for adjusting the containers configured hostname. It is a best effort workaround for supporting deployment environments like kubernetes.
+    `OVERRIDE_HOSTNAME` is checked early during DMS container setup. When set it will be preferred over querying the containers hostname via the `hostname --fqdn` command (_configured via `docker run --hostname` or the equivalent `hostname:` field in `compose.yaml`_).
 
-    Typically this feature is only useful when software supports configuring settings to use a value that'd otherwise default to the hostname. Some software like [Fetchmail are known to be incompatible][gh-issue::hostname-compatibility] as they retrieve the hostname via querying the kernel.
+!!! warning "Compatibility may differ"
+
+    `OVERRIDE_HOSTNAME` is not a complete replacement for adjusting the containers configured hostname. It is a best effort workaround for supporting deployment environments like Kubernetes or when using Docker with `--network=host`.
+
+    Typically this feature is only useful when software supports configuring a specific hostname to use, instead of a default fallback that infers the hostname (such as retrieving the hostname via libc / NSS). [Fetchmail is known to be incompatible][gh--issue::hostname-compatibility] with this ENV, requiring manual workarounds.
+
+    Compatibility differences are being [tracked here][gh-issue::dms-fqdn] as they become known.
 
 ##### LOG_LEVEL
 
@@ -1190,3 +1196,4 @@ Provide the credentials to use with `RELAY_HOST` or `DEFAULT_RELAY_HOST`.
 [postfix-config::sasl_passwd]: https://www.postfix.org/postconf.5.html#smtp_sasl_password_maps
 [gh-issue::tls-legacy-workaround]: https://github.com/docker-mailserver/docker-mailserver/pull/2945#issuecomment-1949907964
 [gh-issue::hostname-compatibility]: https://github.com/docker-mailserver/docker-mailserver-helm/issues/168#issuecomment-2911782106
+[gh-issue::dms-fqdn]: https://github.com/docker-mailserver/docker-mailserver/issues/3520#issuecomment-1700191973

--- a/mailserver.env
+++ b/mailserver.env
@@ -11,7 +11,7 @@
 
 # empty => uses the `hostname` command to get the mail server's canonical hostname
 # => Specify a fully-qualified domainname to serve mail for.  This is used for many of the config features so
-# if you can't set your hostname (e.g. you're in a container platform that doesn't let you) specify it in 
+# if you can't set your hostname (e.g. you're in a container platform that doesn't let you) specify it in
 # this environment variable.
 # **WARNING**: Setting OVERRIDE_HOSTNAME can have difficult to predict side effects.
 OVERRIDE_HOSTNAME=

--- a/mailserver.env
+++ b/mailserver.env
@@ -9,15 +9,12 @@
 # --- General Section ---------------------------
 # -----------------------------------------------
 
-# empty => uses the `hostname` command to get the mail server's canonical hostname
-# => Specify a fully-qualified domainname to serve mail for.  This is used for many of the config features so
-# if you can't set your hostname (e.g. you're in a container platform that doesn't let you) specify it in
-# this environment variable.
-# **WARNING**: Setting OVERRIDE_HOSTNAME can have difficult to predict side effects.
+# **empty** => Internally uses the `hostname --fqdn` command to get the canonical hostname assigned to the DMS container.
+# => Specify an FQDN (fully-qualified domain name) to serve mail for. The hostname is required for DMS to function correctly
+#
+# **WARNING**: Setting OVERRIDE_HOSTNAME can have difficult to predict side effects:
+# https://docker-mailserver.github.io/docker-mailserver/latest/config/environment/#override_hostname
 OVERRIDE_HOSTNAME=
-
-# REMOVED in version v11.0.0! Use LOG_LEVEL instead.
-DMS_DEBUG=0
 
 # Set the log level for DMS.
 # This is mostly relevant for container startup scripts and change detection event feedback.

--- a/mailserver.env
+++ b/mailserver.env
@@ -10,7 +10,10 @@
 # -----------------------------------------------
 
 # empty => uses the `hostname` command to get the mail server's canonical hostname
-# => Specify a fully-qualified domainname to serve mail for.  This is used for many of the config features so if you can't set your hostname (e.g. you're in a container platform that doesn't let you) specify it in this environment variable.
+# => Specify a fully-qualified domainname to serve mail for.  This is used for many of the config features so
+# if you can't set your hostname (e.g. you're in a container platform that doesn't let you) specify it in 
+# this environment variable.
+# **WARNING**: Setting OVERRIDE_HOSTNAME can have difficult to predict side effects.
 OVERRIDE_HOSTNAME=
 
 # REMOVED in version v11.0.0! Use LOG_LEVEL instead.


### PR DESCRIPTION
Changed the description of OVERRIDE_HOSTNAME environment variable, to raise awareness of unforeseen side effects.

# Description


The current documentation of `OVERRIDE_HOSTNAME` in `mailserver.env` doesnt reflect the fact that setting this can lead to unforeseen problems. See explanation at the bottom of this comment https://github.com/docker-mailserver/docker-mailserver/issues/4484#issuecomment-2908101121

When setting up DMS the first time i thought it would be better to set it to make sure all internal services use the correct hostname. When in reality its better not to set this unless you need to.

While at it i reformated the text so it looks more like the rest of the comments in the file. Now with no trailing whitespaces.

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
I dont think this is necessary since the documentation already tells to only set this when you cant change the hostname.
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
No tests necessary, since this only changes a comment.
- [ ] New and existing unit tests pass locally with my changes
No tests necessary, since this only changes a comment.
- [X] I have added information about changes made in this PR to `CHANGELOG.md`
