### PR TITLE
feat: add `dms-healthcheck` script for container health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. The format 
   - `ENABLE_QUOTAS=1` - When an alias has multiple addresses, the first local mailbox address found will be used for the Dovecot dummy account workaround ([#4581](https://github.com/docker-mailserver/docker-mailserver/pull/4581))
   - Change Detection service - Added support for responding to updated DMS config (_Rspamd and TLS certificates_) to `ACCOUNT_PROVISIONER=LDAP` ([#4627](https://github.com/docker-mailserver/docker-mailserver/pull/4627))
   - The `Dockerfile` has changed the source of `dovecot-fts-xapian` package from the [upstream Github repo source](https://github.com/grosjo/fts-xapian) (_which is presently unaccessible_) to instead use the [Debian package source files](https://deb.debian.org/debian/pool/main/d/dovecot-fts-xapian/) (#4700)
+  - Improved service healthcheck capabilities to validate against the services the running instance has actually enabled. Pre-requiste to resolve an outstanding edge case from [docker-mailserver-helm](https://github.com/docker-mailserver/docker-mailserver-helm/pull/135) ([#4706](https://github.com/docker-mailserver/docker-mailserver/pull/4706)) 
 - **Tests:**
   - Make the helper method `_get_container_ip()` compatible with Docker 29 ([#4606](https://github.com/docker-mailserver/docker-mailserver/pull/4606))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ All notable changes to this project will be documented in this file. The format 
   - `ENABLE_QUOTAS=1` - When an alias has multiple addresses, the first local mailbox address found will be used for the Dovecot dummy account workaround ([#4581](https://github.com/docker-mailserver/docker-mailserver/pull/4581))
   - Change Detection service - Added support for responding to updated DMS config (_Rspamd and TLS certificates_) to `ACCOUNT_PROVISIONER=LDAP` ([#4627](https://github.com/docker-mailserver/docker-mailserver/pull/4627))
   - The `Dockerfile` has changed the source of `dovecot-fts-xapian` package from the [upstream Github repo source](https://github.com/grosjo/fts-xapian) (_which is presently unaccessible_) to instead use the [Debian package source files](https://deb.debian.org/debian/pool/main/d/dovecot-fts-xapian/) (#4700)
-  - Improved service healthcheck capabilities to validate against the services the running instance has actually enabled. Pre-requiste to resolve an outstanding edge case from [docker-mailserver-helm](https://github.com/docker-mailserver/docker-mailserver-helm/pull/135) ([#4706](https://github.com/docker-mailserver/docker-mailserver/pull/4706)) 
+  - Added the command `dms-healthcheck` to ease implementing a healthcheck for services enabled in DMS. ([#4706](https://github.com/docker-mailserver/docker-mailserver/pull/4706))
+    - Includes a default [`HEALTHCHECK`](https://docs.docker.com/reference/dockerfile/#healthcheck) in the `Dockerfile` for container runtimes that support it.
+    - Runtimes like k8s or podman must configure a healthcheck explicitly. The DMS Helm chart (`docker-mailserver-helm`) will be [updated to use `dms-healthcheck`](https://github.com/docker-mailserver/docker-mailserver-helm/pull/135).
 - **Tests:**
   - Make the helper method `_get_container_ip()` compatible with Docker 29 ([#4606](https://github.com/docker-mailserver/docker-mailserver/pull/4606))
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -296,6 +296,10 @@ ENV POSTGREY_MAX_AGE=35
 ENV POSTGREY_TEXT="Delayed by Postgrey"
 ENV SASLAUTHD_MECH_OPTIONS=""
 
+# NOTE: This is not part of the OCI image spec (limited compatibility at runtime)
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD dms-healthcheck
+
 # Add metadata to image:
 LABEL org.opencontainers.image.title="docker-mailserver"
 LABEL org.opencontainers.image.vendor="The Docker Mailserver Organization"

--- a/Dockerfile
+++ b/Dockerfile
@@ -298,8 +298,7 @@ ENV SASLAUTHD_MECH_OPTIONS=""
 
 # NOTE: HEALTHCHECK is not part of the OCI image spec and should not be relied on.
 # Ensure it is either supported by your runtime or use this as an example for your deployment scenario (e.g., kubernetes livenessProbe etc)
-HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-  CMD dms-healthcheck
+HEALTHCHECK --start-period=30s CMD dms-healthcheck
 
 # Add metadata to image:
 LABEL org.opencontainers.image.title="docker-mailserver"

--- a/Dockerfile
+++ b/Dockerfile
@@ -296,7 +296,8 @@ ENV POSTGREY_MAX_AGE=35
 ENV POSTGREY_TEXT="Delayed by Postgrey"
 ENV SASLAUTHD_MECH_OPTIONS=""
 
-# NOTE: This is not part of the OCI image spec (limited compatibility at runtime)
+# NOTE: HEALTHCHECK is not part of the OCI image spec and should not be relied on.
+# Ensure it is either supported by your runtime or use this as an example for your deployment scenario (e.g., kubernetes livenessProbe etc)
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD dms-healthcheck
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -24,6 +24,7 @@ services:
     # Uncomment if using `ENABLE_FAIL2BAN=1`:
     # cap_add:
     #   - NET_ADMIN
-    healthcheck:
-      # Note that the docker image contains a HEALTHCHECK directive in the Dockerfile; the below is in case your runtime does not support it.
-      test: ["CMD", "dms-healthcheck"]
+    # NOTE: The container image configures a `HEALTHCHECK` internally.
+    # Docker Compose should default to using `dms-healthcheck`.
+    # healthcheck:
+    #   test: "ss --listening --ipv4 --tcp | grep --silent ':smtp' || exit 1"

--- a/compose.yaml
+++ b/compose.yaml
@@ -25,6 +25,5 @@ services:
     # cap_add:
     #   - NET_ADMIN
     healthcheck:
-      test: "ss --listening --ipv4 --tcp | grep --silent ':smtp' || exit 1"
-      timeout: 3s
-      retries: 0
+      # Note that the docker image contains a HEALTHCHECK directive in the Dockerfile; the below is in case your runtime does not support it.
+      test: ["CMD", "dms-healthcheck"]

--- a/target/bin/dms-healthcheck
+++ b/target/bin/dms-healthcheck
@@ -3,13 +3,12 @@
 # Verifies that all supervisor-managed services that should be running are in
 # the `RUNNING` state. Returns exit code `0` if all are healthy, otherwise `1`.
 
-# NOTE: There is an improvement opportunity, if identified in the future, to verify
-# service ports are also listening and operational. An example of this might look like:
-# `ss --listening --ipv4 --tcp | grep --silent ':smtp' || exit 1` or similar.
+# TODO: If beneficial, the script could additionally verify service ports have
+# listeners bound (`ss --listening --ipv4 --tcp | grep --silent ':smtp' || exit 1`)
 
 readonly DMS_SETTINGS='/etc/dms-settings'
 
-# Required to proceed (ensures awareness default enabled services):
+# Required to proceed (ensures awareness of default enabled services):
 [[ ! -f ${DMS_SETTINGS} ]] && exit 1
 
 # shellcheck source=/dev/null

--- a/target/bin/dms-healthcheck
+++ b/target/bin/dms-healthcheck
@@ -53,9 +53,12 @@ declare -a SERVICES=(
 [[ ${ENABLE_MTA_STS}      -eq 1 ]] && SERVICES+=('mta-sts-daemon')
 [[ ${ENABLE_SASLAUTHD}    -eq 1 ]] && SERVICES+=("saslauthd_${SASLAUTHD_MECHANISMS}")
 
+# shellcheck disable=SC2207
 [[ ${ENABLE_FETCHMAIL}    -eq 1 ]] && SERVICES+=(
   $(_get_services_for 'fetchmail' "${FETCHMAIL_PARALLEL}")
 )
+
+# shellcheck disable=SC2207
 [[ ${ENABLE_GETMAIL}      -eq 1 ]] && SERVICES+=(
   $(_get_services_for 'getmail' "${GETMAIL_PARALLEL}")
 )

--- a/target/bin/dms-healthcheck
+++ b/target/bin/dms-healthcheck
@@ -57,8 +57,6 @@ declare -a SERVICES=(
   $(_get_services_for 'getmail' "${GETMAIL_PARALLEL}")
 )
 
-# --- Verify all expected services are RUNNING ---
-
 # `supervisorctl status` reports RUNNING for STARTING/BACKOFF states too.
 # Extract the actual state of each service and verify they all reduce to
 # a single unique value: RUNNING.

--- a/target/bin/dms-healthcheck
+++ b/target/bin/dms-healthcheck
@@ -57,7 +57,7 @@ declare -a SERVICES=(
   $(_get_services_for 'getmail' "${GETMAIL_PARALLEL}")
 )
 
-# `supervisorctl status` reports RUNNING for STARTING/BACKOFF states too.
-# Extract the actual state of each service and verify they all reduce to
-# a single unique value: RUNNING.
+# Ensure all enabled services report a 'RUNNING' status.
+# - We cannot rely upon the exit status of `supervisorctl status` (due to `STARTING`/`BACKOFF`).
+# - Returns an exit status of `0` only when the 2nd column reduces to `RUNNING`.
 test 'RUNNING' = "$(supervisorctl status "${SERVICES[@]}" | awk '{print $2}' | sort -u)"

--- a/target/bin/dms-healthcheck
+++ b/target/bin/dms-healthcheck
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Health check for docker-mailserver.
+# Verifies that all supervisor-managed services that should be running are in
+# the `RUNNING` state. Returns exit code `0` if all are healthy, otherwise `1`.
+
+readonly DMS_SETTINGS='/etc/dms-settings'
+
+# The settings file is written near the end of container startup.
+# Until it exists the container is still initializing.
+if [[ ! -f ${DMS_SETTINGS} ]]; then
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+source "${DMS_SETTINGS}"
+
+# When FETCHMAIL_PARALLEL or GETMAIL_PARALLEL is enabled, numbered service
+# instances (e.g. fetchmail-1, fetchmail-2) are registered with supervisor
+# at runtime. Resolve a service name to the actual instance name(s).
+SERVICE_LIST=$(supervisorctl status | awk '{print $1}')
+
+function _get_services_for() {
+  local SERVICE_NAME=${1:?Service name required}
+  local IS_PARALLEL="${2:-0}"
+
+  if [[ ${IS_PARALLEL} -eq 1 ]]; then
+    grep -E "^${SERVICE_NAME}-[0-9]+$" <<< "${SERVICE_LIST}"
+  else
+    echo "${SERVICE_NAME}"
+  fi
+}
+
+# --- Build expected service list ---
+
+# Core services that are always expected to be running:
+declare -a SERVICES=(
+  'cron'
+  'rsyslog'
+  'postfix'
+  'changedetector'
+)
+
+# Conditional services based on enabled features:
+[[ ${SMTP_ONLY}           -ne 1 ]] && SERVICES+=('dovecot')
+[[ ${ENABLE_OPENDKIM}     -eq 1 ]] && SERVICES+=('opendkim')
+[[ ${ENABLE_OPENDMARC}    -eq 1 ]] && SERVICES+=('opendmarc')
+[[ ${ENABLE_AMAVIS}       -eq 1 ]] && SERVICES+=('amavis')
+[[ ${ENABLE_CLAMAV}       -eq 1 ]] && SERVICES+=('clamav')
+[[ ${ENABLE_FAIL2BAN}     -eq 1 ]] && SERVICES+=('fail2ban')
+[[ ${ENABLE_POSTGREY}     -eq 1 ]] && SERVICES+=('postgrey')
+[[ ${ENABLE_SRS}          -eq 1 ]] && SERVICES+=('postsrsd')
+[[ ${ENABLE_RSPAMD_REDIS} -eq 1 ]] && SERVICES+=('rspamd-redis')
+[[ ${ENABLE_RSPAMD}       -eq 1 ]] && SERVICES+=('rspamd')
+[[ ${ENABLE_MTA_STS}      -eq 1 ]] && SERVICES+=('mta-sts-daemon')
+[[ ${ENABLE_SASLAUTHD}    -eq 1 ]] && SERVICES+=("saslauthd_${SASLAUTHD_MECHANISMS}")
+
+[[ ${ENABLE_FETCHMAIL}    -eq 1 ]] && SERVICES+=(
+  $(_get_services_for 'fetchmail' "${FETCHMAIL_PARALLEL}")
+)
+[[ ${ENABLE_GETMAIL}      -eq 1 ]] && SERVICES+=(
+  $(_get_services_for 'getmail' "${GETMAIL_PARALLEL:-0}")
+)
+
+# --- Verify all expected services are RUNNING ---
+
+# `supervisorctl status` reports RUNNING for STARTING/BACKOFF states too.
+# Extract the actual state of each service and verify they all reduce to
+# a single unique value: RUNNING.
+test 'RUNNING' = "$(supervisorctl status "${SERVICES[@]}" | awk '{print $2}' | sort -u)"

--- a/target/bin/dms-healthcheck
+++ b/target/bin/dms-healthcheck
@@ -6,11 +6,8 @@
 
 readonly DMS_SETTINGS='/etc/dms-settings'
 
-# The settings file is written near the end of container startup.
-# Until it exists the container is still initializing.
-if [[ ! -f ${DMS_SETTINGS} ]]; then
-  exit 1
-fi
+# Required to proceed (ensures awareness default enabled services):
+[[ ! -f ${DMS_SETTINGS} ]] && exit 1
 
 # shellcheck source=/dev/null
 source "${DMS_SETTINGS}"

--- a/target/bin/dms-healthcheck
+++ b/target/bin/dms-healthcheck
@@ -28,8 +28,6 @@ function _get_services_for() {
   fi
 }
 
-# --- Build expected service list ---
-
 # Core services that are always expected to be running:
 declare -a SERVICES=(
   'cron'

--- a/target/bin/dms-healthcheck
+++ b/target/bin/dms-healthcheck
@@ -59,7 +59,7 @@ declare -a SERVICES=(
   $(_get_services_for 'fetchmail' "${FETCHMAIL_PARALLEL}")
 )
 [[ ${ENABLE_GETMAIL}      -eq 1 ]] && SERVICES+=(
-  $(_get_services_for 'getmail' "${GETMAIL_PARALLEL:-0}")
+  $(_get_services_for 'getmail' "${GETMAIL_PARALLEL}")
 )
 
 # --- Verify all expected services are RUNNING ---

--- a/target/bin/dms-healthcheck
+++ b/target/bin/dms-healthcheck
@@ -12,11 +12,11 @@ readonly DMS_SETTINGS='/etc/dms-settings'
 # shellcheck source=/dev/null
 source "${DMS_SETTINGS}"
 
-# When FETCHMAIL_PARALLEL or GETMAIL_PARALLEL is enabled, numbered service
-# instances (e.g. fetchmail-1, fetchmail-2) are registered with supervisor
-# at runtime. Resolve a service name to the actual instance name(s).
 SERVICE_LIST=$(supervisorctl status | awk '{print $1}')
 
+# Support for `IMAP IDLE` (via ENV `FETCHMAIL_PARALLEL` / `GETMAIL_PARALLEL`):
+# This feature requires multiple instances of a service managed by supervisord.
+# Filter the service list for a numbered suffix of the service name.
 function _get_services_for() {
   local SERVICE_NAME=${1:?Service name required}
   local IS_PARALLEL="${2:-0}"

--- a/target/bin/dms-healthcheck
+++ b/target/bin/dms-healthcheck
@@ -3,8 +3,9 @@
 # Verifies that all supervisor-managed services that should be running are in
 # the `RUNNING` state. Returns exit code `0` if all are healthy, otherwise `1`.
 
-# TODO: If beneficial, the script could additionally verify service ports have
-# listeners bound (`ss --listening --ipv4 --tcp | grep --silent ':smtp' || exit 1`)
+# TODO: The script could also verify that service ports have listeners bound (if justified).
+# Implementation approach was discussed with two examples for checking port 25 here:
+# https://github.com/docker-mailserver/docker-mailserver/pull/4706#discussion_r3344258001
 
 readonly DMS_SETTINGS='/etc/dms-settings'
 

--- a/target/bin/dms-healthcheck
+++ b/target/bin/dms-healthcheck
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-# Health check for docker-mailserver.
 # Verifies that all supervisor-managed services that should be running are in
 # the `RUNNING` state. Returns exit code `0` if all are healthy, otherwise `1`.
+
+# NOTE: There is an improvement opportunity, if identified in the future, to verify
+# service ports are also listening and operational. An example of this might look like:
+# `ss --listening --ipv4 --tcp | grep --silent ':smtp' || exit 1` or similar.
 
 readonly DMS_SETTINGS='/etc/dms-settings'
 


### PR DESCRIPTION
## Summary

Adds a new `dms-healthcheck` script to `target/bin/` that performs an intelligent health check by querying `supervisorctl` only for services that are actually enabled in the current DMS installation.

The script sources `/etc/dms-settings` (written during container startup) to determine which optional features are enabled, then checks that all corresponding supervisor-managed services are in the `RUNNING` state. `supervisorctl status` returns exit code `0` only when all named services are running — any non-running service results in a non-zero exit, which container runtimes (Docker, Kubernetes) correctly interpret as unhealthy.

If `/etc/dms-settings` does not yet exist, the container is still initializing and the check exits non-zero immediately to avoid false positives during startup.

## Covered Services

| Service | Condition |
|---|---|
| `cron`, `rsyslog`, `postfix`, `changedetector` | Always |
| `dovecot` | `SMTP_ONLY != 1` |
| `opendkim` | `ENABLE_OPENDKIM=1` |
| `opendmarc` | `ENABLE_OPENDMARC=1` |
| `amavis` | `ENABLE_AMAVIS=1` |
| `clamav` | `ENABLE_CLAMAV=1` |
| `fail2ban` | `ENABLE_FAIL2BAN=1` |
| `postgrey` | `ENABLE_POSTGREY=1` |
| `postsrsd` | `ENABLE_SRS=1` |
| `rspamd-redis` | `ENABLE_RSPAMD_REDIS=1` |
| `rspamd` | `ENABLE_RSPAMD=1` |
| `getmail` | `ENABLE_GETMAIL=1` |
| `mta-sts-daemon` | `ENABLE_MTA_STS=1` |
| `saslauthd_ldap` / `saslauthd_rimap` | `ENABLE_SASLAUTHD=1` |
| `fetchmail` / `fetchmail-N` | `ENABLE_FETCHMAIL=1` (parallel-aware) |

## Changes

- **`target/bin/dms-healthcheck`** — new script (installed to `/usr/local/bin/` via existing `COPY target/bin/*` in Dockerfile)
- **`Dockerfile`** — adds `HEALTHCHECK` directive using the new script
- **`compose.yaml`** — updates `healthcheck` from the basic SMTP port check to use `dms-healthcheck`

## Motivation

Discussed in [docker-mailserver-helm #135](https://github.com/docker-mailserver/docker-mailserver-helm/pull/135#discussion_r1748971741) by @polarathene — the Helm chart currently embeds probe logic that needs to know which services are enabled, but this belongs upstream in DMS itself. With this script, external orchestrators can simply call `dms-healthcheck` as their probe command without needing to replicate any of this logic.
