### PR TITLE
chore: Simplify `compose.yaml` healthcheck

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -25,6 +25,6 @@ services:
     # cap_add:
     #   - NET_ADMIN
     healthcheck:
-      test: "ss --listening --tcp | grep -P 'LISTEN.+:smtp' || exit 1"
+      test: "nc -z localhost 25"
       timeout: 3s
       retries: 0


### PR DESCRIPTION
# Description

The current example healthcheck `ss --listening --tcp | grep -P 'LISTEN.+:smtp' || exit 1` can be simplified to [`nc -z localhost 25`](https://linux.die.net/man/1/nc) (_our tests use this via a helper to wait on Postfix being ready_), which effectively does the same check (_that a service is listening on the port_), but without the extra output or need to set an exit status (_both of which could be resolved with grep `-q`_).

The `nc` command is a bit more terser and direct though. The port `25` can be alternatively substituted for the service port `smtp`, (`nc -z localhost smtp`) just like the `ss` output displays (_resolved via `grep smtp /etc/services`_), but I figured most would be more familiar with the port number itself.

---

This has a benefit of less noisy healthcheck logs, which currently looks like this every 30 secs:

```console
$ docker inspect --format='{{json .State.Health}}' dms | jq

{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2025-06-01T07:16:35.79643154Z",
      "End": "2025-06-01T07:16:35.842821137Z",
      "ExitCode": 0,
      "Output": "LISTEN 0      100          0.0.0.0:smtp             0.0.0.0:*          \nLISTEN 0      100             [::]:smtp                [::]:*          \n"
    },
    {
      "Start": "2025-06-01T07:17:05.843928898Z",
      "End": "2025-06-01T07:17:05.891460075Z",
      "ExitCode": 0,
      "Output": "LISTEN 0      100          0.0.0.0:smtp             0.0.0.0:*          \nLISTEN 0      100             [::]:smtp                [::]:*          \n"
    },
    {
      "Start": "2025-06-01T07:17:35.892520906Z",
      "End": "2025-06-01T07:17:35.938991775Z",
      "ExitCode": 0,
      "Output": "LISTEN 0      100          0.0.0.0:smtp             0.0.0.0:*          \nLISTEN 0      100             [::]:smtp                [::]:*          \n"
    },
    {
      "Start": "2025-06-01T07:18:05.939841294Z",
      "End": "2025-06-01T07:18:06.003672308Z",
      "ExitCode": 0,
      "Output": "LISTEN 0      100          0.0.0.0:smtp             0.0.0.0:*          \nLISTEN 0      100             [::]:smtp                [::]:*          \n"
    },
    {
      "Start": "2025-06-01T07:18:36.004749936Z",
      "End": "2025-06-01T07:18:36.048725208Z",
      "ExitCode": 0,
      "Output": "LISTEN 0      100          0.0.0.0:smtp             0.0.0.0:*          \nLISTEN 0      100             [::]:smtp                [::]:*          \n"
    }
  ]
}
```

With `nc` instead:

```console
$ docker inspect --format='{{json .State.Health}}' dms | jq

{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2025-06-01T07:20:00.464604128Z",
      "End": "2025-06-01T07:20:00.516787463Z",
      "ExitCode": 0,
      "Output": ""
    },
    {
      "Start": "2025-06-01T07:20:30.517462343Z",
      "End": "2025-06-01T07:20:30.578389769Z",
      "ExitCode": 0,
      "Output": ""
    },
    {
      "Start": "2025-06-01T07:21:00.579295302Z",
      "End": "2025-06-01T07:21:00.621559922Z",
      "ExitCode": 0,
      "Output": ""
    },
    {
      "Start": "2025-06-01T07:21:30.622531376Z",
      "End": "2025-06-01T07:21:30.67123444Z",
      "ExitCode": 0,
      "Output": ""
    }
  ]
}
```

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)
