### PR TITLE
fix RSPAMD_LEARN with mbsync

### DIFF
--- a/target/scripts/startup/setup.d/security/rspamd.sh
+++ b/target/scripts/startup/setup.d/security/rspamd.sh
@@ -229,13 +229,13 @@ function __rspamd__setup_learning() {
 
   # From anywhere to Junk
   imapsieve_mailbox1_name = Junk
-  imapsieve_mailbox1_causes = COPY
+  imapsieve_mailbox1_causes = COPY APPEND
   imapsieve_mailbox1_before = file:${SIEVE_PIPE_BIN_DIR}/learn-spam.sieve
 
   # From Junk to Inbox
   imapsieve_mailbox2_name = INBOX
   imapsieve_mailbox2_from = Junk
-  imapsieve_mailbox2_causes = COPY
+  imapsieve_mailbox2_causes = COPY APPEND
   imapsieve_mailbox2_before = file:${SIEVE_PIPE_BIN_DIR}/learn-ham.sieve
 }
 EOF


### PR DESCRIPTION
# Description
So I had an issue - RSPAMD_LEARN functionality didn't work with my mbsync/aerc setup. Turns out, mbsync uses APPEND instead of COPY to copy emails, so it didn't trigger those sieve scripts in my case. 

This adds APPEND to the list of operations, that trigger sieve scripts.

I have tested this and it works.

## Type of change
<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

Do we need to add this to CHANGELOG.md?