### PR TITLE
fix: `Dockerfile` - Build `dovecot-fts-xapian` package from debian sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. The format 
 - **Internal:**
   - `ENABLE_QUOTAS=1` - When an alias has multiple addresses, the first local mailbox address found will be used for the Dovecot dummy account workaround ([#4581](https://github.com/docker-mailserver/docker-mailserver/pull/4581))
   - Change Detection service - Added support for responding to updated DMS config (_Rspamd and TLS certificates_) to `ACCOUNT_PROVISIONER=LDAP` ([#4627](https://github.com/docker-mailserver/docker-mailserver/pull/4627))
+  - Build for Dovecot Full Text Search now uses the debian source files (#4700)
 - **Tests:**
   - Make the helper method `_get_container_ip()` compatible with Docker 29 ([#4606](https://github.com/docker-mailserver/docker-mailserver/pull/4606))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file. The format 
 - **Internal:**
   - `ENABLE_QUOTAS=1` - When an alias has multiple addresses, the first local mailbox address found will be used for the Dovecot dummy account workaround ([#4581](https://github.com/docker-mailserver/docker-mailserver/pull/4581))
   - Change Detection service - Added support for responding to updated DMS config (_Rspamd and TLS certificates_) to `ACCOUNT_PROVISIONER=LDAP` ([#4627](https://github.com/docker-mailserver/docker-mailserver/pull/4627))
-  - Build for Dovecot Full Text Search now uses the debian source files (#4700)
+  - The `Dockerfile` has changed the source of `dovecot-fts-xapian` package from the [upstream Github repo source](https://github.com/grosjo/fts-xapian) (_which is presently unaccessible_) to instead use the [Debian package source files](https://deb.debian.org/debian/pool/main/d/dovecot-fts-xapian/) (#4700)
 - **Tests:**
   - Make the helper method `_get_container_ip()` compatible with Docker 29 ([#4606](https://github.com/docker-mailserver/docker-mailserver/pull/4606))
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,11 @@ ARG LOG_LEVEL
 ARG DEBIAN_FRONTEND
 
 COPY target/scripts/build/compile.sh /build/
+# When absolutely necessary DMS carries support to compile `.deb` packages of software:
+# - `dovecot-fts-xapian` for compatibility with the Dovecot CE `dovecot-core` package:
+#   https://github.com/docker-mailserver/docker-mailserver/pull/3373
+FROM stage-base AS stage-compile
+COPY target/scripts/build/compile.sh /build/
 RUN /bin/bash /build/compile.sh
 
 #
@@ -81,9 +86,9 @@ EOF
 # -----------------------------------------------
 
 # install fts_xapian plugin
-
-COPY --from=stage-compile dovecot-fts-xapian_*.deb /
-RUN dpkg -i /dovecot-fts-xapian_*.deb && rm /dovecot-fts-xapian_*.deb
+# Install compiled `dovecot-fts-xapian` package:
+RUN --mount=type=bind,from=stage-compile,target=/mnt/stage-compile/ \
+  dpkg -i /mnt/stage-compile/dovecot-fts-xapian_*.deb
 
 COPY target/dovecot/*.inc target/dovecot/*.conf /etc/dovecot/conf.d/
 COPY target/dovecot/dovecot-purge.cron /etc/cron.d/dovecot-purge.disabled

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,6 @@ RUN /bin/bash /build/packages.sh && rm -r /build
 # --- Compile deb packages ----------------------
 # -----------------------------------------------
 
-FROM stage-base AS stage-compile
-
-ARG LOG_LEVEL
-ARG DEBIAN_FRONTEND
-
 # When absolutely necessary DMS carries support to compile `.deb` packages of software:
 # - `dovecot-fts-xapian` for compatibility with the Dovecot CE `dovecot-core` package:
 #   https://github.com/docker-mailserver/docker-mailserver/pull/3373
@@ -51,12 +46,7 @@ RUN /bin/bash /build/compile.sh
 #
 
 FROM stage-base AS stage-main
-
-ARG DEBIAN_FRONTEND
-ARG LOG_LEVEL
-
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
-
 
 # -----------------------------------------------
 # --- ClamAV & FeshClam -------------------------
@@ -84,7 +74,6 @@ EOF
 # --- Dovecot -----------------------------------
 # -----------------------------------------------
 
-# install fts_xapian plugin
 # Install compiled `dovecot-fts-xapian` package:
 RUN --mount=type=bind,from=stage-compile,target=/mnt/stage-compile/ \
   dpkg -i /mnt/stage-compile/dovecot-fts-xapian_*.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,8 @@ EOF
 
 # install fts_xapian plugin
 
-COPY --from=stage-compile dovecot-fts-xapian-*.deb /
-RUN dpkg -i /dovecot-fts-xapian-*.deb && rm /dovecot-fts-xapian-*.deb
+COPY --from=stage-compile dovecot-fts-xapian_*.deb /
+RUN dpkg -i /dovecot-fts-xapian_*.deb && rm /dovecot-fts-xapian_*.deb
 
 COPY target/dovecot/*.inc target/dovecot/*.conf /etc/dovecot/conf.d/
 COPY target/dovecot/dovecot-purge.cron /etc/cron.d/dovecot-purge.disabled

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ FROM stage-base AS stage-compile
 ARG LOG_LEVEL
 ARG DEBIAN_FRONTEND
 
-COPY target/scripts/build/compile.sh /build/
 # When absolutely necessary DMS carries support to compile `.deb` packages of software:
 # - `dovecot-fts-xapian` for compatibility with the Dovecot CE `dovecot-core` package:
 #   https://github.com/docker-mailserver/docker-mailserver/pull/3373

--- a/target/scripts/build/compile.sh
+++ b/target/scripts/build/compile.sh
@@ -25,11 +25,6 @@ function _build_package() {
   cd "fts-xapian-${XAPIAN_VERSION}"
 
   # Prepare for building DEB source package:
-  # https://manpages.debian.org/bookworm/dh-make/dh_make.1.en.html
-  # License LGPL 2.1: https://github.com/grosjo/fts-xapian/issues/174#issuecomment-2422404568
-  USER=root dh_make --packagename "dovecot-fts-xapian-${XAPIAN_VERSION}" --single --native --copyright lgpl2 -y
-  # Remove generated example files:
-  rm debian/*.ex
   # Add required package metadata:
   # https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#control
   curl -fsSL "http://deb.debian.org/debian/pool/main/d/dovecot-fts-xapian/dovecot-fts-xapian_${XAPIAN_DEBIAN_VERSION}.debian.tar.xz" | tar -xJ

--- a/target/scripts/build/compile.sh
+++ b/target/scripts/build/compile.sh
@@ -20,14 +20,14 @@ function _install_build_deps() {
 function _build_package() {
   local XAPIAN_DEBIAN_VERSION='1.9.1-1~bpo12+1'
   local XAPIAN_VERSION="${XAPIAN_DEBIAN_VERSION%-*}"
-  curl -fsSL "http://deb.debian.org/debian/pool/main/d/dovecot-fts-xapian/dovecot-fts-xapian_${XAPIAN_VERSION}.orig.tar.gz" \
+  curl -fsSL "https://deb.debian.org/debian/pool/main/d/dovecot-fts-xapian/dovecot-fts-xapian_${XAPIAN_VERSION}.orig.tar.gz" \
     | tar -xz
   cd "fts-xapian-${XAPIAN_VERSION}"
 
   # Prepare for building DEB source package:
   # Add required package metadata:
   # https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#control
-  curl -fsSL "http://deb.debian.org/debian/pool/main/d/dovecot-fts-xapian/dovecot-fts-xapian_${XAPIAN_DEBIAN_VERSION}.debian.tar.xz" | tar -xJ
+  curl -fsSL "https://deb.debian.org/debian/pool/main/d/dovecot-fts-xapian/dovecot-fts-xapian_${XAPIAN_DEBIAN_VERSION}.debian.tar.xz" | tar -xJ
 
   # Build arch specific binary package via debuild:
   # https://manpages.debian.org/bookworm/devscripts/debuild.1.en.html

--- a/target/scripts/build/compile.sh
+++ b/target/scripts/build/compile.sh
@@ -18,8 +18,9 @@ function _install_build_deps() {
 }
 
 function _build_package() {
-  local XAPIAN_VERSION='1.9.1'
-  curl -fsSL "https://github.com/grosjo/fts-xapian/releases/download/${XAPIAN_VERSION}/dovecot-fts-xapian-${XAPIAN_VERSION}.tar.gz" \
+  local XAPIAN_DEBIAN_VERSION='1.9.1-1~bpo12+1'
+  local XAPIAN_VERSION="${XAPIAN_DEBIAN_VERSION%-*}"
+  curl -fsSL "http://deb.debian.org/debian/pool/main/d/dovecot-fts-xapian/dovecot-fts-xapian_${XAPIAN_VERSION}.orig.tar.gz" \
     | tar -xz
   cd "fts-xapian-${XAPIAN_VERSION}"
 
@@ -31,13 +32,7 @@ function _build_package() {
   rm debian/*.ex
   # Add required package metadata:
   # https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#control
-  curl -fsSL https://raw.githubusercontent.com/grosjo/fts-xapian/refs/tags/1.7.16/PACKAGES/DEB/control > debian/control
-  # Replace version number:
-  sed -i -E "s|(dovecot-fts-xapian)-[1-9\.-]+|\1-${XAPIAN_VERSION}|g" debian/control
-  # Required to proceed with debuild:
-  # https://www.debian.org/doc/manuals/maint-guide/dother.en.html#compat
-  # (13 is the default debhelper version from the original `dh_make` generated `debian/control`):
-  echo '13' > debian/compat
+  curl -fsSL "http://deb.debian.org/debian/pool/main/d/dovecot-fts-xapian/dovecot-fts-xapian_${XAPIAN_DEBIAN_VERSION}.debian.tar.xz" | tar -xJ
 
   # Build arch specific binary package via debuild:
   # https://manpages.debian.org/bookworm/devscripts/debuild.1.en.html


### PR DESCRIPTION


# Description

the github profile of grosjo is gone (404) so we cannot download from there anymore and with this we use the source package from debian (backports)

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #4699 

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**

Info @wt-io-it
