### PR TITLE
fix: Postfix: `disable_dns_lookups` => `smtp_dns_support_level`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file. The format 
     - `step` CLI from `0.28.2` to [`0.28.7`](https://github.com/smallstep/cli/releases/tag/v0.28.7))
 - **Dovecot**
   - Updated the FTS plugin Xapian from `1.9` to [`1.9.1`](https://github.com/grosjo/fts-xapian/releases/tag/1.9.1) which adds Dovecot 2.4 compatibility ([#4557](https://github.com/docker-mailserver/docker-mailserver/pull/4557))
+- **Postfix**
+  - Replaced `disable_dns_lookups` with `smtp_dns_support_level` in Amavis configuration ([#4568](https://github.com/docker-mailserver/docker-mailserver/pull/4568))
 
 ## [v15.1.0](https://github.com/docker-mailserver/docker-mailserver/compare/v15.1.0...HEAD)
 

--- a/target/amavis/postfix-amavis.cf
+++ b/target/amavis/postfix-amavis.cf
@@ -7,7 +7,7 @@ smtp-amavis     unix    -       -       n       -       2       smtp
   -o syslog_name=postfix/$service_name
   -o smtp_data_done_timeout=1200
   -o smtp_send_xforward_command=yes
-  -o disable_dns_lookups=yes
+  -o smtp_dns_support_level=disabled
   -o max_use=20
   -o smtp_tls_security_level=none
   -o smtp_tls_wrappermode=no


### PR DESCRIPTION
see <https://www.postfix.org/postconf.5.html#disable_dns_lookups>

# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->
Replaces the deprected option `disable_dns_lookups` with `smtp_dns_support_level`. This option was deprecated since Postfix 2.11.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary, I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
