### PR TITLE
Delete user without prompt but keep mailbox data

### DIFF
--- a/target/bin/delmailuser
+++ b/target/bin/delmailuser
@@ -21,6 +21,8 @@ function _main() {
 
     if [[ ${MAILDEL} -eq 1 ]]; then
       _remove_maildir "${MAIL_ACCOUNT}"
+    elif [[ ${MAILDEL} -eq 2 ]]; then
+      _log 'info' "Mailbox data explicitly kept (using -n)."
     else
       _log 'info' "The mailbox data will not be deleted."
     fi
@@ -48,6 +50,8 @@ ${ORANGE}USAGE${RESET}
 ${ORANGE}OPTIONS${RESET}
     -y
         Skip prompt by approving to ${LWHITE}delete all mail data${RESET} for the account(s).
+    -n
+        Skip prompt by declining to ${LWHITE}delete all mail data${RESET} for the account(s).
 
     ${BLUE}Generic Program Information${RESET}
         help       Print the usage information.
@@ -65,6 +69,10 @@ ${ORANGE}EXAMPLES${RESET}
         Delete the two mail accounts requested, their associated data and
         delete the mailbox data for both accounts without asking.
 
+    ${LWHITE}./setup.sh email del -n user@example.com extra-user@example.com${RESET}
+        Delete the two mail accounts requested, their associated data and DO NOT
+        delete the mailbox data for both accounts without asking.
+
 ${ORANGE}EXIT STATUS${RESET}
     Exit status is 0 if command was successful. If wrong arguments are provided
     or arguments contain errors, the script will exit early with exit status 1.
@@ -73,12 +81,14 @@ ${ORANGE}EXIT STATUS${RESET}
 }
 
 function _parse_options() {
-  while getopts ":yY" OPT; do
+  while getopts ":yYnN" OPT; do
     case "${OPT}" in
       ( 'y' | 'Y' )
         MAILDEL=1
         ;;
-
+      ( 'n' | 'N' )
+        MAILDEL=2
+        ;;
       ( * )
         __usage
         _exit_with_error "The option '${OPT}' is unknown"


### PR DESCRIPTION
# Description

Added option to allow to delete email but do not delete email data without prompt using "-n", default and "-y" remains as is.
Its required for UI I made and I want to allow admin to delete email without deleting data.
https://gitlab.com/div-solutions/docker-mailserver-ui

## Type of change

- [X ] Improvement (non-breaking change that does improve existing functionality)
- [X] This change requires a documentation update

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
