### PR TITLE
feat: add `dovecot-solr` (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ All notable changes to this project will be documented in this file. The format 
 - **Dovecot**
   - `ENABLE_QUOTAS=1` no longer rejects aliases that forward to external addresses. Restored the `quota_status_*` responses dropped during the Dovecot 2.3 to 2.4 migration ([#4767](https://github.com/docker-mailserver/docker-mailserver/issues/4767))
   - LDAP `DOVECOT_PASS_ATTRS`, `DOVECOT_USER_ATTRS`, and `DOVECOT_AUTH_BIND` now configure Dovecot 2.4 LDAP fields and authentication binds correctly.
+  - dovecot-solr is included by default again. Using it is optional and requires manual configuration by the user. For this a tuturial is provided.
 - **Internal**
   - `/var/mail` permission repair now runs `chown -R` only on paths `find` reports as mismatched (within `-maxdepth 3`), instead of `chown -R` on the entire tree. Account creation sets ownership on the new mailbox directory (`mail_path`) so change detection no longer needs to scan `/var/mail` ([#4696](https://github.com/docker-mailserver/docker-mailserver/pull/4696), [#4112](https://github.com/docker-mailserver/docker-mailserver/issues/4112))
 - **Documentation**
-  - Updated the dovecot fts solr tutorial for dovecot 2.4+ and solr 10.x. 
+  - Removed the amd64 notice from the dovecot solr tuturial.
+  - Updated the dovecot fts solr tutorial for dovecot 2.4+ and solr 10.x.
 
 ## [v16.0.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v16.0.0)
 

--- a/docs/content/examples/tutorials/dovecot-solr.md
+++ b/docs/content/examples/tutorials/dovecot-solr.md
@@ -16,58 +16,6 @@ As the size of your mail storage grows, the benefits of FTS are especially notab
 
 An FTS backend supported by Dovecot is [Apache Solr][github-solr], a fast and efficient multi-purpose search indexer.
 
-### Add the required `dovecot-solr` package
-
-As the official DMS image does not provide `dovecot-solr`, you'll need to include the package in your own image (_extending a DMS release as a base image_), or via our [`user-patches.sh` feature][docs::user-patches]:
-
-<!-- This empty quote block is purely for a visual border -->
-!!! quote ""
-
-    === "`user-patches.sh`"
-
-        If you'd prefer to avoid a custom image build. This approach is simpler but with the caveat that any time the container is restarted, you'll have a delay as the package is installed each time.
-
-        ```bash
-        #!/bin/bash
-
-        apt-get update && apt-get install dovecot-solr
-        ```
-
-    === "`compose.yaml`"
-
-        A custom DMS image does not add much friction. You do not need a separate `Dockerfile` as Docker Compose supports building from an inline `Dockerfile` in your `compose.yaml`.
-
-        The `image` key of the service is swapped for the `build` key instead, as shown below:
-
-        ```yaml
-        services:
-          mailserver:
-            hostname: mail.example.com
-            # The `image` setting now represents the tag for the local build configured below:
-            image: local/dms:${DMS_TAG?Must set DMS image tag}
-            # Local build (no need to try pull `image` remotely):
-            pull_policy: build
-            # Add this `build` section to your real `compose.yaml` for your DMS service:
-            build:
-              dockerfile_inline: |
-                FROM docker.io/mailserver/docker-mailserver:${DMS_TAG?Must set DMS image tag}
-                RUN apt-get update && apt-get install dovecot-solr
-        ```
-
-        This approach only needs to install the package once with the image build itself which minimizes the delay of container startup.
-
-        - Just run `DMS_TAG='14.0' docker compose up` and it will pull the DMS image, then build your custom DMS image to run a new container instance.
-        - Updating to a new DMS release is straight-forward, just adjust the `DMS_TAG` ENV value or change the image tag directly in `compose.yaml` as you normally would to upgrade an image.
-        - If you make future changes to the `dockerfile_inline` that don't seem to be applied, you may need to force a rebuild with `DMS_TAG='14.0' docker compose up --build`.
-
-!!! note "Why doesn't DMS include `dovecot-solr`?"
-
-    This integration is not officially supported in DMS as no maintainer is able to provide troubleshooting support.
-
-    Prior to v14, the package was included but the community contributed guide had been outdated for several years that it was non-functional. It was decided that it was better to drop support and docs, however some DMS users voiced active use of Solr and it's benefits over Xapian for FTS which led to these revised docs.
-
-    **ARM64 builds do not have support for `dovecot-solr`**. Additionally the [user demand for including `dovecot-solr` is presently too low][gh-dms::feature-request::dovecot-solr-package] to justify vs the minimal effort to add additional packages as shown above.
-
 ### `compose.yaml` config
 
 Firstly you need a working Solr container, for this the [official docker image][dockerhub-solr] will do:
@@ -182,7 +130,6 @@ docker compose exec mailserver doveadm fts rescan -A
 
 [docs::user-patches]: ../../config/advanced/override-defaults/user-patches.md
 [docs::dovecot::full-text-search]: ../../config/advanced/full-text-search.md
-[gh-dms::feature-request::dovecot-solr-package]: https://github.com/docker-mailserver/docker-mailserver/issues/4052
 
 [dockerhub-solr]: https://hub.docker.com/_/solr
 [dockerfile-solr-uidgid]: https://github.com/apache/solr-docker/blob/9cd850b72309de05169544395c83a85b329d6b86/9.6/Dockerfile#L89-L92

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -167,6 +167,7 @@ function _install_dovecot() {
 
     # Additional Dovecot packages for supporting the DMS community (docs-only guide contributions)
     dovecot-auth-lua
+    dovecot-solr
   )
 
   # NOTE: (Opt-in via ENV) Change repo source for dovecot packages


### PR DESCRIPTION
# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->

Add the dovecot-solr package from the official debian-13 repositories again. Edit the fts solr tutorial to reflect this change.

dovecot-solr is a requirement to use solr as a full text searching backend for dovecot. This is considered as a niche option with few user demand. As such it is not configured by default and enabling this is left as something a user must manually do. For this a tuturial is provided with detailed steps explaining how to do this. 

ref #4778

## Type of change

<!-- Delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (non-breaking change that does improve existing functionality)
- [X] This change requires a documentation update

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] **I have added information about changes made in this PR to `CHANGELOG.md`**
