### PR TITLE
fix(opendkim): remove stray `<Paste>` from `OmitHeaders`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ All notable changes to this project will be documented in this file. The format 
 - **Rspamd:**
   - Configuration changes now trigger a service reload instead of a restart ([#4632](https://github.com/docker-mailserver/docker-mailserver/pull/4632))
   - `expand_keys = true` has been removed from the Redis configuration ([#4689](https://github.com/docker-mailserver/docker-mailserver/pull/4689))
+- **OpenDKIM:**
+  - The `OmitHeaders` setting no longer ends with a stray `<Paste>` string. The final entry parsed as a header named `DKIM-Signature<Paste>`, so `DKIM-Signature` was never actually omitted ([#4750](https://github.com/docker-mailserver/docker-mailserver/issues/4750))
 - **Internal:**
   - `ENABLE_QUOTAS=1` - When an alias has multiple addresses, the first local mailbox address found will be used for the Dovecot dummy account workaround ([#4581](https://github.com/docker-mailserver/docker-mailserver/pull/4581))
   - Change Detection service - Added support for responding to updated DMS config (_Rspamd and TLS certificates_) to `ACCOUNT_PROVISIONER=LDAP` ([#4627](https://github.com/docker-mailserver/docker-mailserver/pull/4627))

--- a/target/opendkim/opendkim.conf
+++ b/target/opendkim/opendkim.conf
@@ -20,4 +20,4 @@ SignatureAlgorithm      rsa-sha256
 UserID                  opendkim:opendkim
 
 Socket                  inet:8891@localhost
-OmitHeaders             Message-ID, Date, Return-Path, Bounces-To, Received, Comments, Keywords, Bcc, Resent-Bcc, List-ID, List-Unsubscribe, DKIM-Signature<Paste>
+OmitHeaders             Message-ID, Date, Return-Path, Bounces-To, Received, Comments, Keywords, Bcc, Resent-Bcc, List-ID, List-Unsubscribe, DKIM-Signature


### PR DESCRIPTION
# Description

`target/opendkim/opendkim.conf` ended its `OmitHeaders` line with the literal string `<Paste>` — a bracketed-paste escape artifact that was committed by accident in 0290eca7 ("Added DKIM compatibility with AWS SES", 2017-01-11) and carried through every edit since, including c26d02a9 (2017-12-18).

The final list entry therefore parsed as a header named `DKIM-Signature<Paste>`, which matches nothing, so `DKIM-Signature` was never actually omitted from the signed header set — the opposite of what the line intends.

To be clear about the scope: the practical impact is small. `RemoveOldSignatures Yes` a few lines above strips an existing signature before signing, so there is normally nothing left for the non-omission to include. This is a correctness fix to a config file that people read and copy, not a fix for a live delivery defect.

Before:

```console
$ docker run --rm ghcr.io/docker-mailserver/docker-mailserver:15 grep OmitHeaders /etc/opendkim.conf
OmitHeaders  ... List-Unsubscribe, DKIM-Signature<Paste>
```

The string occurs exactly once in the repository; nothing else references it.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #4750

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas <!-- n/a: a six-character deletion in a config file -->
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`) <!-- n/a: the setting is not documented; only CHANGELOG.md updated -->
- [x] If necessary, I have added tests that prove my fix is effective or that my feature works <!-- n/a: no test asserts on this line, and the change is a literal typo removal -->
- [ ] New and existing unit tests pass locally with my changes <!-- not run: the change is a six-character deletion in a static config file with no test coverage; happy to run the suite if you would like it -->
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**

---

*Disclosure: this change was prepared with AI assistance, as with the issue it fixes. The commit archaeology cited above is reproducible with `git log -L23,23:target/opendkim/opendkim.conf`.*
