### PR TITLE
docs: add FTS solr configuration block

### DIFF
--- a/docs/content/examples/tutorials/dovecot-solr.md
+++ b/docs/content/examples/tutorials/dovecot-solr.md
@@ -127,6 +127,9 @@ DMS will connect internally to the `solr` service above. Either have both servic
       fts_solr = yes
     }
 
+    fts solr {
+    }
+
     fts_solr_url = http://solr:8983/solr/dovecot/
     
     fts_autoindex = yes


### PR DESCRIPTION
# Description

Both:

```ini
fts solr {
  fts_solr_url = http://solr:8983/solr/dovecot/
}
```

And:

```ini
fts solr {
}

fts_solr_url = http://solr:8983/solr/dovecot/
```

Work, but not only:

```
fts_solr_url = http://solr:8983/solr/dovecot/
```

The latter seems cleaner.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #4778

Config example did not work in practice.

## Type of change

<!-- Delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [-] **I have added information about changes made in this PR to `CHANGELOG.md`**
- [X] I can confirm the suggested change works on real hardware.