### PR TITLE
fix(pflogsumm): Prevent incorrect stats when log retention is > 1 year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file. The format 
   - The `Dockerfile` has changed the source of `dovecot-fts-xapian` package from the [upstream Github repo source](https://github.com/grosjo/fts-xapian) (_which is presently unaccessible_) to instead use the [Debian package source files](https://deb.debian.org/debian/pool/main/d/dovecot-fts-xapian/) (#4700)
 - **Tests:**
   - Make the helper method `_get_container_ip()` compatible with Docker 29 ([#4606](https://github.com/docker-mailserver/docker-mailserver/pull/4606))
+- **Pflogsumm:**
+  - Fix wrong daily reporting when mail log retention is greater than one year ([#4709](https://github.com/docker-mailserver/docker-mailserver/pull/4709))
 
 ### Removed
 

--- a/target/bin/report-pflogsumm-yesterday
+++ b/target/bin/report-pflogsumm-yesterday
@@ -14,7 +14,7 @@ SENDER=${3}
 [[ -x /usr/sbin/pflogsumm ]] || _exit_with_error "'/usr/sbin/pflogsumm' not found or executable"
 
 # shellcheck disable=SC2046
-BODY=$(gzip -cdfq $(ls -tr /var/log/mail/mail.log*) | /usr/sbin/pflogsumm --problems_first -d yesterday)
+BODY=$(gzip -cdfq $(find /var/log/mail -type f -name 'mail.log*' -mtime -180 | sort -rV) | /usr/sbin/pflogsumm --problems_first -d yesterday)
 
 sendmail -t <<EOF
 From: ${SENDER}


### PR DESCRIPTION


# Description

I have configured mail log retention to be several years instead of default. Recently, I started to notice unusually high daily volume in the report produced by pflogsumm. After investigation, it appears that the wrapper currently unextract all log files in log folder without considering their age.
So If the log retention for the mailserver is greater than one year, pflogsumm will process files from more 1 year ago, and since the log file only contains the day, it will consider these files as if they were from yesterday, producing incorrect reports.

With this modification, only log files < 180 days will be sent to pflogsumm for processing.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
