### PR TITLE
chore: Avoid logging a warning when `LOG_LEVEL` is unset

### DIFF
--- a/target/scripts/startup/variables-stack.sh
+++ b/target/scripts/startup/variables-stack.sh
@@ -153,7 +153,6 @@ function __environment_variables_general_setup() {
   VARS[FETCHMAIL_PARALLEL]="${FETCHMAIL_PARALLEL:=0}"
   VARS[FETCHMAIL_POLL]="${FETCHMAIL_POLL:=300}"
   VARS[GETMAIL_POLL]="${GETMAIL_POLL:=5}"
-  VARS[LOG_LEVEL]="${LOG_LEVEL:=info}"
   VARS[LOGROTATE_INTERVAL]="${LOGROTATE_INTERVAL:=weekly}"
   VARS[LOGROTATE_COUNT]="${LOGROTATE_COUNT:=4}"
   VARS[LOGWATCH_INTERVAL]="${LOGWATCH_INTERVAL:=none}"
@@ -181,21 +180,12 @@ function __environment_variables_general_setup() {
   fi
 }
 
+# `LOG_LEVEL` must be set early to correctly filter calls to `scripts/helpers/log.sh:_log()`
 function __environment_variables_log_level() {
-  if [[ ${LOG_LEVEL} == 'trace' ]] \
-  || [[ ${LOG_LEVEL} == 'debug' ]] \
-  || [[ ${LOG_LEVEL} == 'info' ]]  \
-  || [[ ${LOG_LEVEL} == 'warn' ]]  \
-  || [[ ${LOG_LEVEL} == 'error' ]]
-  then
-    return 0
-  else
-    local DEFAULT_LOG_LEVEL='info'
-    _log 'warn' "Log level '${LOG_LEVEL}' is invalid (falling back to default '${DEFAULT_LOG_LEVEL}')"
+  VARS[LOG_LEVEL]="${LOG_LEVEL:=info}"
 
-    # shellcheck disable=SC2034
-    VARS[LOG_LEVEL]="${DEFAULT_LOG_LEVEL}"
-    LOG_LEVEL="${DEFAULT_LOG_LEVEL}"
+  if [[ ! ${LOG_LEVEL} =~ ^(trace|debug|info|warn|error)$ ]]; then
+    _log 'warn' "Log level '${LOG_LEVEL}' is invalid (falling back to default: 'info')"
   fi
 }
 


### PR DESCRIPTION
# Description

When `LOG_LEVEL` is not explicitly set, DMS logs a warning early on:

```
WARN  start-mailserver.sh: Log level '' is invalid (falling back to default 'info')
```

This is redundant, so let's configure the fallback earlier and only log this when it has actually been set with an unexpected value.

I've additionally collapsed the series of conditionals against `LOG_LEVEL` to use a regex instead, then inversed the logic so we don't need a redundant branch.

**Reference:**

`LOG_LEVEL` defaults to `info`, where calls to `_log()` filter out by value comparison:

https://github.com/docker-mailserver/docker-mailserver/blob/ea03808c8f8d7ed67a0a9ed6d255e62338c02e9d/target/scripts/helpers/log.sh#L58-L64

For historical PR reference:
- https://github.com/docker-mailserver/docker-mailserver/pull/4323
- https://github.com/docker-mailserver/docker-mailserver/pull/2493

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**

Minor internal change, seems unnecessary to document in the changelog.
