### PR TITLE
fix: re-enable `quota_status_nouser = DUNNO`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 
+- **Dovecot**
+  - `ENABLE_QUOTAS=1` no longer rejects aliases that forward to external addresses. Restored the `quota_status_*` responses dropped during the Dovecot 2.3 to 2.4 migration ([#4767](https://github.com/docker-mailserver/docker-mailserver/issues/4767))
+
 - **Internal**
   - `/var/mail` permission repair now runs `chown -R` only on paths `find` reports as mismatched (within `-maxdepth 3`), instead of `chown -R` on the entire tree. Account creation sets ownership on the new mailbox directory (`mail_path`) so change detection no longer needs to scan `/var/mail` ([#4696](https://github.com/docker-mailserver/docker-mailserver/pull/4696), [#4112](https://github.com/docker-mailserver/docker-mailserver/issues/4112))
 

--- a/target/dovecot/90-quota.conf
+++ b/target/dovecot/90-quota.conf
@@ -90,3 +90,8 @@ service quota-status {
     }
     client_limit = 1
 }
+
+# Defer quota decisions for users unknown to Dovecot until Postfix expands aliases.
+quota_status_success = DUNNO
+quota_status_nouser = DUNNO
+quota_status_overquota = "552 5.2.2 Mailbox is full"

--- a/test/tests/parallel/set1/dovecot/dovecot_quotas.bats
+++ b/test/tests/parallel/set1/dovecot/dovecot_quotas.bats
@@ -135,6 +135,21 @@ function teardown_file() { _default_teardown ; }
   assert_output --partial 'check_policy_service inet:localhost:65265'
 }
 
+@test 'should defer quota checks for aliases to external addresses' {
+  _run_in_container doveconf -h quota_status_success
+  assert_output 'DUNNO'
+
+  _run_in_container doveconf -h quota_status_nouser
+  assert_output 'DUNNO'
+
+  _run_in_container doveconf -h quota_status_overquota
+  assert_output '552 5.2.2 Mailbox is full'
+
+  _run_in_container_bash "printf '%s\n' 'request=smtpd_access_policy' 'protocol_state=RCPT' 'protocol_name=SMTP' 'recipient=alias2@localhost.localdomain' '' | nc -q 1 127.0.0.1 65265"
+  assert_success
+  assert_output --partial 'action=DUNNO'
+}
+
 @test '(ENV POSTFIX_MAILBOX_SIZE_LIMIT) should be configured for both Postfix and Dovecot' {
   _run_in_container postconf -h mailbox_size_limit
   assert_output 4096000


### PR DESCRIPTION
# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->
Re-enable `quota_status_nouser = DUNNO` to fix aliases that forward to external addresses.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #4767

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
