### PR TITLE
fix: `packages.sh` - Remove Postfix hostname workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - **Internal:**
   - The DMS _Config Volume_ (`/tmp/docker-mailserver`) will now ensure it's file tree is accessible for services when the volume was created with missing executable bit ([#4487](https://github.com/docker-mailserver/docker-mailserver/pull/4487))
+  - Removed the build-time hostname workaround for Postfix as Debian has since patched their post-install script ([#4493](https://github.com/docker-mailserver/docker-mailserver/pull/4493))
 
 ### Updates
 

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -83,12 +83,14 @@ function _install_postfix() {
 
   _log 'warn' 'Applying workaround for Postfix bug (see https://github.com/docker-mailserver/docker-mailserver/issues/2023#issuecomment-855326403)'
 
-  # Debians postfix package has a post-install script that expects a valid FQDN hostname to work:
-  mv /bin/hostname /bin/hostname.bak
-  echo "echo 'docker-mailserver.invalid'" >/bin/hostname
-  chmod +x /bin/hostname
+  # Debians postfix package has a post-install script that expects a valid FQDN hostname to work.
+  # Replace the hostname command to instead output temporary hostname that is fully-qualified:
+  mv /usr/bin/hostname /usr/bin/hostname.bak
+  echo -e "#!/bin/bash\necho 'docker-mailserver.invalid'" >/usr/bin/hostname
+  chmod +x /usr/bin/hostname
+  # Install the postfix package, then restore the original hostname command afterwards:
   apt-get "${QUIET}" install --no-install-recommends postfix
-  mv /bin/hostname.bak /bin/hostname
+  mv /usr/bin/hostname.bak /usr/bin/hostname
 
   # Irrelevant - Debian's default `chroot` jail config for Postfix needed a separate syslog socket:
   rm /etc/rsyslog.d/postfix.conf

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -78,24 +78,6 @@ function _install_utils() {
     | tar -xz --directory /usr/local/bin --no-same-owner --strip-components=1 "${SWAKS_RELEASE}/swaks"
 }
 
-function _install_postfix() {
-  _log 'debug' 'Installing Postfix'
-
-  _log 'warn' 'Applying workaround for Postfix bug (see https://github.com/docker-mailserver/docker-mailserver/issues/2023#issuecomment-855326403)'
-
-  # Debians postfix package has a post-install script that expects a valid FQDN hostname to work.
-  # Replace the hostname command to instead output temporary hostname that is fully-qualified:
-  mv /usr/bin/hostname /usr/bin/hostname.bak
-  echo -e "#!/bin/bash\necho 'docker-mailserver.invalid'" >/usr/bin/hostname
-  chmod +x /usr/bin/hostname
-  # Install the postfix package, then restore the original hostname command afterwards:
-  apt-get "${QUIET}" install --no-install-recommends postfix
-  mv /usr/bin/hostname.bak /usr/bin/hostname
-
-  # Irrelevant - Debian's default `chroot` jail config for Postfix needed a separate syslog socket:
-  rm /etc/rsyslog.d/postfix.conf
-}
-
 function _install_packages() {
   _log 'debug' 'Installing all packages now'
 
@@ -127,7 +109,7 @@ function _install_packages() {
   )
 
   local POSTFIX_PACKAGES=(
-    pflogsumm postgrey postfix-ldap postfix-mta-sts-resolver
+    pflogsumm postgrey postfix postfix-ldap postfix-mta-sts-resolver
     postfix-pcre postfix-policyd-spf-python postsrsd
   )
 
@@ -268,11 +250,13 @@ function _post_installation_steps() {
   _log 'trace' 'Removing leftovers from APT'
   apt-get "${QUIET}" clean
   rm -rf /var/lib/apt/lists/*
+
+  # Irrelevant - Debian's default `chroot` jail config for Postfix needed a separate syslog socket:
+  rm /etc/rsyslog.d/postfix.conf
 }
 
 _pre_installation_steps
 _install_utils
-_install_postfix
 _install_packages
 _install_dovecot
 _install_rspamd


### PR DESCRIPTION
# Description

This workaround can be dropped :)

The [original issue report](https://github.com/docker-mailserver/docker-mailserver/issues/2023#issuecomment-855326403) workaround we presently use, and the [verified alternative workaround](https://github.com/docker-mailserver/docker-mailserver/pull/2468#issuecomment-1232428884) (_via buildx arg_) are no longer appear required since upstream commits (_[1](https://salsa.debian.org/postfix-team/postfix-dev/-/commit/77850ee129745608d8e27c40e39462d693894c14) + [2](https://salsa.debian.org/postfix-team/postfix-dev/-/commit/a1d904dc162dfb810fc5b44b0f3efc45b07c12f8)_) in late 2021 have patched the logic in the [Debian Postfix package post-install script](https://salsa.debian.org/postfix-team/postfix-dev/-/blob/aaaa72f00c4bc856300822185ee6ea2b865dcc3d/debian/postfix.postinst#L23-43) 🎉 

---

## Original PR

**UPDATE:** The first commit of this PR was prior to checking the status of the Debian package, so a follow-up commit removes those changes as they're no longer needed 😎

@casperklein [spotted an issue with the original workaround](https://github.com/docker-mailserver/docker-mailserver/pull/2468#discussion_r827093975) that the initial commit of this PR resolves, although it never caused a problem as [without a shebang the existing shell itself was used](https://stackoverflow.com/questions/12296308/shell-script-working-fine-without-shebang-line-why/12296783#12296783) (I've verified).

References:
- https://github.com/docker-mailserver/docker-mailserver/issues/2023#issuecomment-855326403
- https://github.com/docker-mailserver/docker-mailserver/pull/2468#issuecomment-1232428884
- https://github.com/docker-mailserver/docker-mailserver/pull/2468#issuecomment-1071696226

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
