### PR TITLE
Add fail2ban ignore and consider options to setup

### DIFF
--- a/docs/content/config/security/fail2ban.md
+++ b/docs/content/config/security/fail2ban.md
@@ -78,7 +78,7 @@ This following configuration files inside the `docker-data/dms/config/` volume w
 [github-file-f2bjail]: https://github.com/docker-mailserver/docker-mailserver/blob/master/config-examples/fail2ban-jail.cf
 [github-file-f2bconfig]: https://github.com/docker-mailserver/docker-mailserver/blob/master/config-examples/fail2ban-fail2ban.cf
 
-### Viewing All Bans
+### Viewing All Bans and Ignores
 
 When just running
 
@@ -86,7 +86,7 @@ When just running
 setup fail2ban
 ```
 
-the script will show all banned IP addresses.
+the script will show all banned and ignored IP addresses.
 
 To get a more detailed `status` view, run
 
@@ -100,6 +100,14 @@ You can manage F2B with the `setup` script. The usage looks like this:
 
 ```bash
 docker exec <CONTAINER NAME> setup fail2ban [<ban|unban> <IP>]
+```
+
+### Managing Ignores
+
+If there are IPs or IP ranges you wish for fail2ban (never ban) this can be done like so:
+
+```bash
+docker exec <CONTAINER NAME> setup fail2ban [<ignore|consider> <IP OR CDIR RANGE>]
 ```
 
 ### Viewing the Log File

--- a/target/bin/fail2ban
+++ b/target/bin/fail2ban
@@ -5,6 +5,7 @@ source /usr/local/bin/helpers/index.sh
 
 function __usage() {
   echo "Usage: ./setup.sh fail2ban [<ban|unban> <IP>]"
+  echo "       ./setup.sh fail2ban [<ignore|consider> <IP OR CDIR RANGE>]"
   echo "       ./setup.sh fail2ban log"
   echo "       ./setup.sh fail2ban status"
 }

--- a/target/bin/fail2ban
+++ b/target/bin/fail2ban
@@ -21,6 +21,7 @@ done
 
 if [[ -z ${1} ]]; then
   IPS_BANNED=0
+  IPS_IGNORED=0
 
   for JAIL in "${JAILS[@]}"; do
     BANNED_IPS=$(fail2ban-client status "${JAIL}" | grep -oP '(?<=Banned IP list:\s).+')
@@ -29,9 +30,16 @@ if [[ -z ${1} ]]; then
       echo "Banned in ${JAIL}: ${BANNED_IPS}"
       IPS_BANNED=1
     fi
+    IGNORED_IPS=$(fail2ban-client get "${JAIL}" ignoreip | grep -oP '(?<=[|`]-\s).+')
+
+    if [[ -n ${IGNORED_IPS} ]]; then
+      echo "Ignored in ${JAIL}: ${IGNORED_IPS}"
+      IPS_IGNORED=1
+    fi
   done
 
   [[ ${IPS_BANNED} -eq 0 ]] && _log 'info' "No IPs have been banned"
+  [[ ${IPS_IGNORED} -eq 0 ]] && _log 'info' "No IPs are ignored"
 else
 
   case "${1}" in

--- a/target/bin/fail2ban
+++ b/target/bin/fail2ban
@@ -69,6 +69,38 @@ else
       fi
       ;;
 
+    ( 'ignore' )
+      shift
+      if [[ -n ${1} ]]; then
+
+        for JAIL in "${JAILS[@]}"; do
+          fail2ban-client set "${JAIL}" addignoreip "${@}" 2>&1
+
+          [ $? -eq 0 ] && echo "Will ignore from ${JAIL}"
+        done
+
+      else
+        _log 'warn' "You need to specify an IP address: Run './setup.sh fail2ban ignore <IP or CDIR range>'"
+        exit 0
+      fi
+      ;;
+
+    ( 'consider' )
+      shift
+      if [[ -n ${1} ]]; then
+
+        for JAIL in "${JAILS[@]}"; do
+          RESULT=$(fail2ban-client set "${JAIL}" delignoreip "${@}" 2>&1)
+
+          [[ ${RESULT} != *"x not in list"* ]] && [[ ${RESULT} != *"NOK"* ]] && echo "Will consider from ${JAIL}: ${RESULT}"
+        done
+
+      else
+        _log 'warn' "You need to specify an IP address: Run './setup.sh fail2ban consider <IP or CDIR range>'"
+        exit 0
+      fi
+      ;;
+
     ( 'log' )
       cat /var/log/mail/fail2ban.log
       ;;

--- a/target/bin/setup
+++ b/target/bin/setup
@@ -59,6 +59,8 @@ ${RED}[${ORANGE}SUB${RED}]${ORANGE}COMMANDS${RESET}
         setup fail2ban ${RESET}
         setup fail2ban ${CYAN}ban${RESET} <IP>
         setup fail2ban ${CYAN}unban${RESET} <IP>
+        setup fail2ban ${CYAN}ignore${RESET} <IP OR CDIR RANGE>
+        setup fail2ban ${CYAN}consider${RESET} <IP OR CDIR RANGE>
         setup fail2ban ${CYAN}log${RESET}
         setup fail2ban ${CYAN}status${RESET}
 


### PR DESCRIPTION
# Description

This allows an IP or a range to be added to the ignore list for fail2ban from setup.sh, rather than having to edit configuration files

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
