### PR TITLE
fix(pflogsumm): simplify and process necessary files only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file. The format 
 - **Tests:**
   - Make the helper method `_get_container_ip()` compatible with Docker 29 ([#4606](https://github.com/docker-mailserver/docker-mailserver/pull/4606))
 - **Pflogsumm:**
-  - Fix wrong daily reporting when mail log retention is greater than one year ([#4709](https://github.com/docker-mailserver/docker-mailserver/pull/4709))
+  - Fix wrong daily reporting when mail log retention is greater than one year ([#4709](https://github.com/docker-mailserver/docker-mailserver/pull/4709), [#4722](https://github.com/docker-mailserver/docker-mailserver/pull/4722))
 
 ### Removed
 

--- a/target/bin/report-pflogsumm-yesterday
+++ b/target/bin/report-pflogsumm-yesterday
@@ -13,8 +13,9 @@ SENDER=${3}
 
 [[ -x /usr/sbin/pflogsumm ]] || _exit_with_error "'/usr/sbin/pflogsumm' not found or executable"
 
-# shellcheck disable=SC2046
-BODY=$(gzip -cdfq $(find /var/log/mail -type f -name 'mail.log*' -mtime -180 | sort -rV) | /usr/sbin/pflogsumm --problems_first -d yesterday)
+# `pflogsumm` expects files in chronological order, while for `-d yesterday`
+# the only relevant log files to process are `mail.log.1` (oldest) and `mail.log`:
+BODY=$(/usr/sbin/pflogsumm --problems_first -d yesterday /var/log/mail/mail.log{.1,})
 
 sendmail -t <<EOF
 From: ${SENDER}


### PR DESCRIPTION
This fixes commit d15b4468666bb5a6297c626d01cbaee86048aced intronduced with PR #4709 which added 6 months worth of log files when only 2 days are necessary

# Description

This reduces pflogsumm processing to last 2 logs files (mail.log and mail.log.1), as suggested by @polarathene

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #4709 

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
