### PR TITLE
fix: update permissions check to invoke `chown` directly on returned paths of `find`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Breaking
 
-- **Rspamd:**
-  - `setup config dkim` now writes keys as `<domain>-<selector>.private` (previously `<keytype>-<keysize>-<selector>-<domain>.private.txt`). The default `dkim_signing.conf` uses a `$domain-$selector` path template with `try_fallback = true`, so multiple domains share one config. Existing `dkim_signing.conf` files are not overwritten. Rename keys to the new layout if you regenerate them (OpenDKIM: `opendkim/keys/<domain>/<selector>.private` → `rspamd/dkim/<domain>-<selector>.private`). ([#4653](https://github.com/docker-mailserver/docker-mailserver/pull/4653))
-
-### Updated
-
 - **Rspamd**
+  - `setup config dkim` now writes keys as `<domain>-<selector>.private` (previously `<keytype>-<keysize>-<selector>-<domain>.private.txt`). The default `dkim_signing.conf` uses a `$domain-$selector` path template with `try_fallback = true`, so multiple domains share one config. Existing `dkim_signing.conf` files are not overwritten. Rename keys to the new layout if you regenerate them (OpenDKIM: `opendkim/keys/<domain>/<selector>.private` → `rspamd/dkim/<domain>-<selector>.private`). ([#4653](https://github.com/docker-mailserver/docker-mailserver/pull/4653))
   - `setup config dkim` writes a persisted `dkim_selectors.map` for custom selectors. Documentation covers multi-domain setup, OpenDKIM migration, and Ed25519 + RSA fallback (distinct selectors plus a `selectors` array). ([#4653](https://github.com/docker-mailserver/docker-mailserver/pull/4653))
+
+### Fixed
+
+- **Internal**
+  - `/var/mail` permission repair now runs `chown -R` only on paths `find` reports as mismatched (within `-maxdepth 3`), instead of `chown -R` on the entire tree. Account creation sets ownership on new mailbox `home/` and copied sieve files so change detection no longer needs to scan `/var/mail` ([#4696](https://github.com/docker-mailserver/docker-mailserver/pull/4696), [#4112](https://github.com/docker-mailserver/docker-mailserver/issues/4112))
 
 ## [v16.0.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v16.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 
 - **Internal**
-  - `/var/mail` permission repair now runs `chown -R` only on paths `find` reports as mismatched (within `-maxdepth 3`), instead of `chown -R` on the entire tree. Account creation sets ownership on new mailbox `home/` and copied sieve files so change detection no longer needs to scan `/var/mail` ([#4696](https://github.com/docker-mailserver/docker-mailserver/pull/4696), [#4112](https://github.com/docker-mailserver/docker-mailserver/issues/4112))
+  - `/var/mail` permission repair now runs `chown -R` only on paths `find` reports as mismatched (within `-maxdepth 3`), instead of `chown -R` on the entire tree. Account creation sets ownership on the new mailbox directory (`mail_path`) so change detection no longer needs to scan `/var/mail` ([#4696](https://github.com/docker-mailserver/docker-mailserver/pull/4696), [#4112](https://github.com/docker-mailserver/docker-mailserver/issues/4112))
 
 ## [v16.0.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v16.0.0)
 

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -144,7 +144,7 @@ function _postfix_dovecot_changes() {
 
   # Legacy workaround handled here, only seems necessary for _create_accounts:
   # - `helpers/accounts.sh` logic creates folders/files with wrong ownership.
-  _chown_var_mail_if_necessary
+  _chown_var_mail
 }
 
 function _ssl_changes() {

--- a/target/scripts/check-for-changes.sh
+++ b/target/scripts/check-for-changes.sh
@@ -141,10 +141,6 @@ function _postfix_dovecot_changes() {
   [[ ${CHANGED} =~ ${DMS_DIR}/postfix-virtual.cf ]] && _handle_postfix_virtual_config
   [[ ${CHANGED} =~ ${DMS_DIR}/postfix-regexp.cf  ]] && _handle_postfix_regexp_config
   [[ ${CHANGED} =~ ${DMS_DIR}/postfix-aliases.cf ]] && _handle_postfix_aliases_config
-
-  # Legacy workaround handled here, only seems necessary for _create_accounts:
-  # - `helpers/accounts.sh` logic creates folders/files with wrong ownership.
-  _chown_var_mail
 }
 
 function _ssl_changes() {

--- a/target/scripts/helpers/accounts.sh
+++ b/target/scripts/helpers/accounts.sh
@@ -61,15 +61,17 @@ function _create_accounts() {
         echo "${DOVECOT_USERDB_LINE}" >>"${DOVECOT_USERDB_FILE}"
       fi
 
-      local MAILBOX_HOME="/var/mail/${DOMAIN}/${USER}/home"
+      # Dovecot mail_path is /var/mail/<domain>/<user> (mail_home is .../home).
+      local MAILBOX="/var/mail/${DOMAIN}/${USER}"
+      local MAILBOX_HOME="${MAILBOX}/home"
       mkdir -p "${MAILBOX_HOME}"
-      chown -- "${DMS_VMAIL_UID}:${DMS_VMAIL_GID}" "${MAILBOX_HOME}"
 
       # copy user provided sieve file, if present
       if [[ -e "/tmp/docker-mailserver/${LOGIN}.dovecot.sieve" ]]; then
         cp "/tmp/docker-mailserver/${LOGIN}.dovecot.sieve" "${MAILBOX_HOME}/.dovecot.sieve"
-        chown -- "${DMS_VMAIL_UID}:${DMS_VMAIL_GID}" "${MAILBOX_HOME}/.dovecot.sieve"
       fi
+
+      chown -R -- "${DMS_VMAIL_UID}:${DMS_VMAIL_GID}" "${MAILBOX}"
     done < <(_get_valid_lines_from_file "${DATABASE_ACCOUNTS}")
 
     _create_dovecot_alias_dummy_accounts

--- a/target/scripts/helpers/accounts.sh
+++ b/target/scripts/helpers/accounts.sh
@@ -61,11 +61,14 @@ function _create_accounts() {
         echo "${DOVECOT_USERDB_LINE}" >>"${DOVECOT_USERDB_FILE}"
       fi
 
-      mkdir -p "/var/mail/${DOMAIN}/${USER}/home"
+      local MAILBOX_HOME="/var/mail/${DOMAIN}/${USER}/home"
+      mkdir -p "${MAILBOX_HOME}"
+      chown -- "${DMS_VMAIL_UID}:${DMS_VMAIL_GID}" "${MAILBOX_HOME}"
 
       # copy user provided sieve file, if present
       if [[ -e "/tmp/docker-mailserver/${LOGIN}.dovecot.sieve" ]]; then
-        cp "/tmp/docker-mailserver/${LOGIN}.dovecot.sieve" "/var/mail/${DOMAIN}/${USER}/home/.dovecot.sieve"
+        cp "/tmp/docker-mailserver/${LOGIN}.dovecot.sieve" "${MAILBOX_HOME}/.dovecot.sieve"
+        chown -- "${DMS_VMAIL_UID}:${DMS_VMAIL_GID}" "${MAILBOX_HOME}/.dovecot.sieve"
       fi
     done < <(_get_valid_lines_from_file "${DATABASE_ACCOUNTS}")
 

--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -72,12 +72,10 @@ function _get_dms_env_value() {
 #
 # `helpers/accounts.sh:_create_accounts` (mkdir, cp) appears to be the only writer to
 # /var/mail folders (used during startup and change detection handling).
-function _chown_var_mail_if_necessary() {
-  # fix permissions, but skip this if 3 levels deep the user id is already set
-  if find /var/mail -maxdepth 3 -a \( \! -user "${DMS_VMAIL_UID}" -o \! -group "${DMS_VMAIL_GID}" \) | read -r; then
-    _log 'trace' 'Fixing /var/mail permissions'
-    chown -R "${DMS_VMAIL_UID}:${DMS_VMAIL_GID}" /var/mail || return 1
-  fi
+function _chown_var_mail() {
+  # if needed, fix permissions for all files and folders 3 levels deep /var/mail
+  log 'trace' 'Fixing /var/mail permissions'
+  find /var/mail -maxdepth 3 \( \! -user "${DMS_VMAIL_UID}" -o \! -group "${DMS_VMAIL_GID}" \) -exec chown "${DMS_VMAIL_UID}:${DMS_VMAIL_GID}" {} +
 }
 
 function _require_n_parameters_or_print_usage() {

--- a/target/scripts/helpers/utils.sh
+++ b/target/scripts/helpers/utils.sh
@@ -73,9 +73,9 @@ function _get_dms_env_value() {
 # `helpers/accounts.sh:_create_accounts` (mkdir, cp) appears to be the only writer to
 # /var/mail folders (used during startup and change detection handling).
 function _chown_var_mail() {
-  # if needed, fix permissions for all files and folders 3 levels deep /var/mail
-  log 'trace' 'Fixing /var/mail permissions'
-  find /var/mail -maxdepth 3 \( \! -user "${DMS_VMAIL_UID}" -o \! -group "${DMS_VMAIL_GID}" \) -exec chown "${DMS_VMAIL_UID}:${DMS_VMAIL_GID}" {} +
+  # Fix ownership of mismatched paths within 3 levels of /var/mail, recursively.
+  _log 'trace' 'Fixing /var/mail permissions'
+  find /var/mail -maxdepth 3 \( \! -user "${DMS_VMAIL_UID}" -o \! -group "${DMS_VMAIL_GID}" \) -exec chown -R -- "${DMS_VMAIL_UID}:${DMS_VMAIL_GID}" {} +
 }
 
 function _require_n_parameters_or_print_usage() {

--- a/target/scripts/startup/setup-stack.sh
+++ b/target/scripts/startup/setup-stack.sh
@@ -90,7 +90,7 @@ function _setup_directory_and_file_permissions() {
   touch /dev/shm/supervisor.sock
 
   _log 'debug' 'Checking /var/mail permissions'
-  if ! _chown_var_mail_if_necessary; then
+  if ! _chown_var_mail; then
     _dms_panic__general 'Failed to fix /var/mail permissions'
   fi
 


### PR DESCRIPTION
# Description

As stated in #4112, this avoids running chown on a huge number of files and folders by directly using it on the results of the `find` command.

I renamed the function to omit the `_if_necessary` parts as it is not possible anymore to check when find triggers a chown or not. I am not sure if it would be useful to know this information anyway.

Note: The function does not return 1 in case of error anymore. I guess we should reimplement that before merging.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
