### PR TITLE
docs: update Solr image and clean up FTS configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ All notable changes to this project will be documented in this file. The format 
 - Moved `setup_cli.bats` to the serial test suite to prevent `setup.sh` from racing with teardown of another DMS test container ([#4701](https://github.com/docker-mailserver/docker-mailserver/issues/4701))
 - Excluded `saslauthd` from the process kill/restart assertion because its forked parent process is not reliably reaped by the test
 
+### Fixed
+
+- **Dovecot**
+  - FTS solr config: pinned to solr:10.0, explictly start solr in user managed mode and remove the attachment text extraction example. 
+
 ## [v16.0.1](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v16.0.1)
 
 ### Added

--- a/docs/content/config/advanced/full-text-search.md
+++ b/docs/content/config/advanced/full-text-search.md
@@ -167,15 +167,16 @@ Dovecot supports a variety of community-supported [FTS indexing backends][doveco
         ```yaml
         services:
           solr:
-            image: solr:10
+            image: solr:10.0
             container_name: dms-solr
+            command: ["solr-foreground", "--user-managed"]
             environment:
               # As Solr can be quite resource hungry, raise the memory limit to 2GB.
               # The default is 512MB, which may be exhausted quickly.
               SOLR_JAVA_MEM: "-Xms2g -Xmx2g"
               # Current dovecot solr config needs the analysis-extras solr module,
               # so add it with this env var.
-              SOLR_MODULES: "analysis-extras"
+              SOLR_MODULES: analysis-extras
             volumes:
               - ./docker-data/solr:/var/solr
             restart: always
@@ -231,21 +232,9 @@ Dovecot supports a variety of community-supported [FTS indexing backends][doveco
             mailbox Trash {
               fts_autoindex = no
             }
-
-            #fts_decoder_driver = script
-            #fts_decoder_script_socket_path = decode2text
-
-            #service decode2text {
-            #  executable = script /usr/libexec/dovecot/decode2text.sh
-            #  user = dovecot
-            #
-            #  unix_listener decode2text {
-            #    mode = 0666
-            #  }
-            #}
             ```
 
-            Excluding Trash from indexing is optional and so is including attachment text. The `decode2text` script [may or may not work][docs::discussion::decode2text-notice], upstream prefers Tika which SOLR should be able to do but is outside of scope for this tutorial.
+            Excluding Trash from indexing is optional.
 
             Starting with dovecot 2.4 dovecot fts-solr needs a default language to initialize solr searching. In this example langcode `en` was set as default, but any langcode will do. If you want to enable additional languages add them like this:
 


### PR DESCRIPTION
Updated Solr image version,  fixed SOLR_MODULES format and explictly start solr in user-managed mode. Removed commented-out FTS decoder configuration: it is not advised and incorrect for the debian provided dovecot packages. Tika is a better alternative and easy to implement but this is a dovecot fts feature and not fts solr specific so that doesn't belong in the solr tutorial.

## Description

Small iteration: 
 - current solr is 10.0, higher version probably will just work but there is no garantee so don't just use 10.x
 - Starting with solr 10, solr-cloud is the default. In this example a single stand alone solr server is assumed, which was the previous default.
 - Upon further inspection: script based text extraction is not included with dovecot on debian 13, so the example was useless. Tika extraction is better and easy to implement, but has nothing to do with the fts solr plugin for dovecot: it is a dovecot fts feature and should be available to other forms of fts searching also.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #

<!-- Remove this line of the change is breaking
> [!CAUTTION]
>
> This is a breaking change
Remove this line of the change is breaking -->

## Type of change

<!-- Delete options that are not relevant. Multiple choices allowed. -->

- Bug Fix
- Refactoring
- Update

<!-- DO NOT DELETE THE TEXT BELOW THIS LINE -->

---

> [!IMPORTANT]
>
> I understand and have ensured that
>
> 1. my code follows the style guidelines of this project,
> 2. I have commented my code, particularly in hard-to-understand areas,
> 3. new and existing unit tests pass locally with my changes,
> 4. if necessary, I added tests that prove my fix is effective or that my feature works,
> 5. if necessary, I added information about changes made in this PR to the changelog.
