### PR TITLE
fix: open-dkim - Use numerical uid and gid for chown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable changes to this project will be documented in this file. The format 
   - [`DMS_CONFIG_POLL`](https://docker-mailserver.github.io/docker-mailserver/v15.0/config/environment/#dms_config_poll) supports adjusting the polling rate (seconds) for the change detection service `check-for-changes.sh` ([#4450](https://github.com/docker-mailserver/docker-mailserver/pull/4450))
 
 ### Fixes
-
+- **DKIM**
+  - `setup config dkim domain subdomain.example.com` no longer throws an error if the owner of config/opendkim/keys does not exist in the container ([#4517](https://github.com/docker-mailserver/docker-mailserver/pull/4517))
 - **Internal:**
   - The DMS _Config Volume_ (`/tmp/docker-mailserver`) will now ensure it's file tree is accessible for services when the volume was created with missing executable bit ([#4487](https://github.com/docker-mailserver/docker-mailserver/pull/4487))
   - Removed the build-time hostname workaround for Postfix as Debian has since patched their post-install script ([#4493](https://github.com/docker-mailserver/docker-mailserver/pull/4493))

--- a/target/bin/open-dkim
+++ b/target/bin/open-dkim
@@ -152,8 +152,9 @@ function _generate_dkim_keys() {
 
   # Ensure ownership is consistent for all content belonging to the base directory,
   # During container startup, an internal copy will be made via `_setup_opendkim()`
-  # with ownership we expect, while this chown is for the benefit of the users ownership.
-  chown -R "$(stat -c '%U:%G' "${OPENDKIM_BASE_DIR}")" "${OPENDKIM_BASE_DIR}"
+  # with ownership we expect, while this chown is for the benefit of the users' ownership.
+  # use numerical uid and gid in case the owner of the directory does not exist inside container
+  chown -R "$(stat -c '%u:%g' "${OPENDKIM_BASE_DIR}")" "${OPENDKIM_BASE_DIR}"
 }
 
 # Prepare a file with one domain per line (iterated via while loop as DKIM_DOMAIN):


### PR DESCRIPTION
# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->
Use numerical uid and gid for chown as they should always work even when the uid and gid have no names in /etc/...

<!-- Link the issue which will be fixed (if any) here: -->
in case the owner user does not exist in the image we get the following error:
```
open-dkim: Creating DKIM private key '/tmp/docker-mailserver/opendkim/keys/subdomain.example.com/mail.private'
chown: invalid user: 'UNKNOWN:UNKNOWN'
```


## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**

Info @wt-io-it