### PR TITLE
docs: revise Dovecot Solr tutorial for Solr 10 and dovecot 2.4 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project will be documented in this file. The format 
   - LDAP `DOVECOT_PASS_ATTRS`, `DOVECOT_USER_ATTRS`, and `DOVECOT_AUTH_BIND` now configure Dovecot 2.4 LDAP fields and authentication binds correctly.
 - **Internal**
   - `/var/mail` permission repair now runs `chown -R` only on paths `find` reports as mismatched (within `-maxdepth 3`), instead of `chown -R` on the entire tree. Account creation sets ownership on the new mailbox directory (`mail_path`) so change detection no longer needs to scan `/var/mail` ([#4696](https://github.com/docker-mailserver/docker-mailserver/pull/4696), [#4112](https://github.com/docker-mailserver/docker-mailserver/issues/4112))
+- **Documentation**
+  - Updated the dovecot fts solr tutorial for dovecot 2.4+ and solr 10.x. 
 
 ## [v16.0.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v16.0.0)
 

--- a/docs/content/examples/tutorials/dovecot-solr.md
+++ b/docs/content/examples/tutorials/dovecot-solr.md
@@ -150,7 +150,7 @@ DMS will connect internally to the `solr` service above. Either have both servic
     //}
     ```
 
-    Excluding Trash form indexing is optional and so is including attachment text. The decode2text script [may or may not work][decoder-script-notice], upstream prefers Tika which SOLR should be able to do but is outside of scope for this tutorial.
+    Excluding Trash from indexing is optional and so is including attachment text. The decode2text script [may or may not work][decoder-script-notice], upstream prefers Tika which SOLR should be able to do but is outside of scope for this tutorial.
 
     Starting with dovecot 2.4 dovecot fts-solr needs a default language to initialize solr searching. In this example langcode `en` was set as default, but any langcode will do. If you want to enable additional languages add them like this:
 

--- a/docs/content/examples/tutorials/dovecot-solr.md
+++ b/docs/content/examples/tutorials/dovecot-solr.md
@@ -81,6 +81,9 @@ services:
       # As Solr can be quite resource hungry, raise the memory limit to 2GB.
       # The default is 512MB, which may be exhausted quickly.
       SOLR_JAVA_MEM: "-Xms2g -Xmx2g"
+      # Current dovecot solr config needs the analysis-extras solr module,
+      # so add it with this env var.
+      SOLR_MODULES=analysis-extras
     volumes:
       - ./docker-data/solr:/var/solr
     restart: always
@@ -95,14 +98,13 @@ DMS will connect internally to the `solr` service above. Either have both servic
     ```bash
     docker exec -it dms-solr /bin/sh
     solr create -c dovecot
-    cp -R /opt/solr/contrib/analysis-extras/lib /var/solr/data/dovecot
     ```
 
     Stop the `dms-solr` container and you should now have a `./data/dovecot` folder in the local bind mount volume.
 
 2. Solr needs a schema that is specifically tailored for Dovecot FTS.
 
-    As of writing of this guide, Solr 9 is the current release. [Dovecot provides the required schema configs][github-dovecot::core-docs] for Solr, copy the following two v9 config files to `./data/dovecot` and rename them accordingly:
+    As of writing of this guide, Solr 10 is the current release. [Dovecot provides the required schema configs][github-dovecot::core-docs] for Solr, copy the following two v9 config files which also work with solr 10 to `./data/dovecot` and rename them accordingly:
 
     - `solr-config-9.xml` (_rename to `solrconfig.xml`_)
     - `solr-schema-9.xml` (_rename to `schema.xml`_)
@@ -116,14 +118,48 @@ DMS will connect internally to the `solr` service above. Either have both servic
     Create a `10-plugin.conf` file in your `./config/dovecot` folder with this contents:
 
     ```config
-    mail_plugins = $mail_plugins fts fts_solr
+    language en {
+      default = yes
+    }
 
-    plugin {
-      fts = solr
-      fts_autoindex = yes
-      fts_solr = url=http://dms-solr:8983/solr/dovecot/
+    mail_plugins {
+      fts = yes
+      fts_solr = yes
+    }
+
+    fts solr {
+      fts_solr_url = http://solr:8983/solr/dovecot/
+    }
+
+    fts_autoindex = yes
+    fts_search_add_missing = yes
+    fts_search_read_fallback = no
+
+    mailbox Trash {
+      fts_autoindex = no
+    }
+
+    fts_decoder_driver = script
+    fts_decoder_script_socket_path = decode2text
+
+    service decode2text {
+      executable = script /usr/libexec/dovecot/decode2text.sh
+      user = dovecot
+
+      unix_listener decode2text {
+        mode = 0666
+      }
     }
     ```
+
+    Excluding Trash form indexing is optional and so is including attachment text.
+
+    Starting with dovecot 2.4 dovecot fts-solr needs a default language to initialize solr searching. In this example langcode `en` was set as default, but any langcode will do. If you want to enable additional languages add them like this:
+
+   ```config
+   language de {
+   }
+   ```
 
     Add a volume mount for that config to your DMS service in `compose.yaml`:
 
@@ -142,28 +178,9 @@ After following the previous steps, restart DMS and run this command to have Dov
 docker compose exec mailserver doveadm fts rescan -A
 ```
 
-!!! info "Indexing will take a while depending on how large your mail folders"
+!!! info "Indexing will take a while depending on how large your mail folders are"
 
     Usually within 15 minutes or so, you should be able to search your mail using the Dovecot FTS feature! :tada:
-
-### Compatibility
-
-Since Solr 9.8.0 was released (Jan 2025), a breaking change [deprecates support for `<lib>` directives][solr::9.8::lib-directive] which is presently used by the Dovecot supplied Solr config (`solr-config-9.xml`) to automatically load additional jars required.
-
-To enable support for `<lib>` directives, add the following ENV to your `solr` container:
-
-```yaml
-services:
-  solr:
-    environment:
-      SOLR_CONFIG_LIB_ENABLED: true
-```
-
-!!! warning "Solr 10"
-
-    From the Solr 10 release onwards, this opt-in ENV will no longer be available.
-
-    If Dovecot has not updated their example Solr config ([upstream PR][dovecot::pr::solr-config-lib]), you will need to manually modify the Solr XML config to remove the `<lib>` directives and replace the suggested ENV `SOLR_CONFIG_LIB_ENABLED=true` with `SOLR_MODULES=analysis-extras`.
 
 [docs::user-patches]: ../../config/advanced/override-defaults/user-patches.md
 [docs::dovecot::full-text-search]: ../../config/advanced/full-text-search.md

--- a/docs/content/examples/tutorials/dovecot-solr.md
+++ b/docs/content/examples/tutorials/dovecot-solr.md
@@ -83,7 +83,7 @@ services:
       SOLR_JAVA_MEM: "-Xms2g -Xmx2g"
       # Current dovecot solr config needs the analysis-extras solr module,
       # so add it with this env var.
-      SOLR_MODULES=analysis-extras
+      SOLR_MODULES: "analysis-extras"
     volumes:
       - ./docker-data/solr:/var/solr
     restart: always

--- a/docs/content/examples/tutorials/dovecot-solr.md
+++ b/docs/content/examples/tutorials/dovecot-solr.md
@@ -154,10 +154,10 @@ DMS will connect internally to the `solr` service above. Either have both servic
 
     Starting with dovecot 2.4 dovecot fts-solr needs a default language to initialize solr searching. In this example langcode `en` was set as default, but any langcode will do. If you want to enable additional languages add them like this:
 
-     ```config
-     language de {
-     }
-     ```
+    ```config
+    language de {
+    }
+    ```
 
     Add a volume mount for that config to your DMS service in `compose.yaml`:
 

--- a/docs/content/examples/tutorials/dovecot-solr.md
+++ b/docs/content/examples/tutorials/dovecot-solr.md
@@ -127,10 +127,8 @@ DMS will connect internally to the `solr` service above. Either have both servic
       fts_solr = yes
     }
 
-    fts solr {
-      fts_solr_url = http://solr:8983/solr/dovecot/
-    }
-
+    fts_solr_url = http://solr:8983/solr/dovecot/
+    
     fts_autoindex = yes
     fts_search_add_missing = yes
     fts_search_read_fallback = no
@@ -139,20 +137,20 @@ DMS will connect internally to the `solr` service above. Either have both servic
       fts_autoindex = no
     }
 
-    fts_decoder_driver = script
-    fts_decoder_script_socket_path = decode2text
+    //fts_decoder_driver = script
+    //fts_decoder_script_socket_path = decode2text
 
-    service decode2text {
-      executable = script /usr/libexec/dovecot/decode2text.sh
-      user = dovecot
-
-      unix_listener decode2text {
-        mode = 0666
-      }
-    }
+    //service decode2text {
+    //  executable = script /usr/libexec/dovecot/decode2text.sh
+    //  user = dovecot
+    //
+    //  unix_listener decode2text {
+    //    mode = 0666
+    //  }
+    //}
     ```
 
-    Excluding Trash form indexing is optional and so is including attachment text.
+    Excluding Trash form indexing is optional and so is including attachment text. The decode2text script [may or may not work][decoder-script-notice], upstream prefers Tika which SOLR should be able to do but is outside of scope for this tutorial.
 
     Starting with dovecot 2.4 dovecot fts-solr needs a default language to initialize solr searching. In this example langcode `en` was set as default, but any langcode will do. If you want to enable additional languages add them like this:
 
@@ -191,5 +189,4 @@ docker compose exec mailserver doveadm fts rescan -A
 [github-solr]: https://github.com/apache/solr
 [github-dovecot::core-docs]: https://github.com/dovecot/core/tree/main/doc
 
-[solr::9.8::lib-directive]: https://issues.apache.org/jira/browse/SOLR-16781
-[dovecot::pr::solr-config-lib]: https://github.com/dovecot/core/pull/238
+[decoder-script-notice]: https://github.com/orgs/docker-mailserver/discussions/4461#discussioncomment-13002388

--- a/docs/content/examples/tutorials/dovecot-solr.md
+++ b/docs/content/examples/tutorials/dovecot-solr.md
@@ -156,10 +156,10 @@ DMS will connect internally to the `solr` service above. Either have both servic
 
     Starting with dovecot 2.4 dovecot fts-solr needs a default language to initialize solr searching. In this example langcode `en` was set as default, but any langcode will do. If you want to enable additional languages add them like this:
 
-   ```config
-   language de {
-   }
-   ```
+     ```config
+     language de {
+     }
+     ```
 
     Add a volume mount for that config to your DMS service in `compose.yaml`:
 

--- a/docs/content/examples/tutorials/dovecot-solr.md
+++ b/docs/content/examples/tutorials/dovecot-solr.md
@@ -75,7 +75,7 @@ Firstly you need a working Solr container, for this the [official docker image][
 ```yaml
 services:
   solr:
-    image: solr:latest
+    image: solr:10
     container_name: dms-solr
     environment:
       # As Solr can be quite resource hungry, raise the memory limit to 2GB.


### PR DESCRIPTION
Updated Dovecot Solr tutorial for compatibility with Solr 10, including changes to environment variables and configuration instructions. Also rewrite the dovecot config in the new 2.4+ format.

# Description

Rewritten tutorial, tested locally and currently in use with latest dms image (v16.0.0) and solr image (10.0.0).
The linked dovecot schema does has a minor bug, which is easy to fix: a PR for this was already submitted .

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Improvement (non-breaking change that does improve existing functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
