### PR TITLE
docs: Fix path in dkim helper script (rspamd)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - **Documentation:**
   - Added a compatibility note for a Dovecot + Solr 9.8 breaking change ([#4433](https://github.com/docker-mailserver/docker-mailserver/pull/4433))
-  - Fixed path in DKIM helper setup script ([#4521](https://github.com/docker-mailserver/docker-mailserver/issues/4521))
+  - `setup config dkim` (rspamd) - Corrected the expected path for the generated `dkim_signing.conf` file is now found in the DMS config volume ([#4521](https://github.com/docker-mailserver/docker-mailserver/issues/4521))
 - **Internal:**
   - Refactored `setup config dkim` (`open-dkim`) ([#4375](https://github.com/docker-mailserver/docker-mailserver/pull/4375))
   - `setup email list` and the default `ENABLE_QUOTAS=1` ENV now better communicates when config is incompatible ([#4453](https://github.com/docker-mailserver/docker-mailserver/pull/4453))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - **Documentation:**
   - Added a compatibility note for a Dovecot + Solr 9.8 breaking change ([#4433](https://github.com/docker-mailserver/docker-mailserver/pull/4433))
+  - Fixed path in DKIM helper setup script ([#4521](https://github.com/docker-mailserver/docker-mailserver/issues/4521))
 - **Internal:**
   - Refactored `setup config dkim` (`open-dkim`) ([#4375](https://github.com/docker-mailserver/docker-mailserver/pull/4375))
   - `setup email list` and the default `ENABLE_QUOTAS=1` ENV now better communicates when config is incompatible ([#4453](https://github.com/docker-mailserver/docker-mailserver/pull/4453))

--- a/docs/content/config/best-practices/dkim_dmarc_spf.md
+++ b/docs/content/config/best-practices/dkim_dmarc_spf.md
@@ -120,9 +120,6 @@ DKIM is currently supported by either OpenDKIM or Rspamd:
 
     After running `setup config dkim`, your new DKIM key files (_and OpenDKIM config_) have been added to `/tmp/docker-mailserver/opendkim/`.
 
-    !!! info "Restart required"
-
-        After restarting DMS, outgoing mail will now be signed with your new DKIM key(s) :tada:
 
 === "Rspamd"
 
@@ -223,6 +220,10 @@ DKIM is currently supported by either OpenDKIM or Rspamd:
         When `check_pubkey = true;` is set, Rspamd will query the DNS record for each DKIM selector, verifying each public key matches the private key configured.
 
         If there is a mismatch, a warning will be emitted to the Rspamd log `/var/log/mail/rspamd.log`.
+
+!!! info "Restart required"
+
+    After restarting DMS, outgoing mail will now be signed with your new DKIM key(s) :tada:
 
 ### DNS Record { #dkim-dns }
 

--- a/docs/content/config/best-practices/dkim_dmarc_spf.md
+++ b/docs/content/config/best-practices/dkim_dmarc_spf.md
@@ -55,7 +55,6 @@ You'll need to repeat this process if you add any new domains.
 You should have:
 
 - At least one [email account setup][docs-accounts]
-- Attached a [volume for config][docs-volumes-config] to persist the generated files to local storage
 
 !!! example "Creating DKIM Keys"
 

--- a/docs/content/config/best-practices/dkim_dmarc_spf.md
+++ b/docs/content/config/best-practices/dkim_dmarc_spf.md
@@ -148,9 +148,7 @@ DKIM is currently supported by either OpenDKIM or Rspamd:
 
         ---
 
-        In case you have not already provided a default DKIM signing configuration, the script will create one and write it to `/etc/rspamd/override.d/dkim_signing.conf`. If this file already exists, it will not be overwritten.
-
-        When you're already using [the `rspamd/override.d/` directory][docs-rspamd-config-dropin], the file is created inside your volume and therefore persisted correctly. If you are not using `rspamd/override.d/`, you will need to persist the file yourself (otherwise it is lost on container restart).
+        In case you have not already provided a default DKIM signing configuration, the script will create one and write it to `/tmp/docker-mailserver/rspamd/override.d/dkim_signing.conf` (which will be persisted with the default volume mounts). If this file already exists, it will not be overwritten.
 
         An example of what a default configuration file for DKIM signing looks like can be found by expanding the example below.
 

--- a/docs/content/config/best-practices/dkim_dmarc_spf.md
+++ b/docs/content/config/best-practices/dkim_dmarc_spf.md
@@ -55,6 +55,7 @@ You'll need to repeat this process if you add any new domains.
 You should have:
 
 - At least one [email account setup][docs-accounts]
+- Attached a [volume for config][docs-volumes-config] to persist the generated files to local storage
 
 !!! example "Creating DKIM Keys"
 
@@ -147,7 +148,7 @@ DKIM is currently supported by either OpenDKIM or Rspamd:
 
         ---
 
-        In case you have not already provided a default DKIM signing configuration, the script will create one and write it to `/tmp/docker-mailserver/rspamd/override.d/dkim_signing.conf` (which will be persisted with the default volume mounts). If this file already exists, it will not be overwritten.
+        In case you have not already provided a default DKIM signing configuration, the script will create one and write it to `/tmp/docker-mailserver/rspamd/override.d/dkim_signing.conf`. If this file already exists, it will not be overwritten.
 
         An example of what a default configuration file for DKIM signing looks like can be found by expanding the example below.
 
@@ -361,7 +362,6 @@ volumes:
 [docs-env-opendkim]: ../environment.md#enable_opendkim
 [docs-env-rspamd]: ../environment.md#enable_rspamd
 [docs-env-spf-policyd]: ../environment.md#enable_policyd_spf
-[docs-rspamd-config-dropin]: ../security/rspamd.md#manually
 [cloudflare-dkim-dmarc-spf]: https://www.cloudflare.com/learning/email-security/dmarc-dkim-spf/
 [rfc-8301]: https://datatracker.ietf.org/doc/html/rfc8301#section-3.2
 [gh-discussion::dkim-key-rotation-expiry]: https://github.com/orgs/docker-mailserver/discussions/4068#discussioncomment-9784263

--- a/docs/content/config/best-practices/dkim_dmarc_spf.md
+++ b/docs/content/config/best-practices/dkim_dmarc_spf.md
@@ -120,6 +120,9 @@ DKIM is currently supported by either OpenDKIM or Rspamd:
 
     After running `setup config dkim`, your new DKIM key files (_and OpenDKIM config_) have been added to `/tmp/docker-mailserver/opendkim/`.
 
+    !!! info "Restart required"
+
+        After restarting DMS, outgoing mail will now be signed with your new DKIM key(s) :tada:
 
 === "Rspamd"
 
@@ -220,10 +223,6 @@ DKIM is currently supported by either OpenDKIM or Rspamd:
         When `check_pubkey = true;` is set, Rspamd will query the DNS record for each DKIM selector, verifying each public key matches the private key configured.
 
         If there is a mismatch, a warning will be emitted to the Rspamd log `/var/log/mail/rspamd.log`.
-
-!!! info "Restart required"
-
-    After restarting DMS, outgoing mail will now be signed with your new DKIM key(s) :tada:
 
 ### DNS Record { #dkim-dns }
 


### PR DESCRIPTION
# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->
This PR improves the DKIM setup docs by correcting the config path that the helper script uses, and it removes the mentioned need for additional config volume mount. 

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #4521

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
